### PR TITLE
Proposal: Switch to just speak Call.Factory

### DIFF
--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -23,7 +23,6 @@ import okhttp3.OkHttpClient
 class ImageLoaderBuilder(private val context: Context) {
 
     private var callFactory: Call.Factory? = null
-    private var canRebuildWithOptimizations: Boolean = false
 
     private var registry: ComponentRegistry? = null
 

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -11,12 +11,11 @@ import coil.annotation.BuilderMarker
 import coil.drawable.CrossfadeDrawable
 import coil.target.ImageViewTarget
 import coil.util.Utils
+import coil.util.Utils.applyOkHttpClientOptimizations
 import coil.util.getDrawableCompat
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import okhttp3.Cache
 import okhttp3.Call
-import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 
 /** Builder for an [ImageLoader]. */
@@ -36,7 +35,8 @@ class ImageLoaderBuilder(private val context: Context) {
     /**
      * Set the [Call.Factory] to be used for network requests.
      *
-     * If using an [OkHttpClient] instance under the hood, use [applyCoilOptimizations] if possible to optimize it for Coil.
+     * If using an [OkHttpClient] instance under the hood, use [Utils.applyOkHttpClientOptimizations] if possible to optimize it
+     * for Coil.
      */
     fun callFactory(callFactory: Call.Factory) = apply {
         this.callFactory = callFactory
@@ -188,25 +188,7 @@ class ImageLoaderBuilder(private val context: Context) {
 
     private fun buildDefaultOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
-            .applyCoilOptimizations(context)
+            .applyOkHttpClientOptimizations(context)
             .build()
-    }
-
-    companion object {
-        /**
-         * Applies the preferred optimizations for Coil (image loading library) to this given Builder instance.
-         */
-        fun OkHttpClient.Builder.applyCoilOptimizations(context: Context): OkHttpClient.Builder = apply {
-            // Create the default image disk cache.
-            val cacheDirectory = Utils.getDefaultCacheDirectory(context)
-            val cacheSize = Utils.calculateDiskCacheSize(cacheDirectory)
-            cache(Cache(cacheDirectory, cacheSize))
-
-            // Don't limit the number of requests by host.
-            val dispatcher = Dispatcher().apply {
-                maxRequestsPerHost = maxRequests
-            }
-            dispatcher(dispatcher)
-        }
     }
 }

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -10,7 +10,7 @@ import androidx.annotation.FloatRange
 import coil.annotation.BuilderMarker
 import coil.drawable.CrossfadeDrawable
 import coil.target.ImageViewTarget
-import coil.util.OkHttpClients.applyCoilOptimizations
+import coil.util.applyCoilOptimizations
 import coil.util.Utils
 import coil.util.getDrawableCompat
 import kotlinx.coroutines.CoroutineDispatcher

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -33,10 +33,21 @@ class ImageLoaderBuilder(private val context: Context) {
     private var defaults = DefaultRequestOptions()
 
     /**
-     * Set the [Call.Factory] to be used for network requests.
+     * The HTTP client used for requests.
+     *
+     * This is a convenience method for calling [callFactory].
+     *
+     * Use [Utils.applyOkHttpClientOptimizations] if possible during its construction to optimize it for Coil.
+     */
+    fun okHttpClient(okHttpClient: OkHttpClient) = callFactory(okHttpClient)
+
+    /**
+     * Specify a custom call factory for creating [Call] instances.
      *
      * If using an [OkHttpClient] instance under the hood, use [Utils.applyOkHttpClientOptimizations] if possible to optimize it
      * for Coil.
+     *
+     * Note: Calling [okHttpClient] automatically sets this value.
      */
     fun callFactory(callFactory: Call.Factory) = apply {
         this.callFactory = callFactory

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -10,8 +10,8 @@ import androidx.annotation.FloatRange
 import coil.annotation.BuilderMarker
 import coil.drawable.CrossfadeDrawable
 import coil.target.ImageViewTarget
+import coil.util.OkHttpClients.applyCoilOptimizations
 import coil.util.Utils
-import coil.util.Utils.applyOkHttpClientOptimizations
 import coil.util.getDrawableCompat
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -36,14 +36,14 @@ class ImageLoaderBuilder(private val context: Context) {
      *
      * This is a convenience method for calling [callFactory].
      *
-     * Use [Utils.applyOkHttpClientOptimizations] if possible during its construction to optimize it for Coil.
+     * Use [applyCoilOptimizations] if possible during its construction to optimize it for Coil.
      */
     fun okHttpClient(okHttpClient: OkHttpClient) = callFactory(okHttpClient)
 
     /**
      * Specify a custom call factory for creating [Call] instances.
      *
-     * If using an [OkHttpClient] instance under the hood, use [Utils.applyOkHttpClientOptimizations] if possible to optimize it
+     * If using an [OkHttpClient] instance under the hood, use [applyCoilOptimizations] if possible to optimize it
      * for Coil.
      *
      * Note: Calling [okHttpClient] automatically sets this value.
@@ -198,7 +198,7 @@ class ImageLoaderBuilder(private val context: Context) {
 
     private fun buildDefaultOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
-            .applyOkHttpClientOptimizations(context)
+            .applyCoilOptimizations(context)
             .build()
     }
 }

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -67,14 +67,14 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
+import okhttp3.Call
 
 internal class RealImageLoader(
     private val context: Context,
     override val defaults: DefaultRequestOptions,
     bitmapPoolSize: Long,
     memoryCacheSize: Int,
-    okHttpClient: OkHttpClient,
+    callFactory: Call.Factory,
     registry: ComponentRegistry
 ) : ImageLoader, ComponentCallbacks {
 
@@ -98,7 +98,7 @@ internal class RealImageLoader(
         add(HttpUriMapper())
         add(FileMapper())
 
-        add(HttpUrlFetcher(okHttpClient))
+        add(HttpUrlFetcher(callFactory))
         add(UriFetcher(context))
         add(ResourceFetcher(context, drawableDecoder))
         add(DrawableFetcher(drawableDecoder))

--- a/coil-base/src/main/java/coil/fetch/HttpUrlFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/HttpUrlFetcher.kt
@@ -7,12 +7,12 @@ import coil.network.HttpException
 import coil.size.Size
 import coil.util.await
 import okhttp3.CacheControl
+import okhttp3.Call
 import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import okhttp3.Request
 
 internal class HttpUrlFetcher(
-    private val okHttp: OkHttpClient
+    private val callFactory: Call.Factory
 ) : Fetcher<HttpUrl> {
 
     companion object {
@@ -47,7 +47,7 @@ internal class HttpUrlFetcher(
             }
         }
 
-        val response = okHttp.newCall(request.build()).await()
+        val response = callFactory.newCall(request.build()).await()
         if (!response.isSuccessful) {
             throw HttpException(response)
         }

--- a/coil-base/src/main/java/coil/util/OkHttpClients.kt
+++ b/coil-base/src/main/java/coil/util/OkHttpClients.kt
@@ -1,3 +1,5 @@
+@file:JvmName("OkHttpClients")
+
 package coil.util
 
 import android.content.Context
@@ -6,23 +8,17 @@ import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 
 /**
- * [OkHttpClient] utilities for Coil.
+ * Applies the preferred optimizations for Coil (image loading library) to this given Builder instance.
  */
-object OkHttpClients {
+fun OkHttpClient.Builder.applyCoilOptimizations(context: Context): OkHttpClient.Builder = apply {
+    // Create the default image disk cache.
+    val cacheDirectory = Utils.getDefaultCacheDirectory(context)
+    val cacheSize = Utils.calculateDiskCacheSize(cacheDirectory)
+    cache(Cache(cacheDirectory, cacheSize))
 
-    /**
-     * Applies the preferred optimizations for Coil (image loading library) to this given Builder instance.
-     */
-    fun OkHttpClient.Builder.applyCoilOptimizations(context: Context): OkHttpClient.Builder = apply {
-        // Create the default image disk cache.
-        val cacheDirectory = Utils.getDefaultCacheDirectory(context)
-        val cacheSize = Utils.calculateDiskCacheSize(cacheDirectory)
-        cache(Cache(cacheDirectory, cacheSize))
-
-        // Don't limit the number of requests by host.
-        val dispatcher = Dispatcher().apply {
-            maxRequestsPerHost = maxRequests
-        }
-        dispatcher(dispatcher)
+    // Don't limit the number of requests by host.
+    val dispatcher = Dispatcher().apply {
+        maxRequestsPerHost = maxRequests
     }
+    dispatcher(dispatcher)
 }

--- a/coil-base/src/main/java/coil/util/OkHttpClients.kt
+++ b/coil-base/src/main/java/coil/util/OkHttpClients.kt
@@ -1,0 +1,28 @@
+package coil.util
+
+import android.content.Context
+import okhttp3.Cache
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+
+/**
+ * [OkHttpClient] utilities for Coil.
+ */
+object OkHttpClients {
+
+    /**
+     * Applies the preferred optimizations for Coil (image loading library) to this given Builder instance.
+     */
+    fun OkHttpClient.Builder.applyCoilOptimizations(context: Context): OkHttpClient.Builder = apply {
+        // Create the default image disk cache.
+        val cacheDirectory = Utils.getDefaultCacheDirectory(context)
+        val cacheSize = Utils.calculateDiskCacheSize(cacheDirectory)
+        cache(Cache(cacheDirectory, cacheSize))
+
+        // Don't limit the number of requests by host.
+        val dispatcher = Dispatcher().apply {
+            maxRequestsPerHost = maxRequests
+        }
+        dispatcher(dispatcher)
+    }
+}

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -10,12 +10,9 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.O
 import android.os.StatFs
 import androidx.annotation.Px
-import okhttp3.Cache
-import okhttp3.Dispatcher
-import okhttp3.OkHttpClient
 import java.io.File
 
-object Utils {
+internal object Utils {
 
     private const val CACHE_DIRECTORY_NAME = "image_cache"
 
@@ -28,16 +25,16 @@ object Utils {
     private const val LOW_MEMORY_MULTIPLIER = 0.15
 
     /** Return the in memory size of a [Bitmap] with the given width, height, and [Bitmap.Config]. */
-    internal fun calculateAllocationByteCount(@Px width: Int, @Px height: Int, config: Bitmap.Config?): Int {
+    fun calculateAllocationByteCount(@Px width: Int, @Px height: Int, config: Bitmap.Config?): Int {
         return width * height * config.getBytesPerPixel()
     }
 
-    internal fun getDefaultCacheDirectory(context: Context): File {
+    fun getDefaultCacheDirectory(context: Context): File {
         return File(context.cacheDir, CACHE_DIRECTORY_NAME).apply { mkdirs() }
     }
 
     /** Modified from Picasso. */
-    private fun calculateDiskCacheSize(cacheDirectory: File): Long {
+    fun calculateDiskCacheSize(cacheDirectory: File): Long {
         return try {
             val cacheDir = StatFs(cacheDirectory.absolutePath)
             val size = DISK_CACHE_PERCENTAGE * cacheDir.getBlockCountCompat() * cacheDir.getBlockSizeCompat()
@@ -48,43 +45,27 @@ object Utils {
     }
 
     /** Modified from Picasso. */
-    internal fun calculateAvailableMemorySize(context: Context, percentage: Double): Long {
+    fun calculateAvailableMemorySize(context: Context, percentage: Double): Long {
         val activityManager: ActivityManager = context.requireSystemService()
         val isLargeHeap = (context.applicationInfo.flags and ApplicationInfo.FLAG_LARGE_HEAP) != 0
         val memoryClassMegabytes = if (isLargeHeap) activityManager.largeMemoryClass else activityManager.memoryClass
         return (percentage * memoryClassMegabytes * 1024 * 1024).toLong()
     }
 
-    internal fun getDefaultAvailableMemoryPercentage(context: Context): Double {
+    fun getDefaultAvailableMemoryPercentage(context: Context): Double {
         val activityManager: ActivityManager = context.requireSystemService()
         return if (activityManager.isLowRawDeviceCompat()) LOW_MEMORY_MULTIPLIER else STANDARD_MULTIPLIER
     }
 
-    internal fun getDefaultBitmapPoolPercentage(): Double {
+    fun getDefaultBitmapPoolPercentage(): Double {
         // Allocate less memory for bitmap pooling on Android O and above since we default to
         // hardware bitmaps, which cannot be added to the pool.
         return if (SDK_INT >= O) 0.25 else 0.5
     }
 
-    internal fun getDefaultBitmapConfig(): Bitmap.Config {
+    fun getDefaultBitmapConfig(): Bitmap.Config {
         // Prefer hardware bitmaps on Android O and above since they are optimized for drawing
         // without transformations.
         return if (SDK_INT >= O) Bitmap.Config.HARDWARE else Bitmap.Config.ARGB_8888
-    }
-
-    /**
-     * Applies the preferred optimizations for Coil (image loading library) to this given Builder instance.
-     */
-    fun OkHttpClient.Builder.applyOkHttpClientOptimizations(context: Context): OkHttpClient.Builder = apply {
-        // Create the default image disk cache.
-        val cacheDirectory = getDefaultCacheDirectory(context)
-        val cacheSize = calculateDiskCacheSize(cacheDirectory)
-        cache(Cache(cacheDirectory, cacheSize))
-
-        // Don't limit the number of requests by host.
-        val dispatcher = Dispatcher().apply {
-            maxRequestsPerHost = maxRequests
-        }
-        dispatcher(dispatcher)
     }
 }

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -7,9 +7,26 @@ import android.os.Build.VERSION_CODES.LOLLIPOP
 import androidx.multidex.MultiDexApplication
 import coil.Coil
 import coil.ImageLoader
+import coil.ImageLoaderBuilder.Companion.applyCoilOptimizations
 import coil.util.CoilLogger
+import okhttp3.Call
+import okhttp3.OkHttpClient
 
 class Application : MultiDexApplication() {
+
+    /**
+     * Clever technique with Call.Factory. By lazily constructing our OkHttpClient instance,
+     * we can defer its instantiation until the first network request and off the main thread.
+     */
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder()
+            .applyCoilOptimizations(this@Application)
+            .apply {
+                // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
+                if (SDK_INT < LOLLIPOP) forceTls12()
+            }
+            .build()
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -22,10 +39,7 @@ class Application : MultiDexApplication() {
             availableMemoryPercentage(0.5)
             bitmapPoolPercentage(0.5)
             crossfade(true)
-            okHttpClient {
-                // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
-                if (SDK_INT < LOLLIPOP) forceTls12()
-            }
+            callFactory(Call.Factory { request -> okHttpClient.newCall(request) })
         }
     }
 }

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -7,7 +7,7 @@ import android.os.Build.VERSION_CODES.LOLLIPOP
 import androidx.multidex.MultiDexApplication
 import coil.Coil
 import coil.ImageLoader
-import coil.ImageLoaderBuilder.Companion.applyCoilOptimizations
+import coil.util.Utils.applyOkHttpClientOptimizations
 import coil.util.CoilLogger
 import okhttp3.OkHttpClient
 
@@ -26,7 +26,7 @@ class Application : MultiDexApplication() {
             crossfade(true)
             callFactory(
                 OkHttpClient.Builder()
-                    .applyCoilOptimizations(this@Application)
+                    .applyOkHttpClientOptimizations(this@Application)
                     .apply {
                         // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
                         if (SDK_INT < LOLLIPOP) forceTls12()

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -8,7 +8,7 @@ import androidx.multidex.MultiDexApplication
 import coil.Coil
 import coil.ImageLoader
 import coil.util.CoilLogger
-import coil.util.Utils.applyOkHttpClientOptimizations
+import coil.util.OkHttpClients.applyCoilOptimizations
 import okhttp3.OkHttpClient
 
 class Application : MultiDexApplication() {
@@ -26,7 +26,7 @@ class Application : MultiDexApplication() {
             crossfade(true)
             okHttpClient(
                 OkHttpClient.Builder()
-                    .applyOkHttpClientOptimizations(this@Application)
+                    .applyCoilOptimizations(this@Application)
                     .apply {
                         // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
                         if (SDK_INT < LOLLIPOP) forceTls12()

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -9,24 +9,9 @@ import coil.Coil
 import coil.ImageLoader
 import coil.ImageLoaderBuilder.Companion.applyCoilOptimizations
 import coil.util.CoilLogger
-import okhttp3.Call
 import okhttp3.OkHttpClient
 
 class Application : MultiDexApplication() {
-
-    /**
-     * Clever technique with Call.Factory. By lazily constructing our OkHttpClient instance,
-     * we can defer its instantiation until the first network request and off the main thread.
-     */
-    private val okHttpClient by lazy {
-        OkHttpClient.Builder()
-            .applyCoilOptimizations(this@Application)
-            .apply {
-                // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
-                if (SDK_INT < LOLLIPOP) forceTls12()
-            }
-            .build()
-    }
 
     override fun onCreate() {
         super.onCreate()
@@ -39,7 +24,15 @@ class Application : MultiDexApplication() {
             availableMemoryPercentage(0.5)
             bitmapPoolPercentage(0.5)
             crossfade(true)
-            callFactory(Call.Factory { request -> okHttpClient.newCall(request) })
+            callFactory(
+                OkHttpClient.Builder()
+                    .applyCoilOptimizations(this@Application)
+                    .apply {
+                        // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
+                        if (SDK_INT < LOLLIPOP) forceTls12()
+                    }
+                    .build()
+            )
         }
     }
 }

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -7,8 +7,8 @@ import android.os.Build.VERSION_CODES.LOLLIPOP
 import androidx.multidex.MultiDexApplication
 import coil.Coil
 import coil.ImageLoader
-import coil.util.Utils.applyOkHttpClientOptimizations
 import coil.util.CoilLogger
+import coil.util.Utils.applyOkHttpClientOptimizations
 import okhttp3.OkHttpClient
 
 class Application : MultiDexApplication() {
@@ -24,7 +24,7 @@ class Application : MultiDexApplication() {
             availableMemoryPercentage(0.5)
             bitmapPoolPercentage(0.5)
             crossfade(true)
-            callFactory(
+            okHttpClient(
                 OkHttpClient.Builder()
                     .applyOkHttpClientOptimizations(this@Application)
                     .apply {

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -8,7 +8,7 @@ import androidx.multidex.MultiDexApplication
 import coil.Coil
 import coil.ImageLoader
 import coil.util.CoilLogger
-import coil.util.OkHttpClients.applyCoilOptimizations
+import coil.util.applyCoilOptimizations
 import okhttp3.OkHttpClient
 
 class Application : MultiDexApplication() {


### PR DESCRIPTION
This is a proposal PR that switches the `ImageLoaderBuilder` + internals to just speak `Call.Factory`. This is similar to [how Retrofit handles it](https://github.com/square/retrofit/blob/master/retrofit/src/main/java/retrofit2/Retrofit.java#L456-L473), and allows for consumers to provide their own implementations of `Call.Factory`.

Two primary examples:
- A clever technique to improve startup perf is to lazily instantiate the OkHttpClient stack (instance + cache) by deferring its construction until the first network call. This way, construction is done _off_ the main thread. I demoed this in c03e7c2, and can revert 69ca796 if you want to keep that in the sample.
- Some apps provide entirely different network implementations behind `Call.Factory`, using the interface to allow them to interop with popular libraries like Retrofit still. This would enable those as well.

In order to sanely support this, I think the builder helper method didn't have a place, and instead made the logic for applying those configurations available via public helper extension function. This way consumers can use it in their own construction, and also better supports sharing connection pools between instances. If clients want to use the optimized configuration, they can just call `newBuilder()` on their existing instance to share the connection pool while gettin the optimized configuration for a new instance ultimately provided into `callFactory`.