### PR TITLE
Ensure View dimensions are evaluated to at least 1px.

### DIFF
--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.view.ViewTreeObserver
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
+import kotlin.math.max
 
 /**
  * A [SizeResolver] that measures the size of a [View].
@@ -38,19 +39,11 @@ interface ViewSizeResolver<T : View> : SizeResolver {
             val viewTreeObserver = view.viewTreeObserver
 
             val preDrawListener = object : ViewTreeObserver.OnPreDrawListener {
-
-                private var isResumed = false
-
                 override fun onPreDraw(): Boolean {
-                    if (!isResumed) {
-                        val width = view.width - view.paddingLeft - view.paddingRight
-                        val height = view.height - view.paddingTop - view.paddingBottom
-                        if (width > 0 && height > 0) {
-                            isResumed = true
-                            viewTreeObserver.removePreDrawListenerSafe(this)
-                            continuation.resume(PixelSize(width, height))
-                        }
-                    }
+                    viewTreeObserver.removePreDrawListenerSafe(this)
+                    val width = max(1, view.width - view.paddingLeft - view.paddingRight)
+                    val height = max(1, view.height - view.paddingTop - view.paddingBottom)
+                    continuation.resume(PixelSize(width, height))
                     return true
                 }
             }

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -39,11 +39,18 @@ interface ViewSizeResolver<T : View> : SizeResolver {
             val viewTreeObserver = view.viewTreeObserver
 
             val preDrawListener = object : ViewTreeObserver.OnPreDrawListener {
+
+                private var isResumed = false
+
                 override fun onPreDraw(): Boolean {
-                    viewTreeObserver.removePreDrawListenerSafe(this)
-                    val width = max(1, view.width - view.paddingLeft - view.paddingRight)
-                    val height = max(1, view.height - view.paddingTop - view.paddingBottom)
-                    continuation.resume(PixelSize(width, height))
+                    if (!isResumed) {
+                        isResumed = true
+
+                        viewTreeObserver.removePreDrawListenerSafe(this)
+                        val width = max(1, view.width - view.paddingLeft - view.paddingRight)
+                        val height = max(1, view.height - view.paddingTop - view.paddingBottom)
+                        continuation.resume(PixelSize(width, height))
+                    }
                     return true
                 }
             }

--- a/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
+++ b/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
@@ -53,4 +53,23 @@ class ViewSizeResolverTest {
         }
         assertEquals(PixelSize(120, 120), size)
     }
+
+    @Test
+    fun `wrap_content is treated as 1px`() {
+        val view = View(context)
+        val resolver = ViewSizeResolver(view)
+
+        val deferred = GlobalScope.async(Dispatchers.Main.immediate) {
+            resolver.size()
+        }
+
+        view.measure(ViewGroup.LayoutParams.WRAP_CONTENT, 100)
+        view.layout(0, 0, 0, 100)
+        view.viewTreeObserver.dispatchOnPreDraw()
+
+        val size = runBlocking {
+            deferred.await()
+        }
+        assertEquals(PixelSize(1, 100), size)
+    }
 }


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/20

This fixes the case where one or more of a View's dimensions resolves to 0px. In this case, we treat the dimension as 1px. Image dimensions must be loaded with all dimensions > 0 so this saves us from handling a lot of complexity later in the image pipline.