### PR TITLE
Adds support for generic Uri strings.

### DIFF
--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -120,6 +120,20 @@ class RealImageLoaderIntegrationTest {
     }
 
     @Test
+    fun fileUrl() {
+        val data = "file://${copyNormalImageAssetToCacheDir().absolutePath}"
+        testLoad(data)
+        testGet(data)
+    }
+
+    @Test
+    fun filePath() {
+        val data = copyNormalImageAssetToCacheDir().absolutePath
+        testLoad(data)
+        testGet(data)
+    }
+
+    @Test
     fun drawable() {
         val data = context.getDrawableCompat(R.drawable.normal)
         val expectedSize = PixelSize(1080, 1350)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -26,8 +26,9 @@ import coil.fetch.ResourceFetcher
 import coil.fetch.SourceResult
 import coil.fetch.UriFetcher
 import coil.map.FileMapper
+import coil.map.UriStringMapper
 import coil.map.HttpUriMapper
-import coil.map.StringMapper
+import coil.map.HttpStringMapper
 import coil.memory.BitmapReferenceCounter
 import coil.memory.DelegateService
 import coil.memory.MemoryCache
@@ -94,9 +95,10 @@ internal class RealImageLoader(
     private val networkObserver = NetworkObserver(context)
 
     private val registry = ComponentRegistry(registry) {
-        add(StringMapper())
+        add(HttpStringMapper())
         add(HttpUriMapper())
         add(FileMapper())
+        add(UriStringMapper())
 
         add(HttpUrlFetcher(okHttpClient))
         add(UriFetcher(context))

--- a/coil-base/src/main/java/coil/map/HttpStringMapper.kt
+++ b/coil-base/src/main/java/coil/map/HttpStringMapper.kt
@@ -1,0 +1,10 @@
+package coil.map
+
+import okhttp3.HttpUrl
+
+internal class HttpStringMapper : Mapper<String, HttpUrl> {
+
+    override fun handles(data: String): Boolean = HttpUrl.parse(data) != null
+
+    override fun map(data: String): HttpUrl = HttpUrl.get(data)
+}

--- a/coil-base/src/main/java/coil/map/StringMapper.kt
+++ b/coil-base/src/main/java/coil/map/StringMapper.kt
@@ -1,8 +1,0 @@
-package coil.map
-
-import okhttp3.HttpUrl
-
-internal class StringMapper : Mapper<String, HttpUrl> {
-
-    override fun map(data: String): HttpUrl = HttpUrl.get(data)
-}

--- a/coil-base/src/main/java/coil/map/UriStringMapper.kt
+++ b/coil-base/src/main/java/coil/map/UriStringMapper.kt
@@ -1,0 +1,15 @@
+package coil.map
+
+import android.content.ContentResolver
+import android.net.Uri
+
+internal class UriStringMapper : Mapper<String, Uri> {
+
+    override fun map(data: String): Uri = Uri.parse(data).let {
+        return if (it.scheme != null) {
+            it
+        } else {
+            it.buildUpon().scheme(ContentResolver.SCHEME_FILE).build()
+        }
+    }
+}


### PR DESCRIPTION
Fixes #24 

### Changes

I added a generic `UriStringMapper` to handle generic strings.  It is intentionally added at the end of the mappers in the `RealImageLoader` so that `HttpStringMapper` is preferred.  I also updated the `StringMapper` to only handle strings supported by `HttpUrl` instead of throwing an exception.

### Alternative

In the process of implementing this I realized that there could be an alternative approach that might be more flexible, but could come with a performance/complexity overhead. Since there is already a `Mapper<Uri, HttpUrl>`, the data mapping could be updated to continue mapping data until there are no more mappers that can handle the data.

```kotlin
var mapped = data
var mapper = registry.getMapper(mapped)
while (mapper != null) {
    mapped = mapper.map(mapped)
    mapper = registry.getMapper(mapped)
}
```

This would result in a url string going `String > Uri > HttpUrl` and a file string going `String > Uri`, but would also probably require more code to handle cases like map cycles and could result in a very long conversion route in extreme cases.

Because that's a larger change, I decided to simply implement the simple approach for this PR.