### PR TITLE
Adds the last modified date to the cache key for file Uris.

### DIFF
--- a/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
@@ -108,6 +108,12 @@ class UriFetcherTest {
     }
 
     @Test
+    fun assetCacheKeyWithLastModified() {
+        val uri = Uri.parse("file:///android_asset/normal.jpg")
+        assertEquals("$uri:0", loader.key(uri))
+    }
+
+    @Test
     fun nonfileCacheKeyEqualsUri() {
         val uri = Uri.parse("content://fake/content/path")
         assertEquals(uri.toString(), loader.key(uri))

--- a/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
@@ -91,7 +91,7 @@ class UriFetcherTest {
     @Test
     fun fileCacheKeyWithLastModified() {
         val file = File(context.filesDir.absolutePath + File.separator + "file.jpg")
-        val uri = Uri.fromFile(file)
+        val uri = file.toUri()
 
         // Copy the asset to filesDir.
         val source = context.assets.open("normal.jpg").source().buffer()

--- a/coil-base/src/main/java/coil/fetch/UriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/UriFetcher.kt
@@ -6,6 +6,7 @@ import android.content.res.AssetManager
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import androidx.collection.arraySetOf
+import androidx.core.net.toFile
 import coil.bitmappool.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
@@ -29,7 +30,11 @@ internal class UriFetcher(
 
     override fun handles(data: Uri) = SUPPORTED_SCHEMES.contains(data.scheme)
 
-    override fun key(data: Uri): String = data.toString()
+    override fun key(data: Uri): String = if (data.scheme == ContentResolver.SCHEME_FILE) {
+        "$data:${data.toFile().lastModified()}"
+    } else {
+        data.toString()
+    }
 
     override suspend fun fetch(
         pool: BitmapPool,


### PR DESCRIPTION
This is a pretty straightforward change to add the file's last modified timestamp to the cache key for file Uris to accurately determine freshness.