### PR TITLE
Add option to disable hardware bitmaps when constructing ImageLoader.

### DIFF
--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
  */
 data class DefaultRequestOptions(
     val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    val allowHardware: Boolean = true,
     val allowRgb565: Boolean = false,
     val crossfadeMillis: Int = 0,
     val placeholder: Drawable? = null,

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -108,7 +108,7 @@ class ImageLoaderBuilder(private val context: Context) {
      *
      * If false, any use of [Bitmap.Config.HARDWARE] will be treated as [Bitmap.Config.ARGB_8888].
      *
-     * NOTE: Setting this to false this will reduce performance on Android O+. Avoid disabling this if possible.
+     * NOTE: Setting this to false this will reduce performance on Android O and above. Only disable if necessary.
      *
      * Default: true
      */

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -104,6 +104,19 @@ class ImageLoaderBuilder(private val context: Context) {
     }
 
     /**
+     * Allow the use of [Bitmap.Config.HARDWARE].
+     *
+     * If false, any use of [Bitmap.Config.HARDWARE] will be treated as [Bitmap.Config.ARGB_8888].
+     *
+     * NOTE: Setting this to false this will reduce performance on Android O+. Avoid disabling this if possible.
+     *
+     * Default: true
+     */
+    fun allowHardware(enable: Boolean) = apply {
+        this.defaults = this.defaults.copy(allowHardware = enable)
+    }
+
+    /**
      * Allow automatically using [Bitmap.Config.RGB_565] when an image is guaranteed to not have alpha.
      *
      * This will reduce the visual quality of the image, but will also reduce memory usage.

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -72,7 +72,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         diskCachePolicy = CachePolicy.ENABLED
         memoryCachePolicy = CachePolicy.ENABLED
 
-        allowHardware = true
+        allowHardware = defaults.allowHardware
         allowRgb565 = defaults.allowRgb565
     }
 


### PR DESCRIPTION
Was initially against this, but I think it's fair to add as long as it's accompanied by a warning.

Fixes: https://github.com/coil-kt/coil/issues/31