### PR TITLE
Added support for directories in android_asset resolver

### DIFF
--- a/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/UriFetcherTest.kt
@@ -68,23 +68,30 @@ class UriFetcherTest {
     }
 
     @Test
-    fun basicExtractFileName() {
+    fun basicExtractPath() {
         val uri = Uri.parse("file:///android_asset/something.jpg")
-        val result = loader.extractAssetFileName(uri)
+        val result = loader.extractAssetPath(uri)
         assertEquals("something.jpg", result)
     }
 
     @Test
-    fun emptyExtractFileName() {
+    fun nestedDirectoriesExtractPath() {
+        val uri = Uri.parse("file:///android_asset/img/foo/bar/test.jpg")
+        val result = loader.extractAssetPath(uri)
+        assertEquals("img/foo/bar/test.jpg", result)
+    }
+
+    @Test
+    fun emptyExtractPath() {
         val uri = Uri.parse("file:///android_asset/")
-        val result = loader.extractAssetFileName(uri)
+        val result = loader.extractAssetPath(uri)
         assertEquals(null, result)
     }
 
     @Test
-    fun nonAssetUriExtractFileName() {
+    fun nonAssetUriExtractPath() {
         val uri = Uri.parse("file:///fake/file/path")
-        val result = loader.extractAssetFileName(uri)
+        val result = loader.extractAssetPath(uri)
         assertEquals(null, result)
     }
 

--- a/coil-base/src/main/java/coil/fetch/UriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/UriFetcher.kt
@@ -42,9 +42,9 @@ internal class UriFetcher(
         size: Size,
         options: Options
     ): FetchResult {
-        val assetFileName = extractAssetFileName(data)
-        val inputStream = if (assetFileName != null) {
-            context.assets.open(assetFileName)
+        val assetPath = extractAssetPath(data)
+        val inputStream = if (assetPath != null) {
+            context.assets.open(assetPath)
         } else {
             checkNotNull(context.contentResolver.openInputStream(data))
         }
@@ -56,20 +56,26 @@ internal class UriFetcher(
         )
     }
 
-    /** Return the asset's filename if [uri] must be handled by [AssetManager]. Else, return null. */
+    /** Return the asset's path if [uri] must be handled by [AssetManager]. Else, return null. */
     @VisibleForTesting
-    internal fun extractAssetFileName(uri: Uri): String? {
+    internal fun extractAssetPath(uri: Uri): String? {
         if (uri.scheme != ContentResolver.SCHEME_FILE) {
             return null
         }
 
         val segments = uri.pathSegments
-        return if (segments.count() == 2 &&
-            segments[0] == ASSET_FILE_PATH_SEGMENT &&
-            segments[1].isNotBlank()) {
-            segments[1]
-        } else {
-            null
+        if (segments.count() < 2 || segments[0] != ASSET_FILE_PATH_SEGMENT) {
+            return null
         }
+
+        val path = segments
+                .drop(1)
+                .joinToString("/")
+
+        if (path.isBlank()) {
+            return null
+        }
+
+        return path
     }
 }

--- a/coil-base/src/main/java/coil/fetch/UriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/UriFetcher.kt
@@ -69,8 +69,8 @@ internal class UriFetcher(
         }
 
         val path = segments
-                .drop(1)
-                .joinToString("/")
+            .drop(1)
+            .joinToString("/")
 
         if (path.isBlank()) {
             return null


### PR DESCRIPTION
## Problem
Coil is not able to load images from android_asset that aren't placed in the root directory of assets.

## Example
```
imageBackground.load("file:///android_asset/background.jpg".toUri()) // Works ok
imageBackground.load("file:///android_asset/foo/background.jpg".toUri()) // Fails
```

## Changes
`extractAssetFileName` method in UriFetcher was modified to accept more than 2 path segments. Uri is now verified, stripped from android_asset prefix and joined to a path with subdirectories included.
