### PR TITLE
Guard against running out of file descriptors on Android O and O_MR1.

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -310,7 +310,7 @@ internal class RealImageLoader(
         scale: Scale
     ): DrawableResult = withContext(request.dispatcher) {
         // Convert the data into a Drawable.
-        val options = requestService.options(request, scale, networkObserver.isOnline())
+        val options = requestService.options(request, size, scale, networkObserver.isOnline())
         val result = when (val fetchResult = fetcher.fetch(bitmapPool, mappedData, size, options)) {
             is SourceResult -> {
                 val decodeResult = try {

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -5,6 +5,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.O
 import android.os.Build.VERSION_CODES.O_MR1
 import android.util.Log
+import androidx.annotation.WorkerThread
 import coil.size.PixelSize
 import coil.size.Size
 import coil.util.log
@@ -68,6 +69,7 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
     }
 
     @Synchronized
+    @WorkerThread
     private fun hasAvailableFileDescriptors(): Boolean {
         // Only check if we have available file descriptors after a
         // set amount of decodes since it's expensive (1-2 milliseconds).

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -56,8 +56,8 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
 
     private val fileDescriptorList = File("/proc/self/fd")
 
-    private var decodesSinceLastFileDescriptorCheck = 0
-    private var hasAvailableFileDescriptors = true
+    @Volatile private var decodesSinceLastFileDescriptorCheck = 0
+    @Volatile private var hasAvailableFileDescriptors = true
 
     override fun allowHardware(size: Size): Boolean {
         // Don't use up file descriptors on small bitmaps.

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -1,0 +1,86 @@
+package coil.memory
+
+import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.O
+import android.os.Build.VERSION_CODES.O_MR1
+import android.util.Log
+import coil.size.PixelSize
+import coil.size.Size
+import coil.util.log
+import java.io.File
+
+/** Decides if a request can use [Bitmap.Config.HARDWARE]. */
+internal sealed class HardwareBitmapService {
+
+    companion object {
+        operator fun invoke(): HardwareBitmapService {
+            return if (SDK_INT == O || SDK_INT == O_MR1) {
+                LimitedFileDescriptorHardwareBitmapService
+            } else {
+                EmptyHardwareBitmapService
+            }
+        }
+    }
+
+    /** Return true if we can currently use [Bitmap.Config.HARDWARE]. */
+    abstract fun allowHardware(size: Size): Boolean
+}
+
+/** A no-op [HardwareBitmapService], which always returns true. */
+private object EmptyHardwareBitmapService : HardwareBitmapService() {
+
+    override fun allowHardware(size: Size) = true
+}
+
+/**
+ * Android O and O_MR1 have a limited number of file descriptors (often 1024) per-process.
+ * This limit was increased to a safe number in Android P (32768). Each hardware bitmap
+ * allocation consumes, on average, 2 file descriptors. In addition, other non-image loading
+ * operations can use file descriptors, which increases competition for these resources.
+ * This class exists to disable [Bitmap.Config.HARDWARE] allocation if this process gets
+ * too close to the limit, as passing the limit can cause crashes and/or rendering issues.
+ *
+ * NOTE: This must be a singleton since it tracks global file descriptor usage state.
+ *
+ * Modified from Glide's HardwareConfigState.
+ */
+private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapService() {
+
+    private const val TAG = "LimitedFileDescriptorHardwareBitmapService"
+
+    private const val MIN_SIZE_DIMENSION = 128
+    private const val FILE_DESCRIPTOR_LIMIT = 768
+    private const val FILE_DESCRIPTOR_CHECK_INTERVAL = 32
+
+    private val fileDescriptorList = File("/proc/self/fd")
+
+    private var decodesSinceLastFileDescriptorCheck = 0
+    private var hasAvailableFileDescriptors = true
+
+    override fun allowHardware(size: Size): Boolean {
+        // Don't use up file descriptors on small Bitmaps.
+        if (size is PixelSize && size.run { width < MIN_SIZE_DIMENSION || size.height < MIN_SIZE_DIMENSION }) {
+            return false
+        }
+        return hasAvailableFileDescriptors()
+    }
+
+    @Synchronized
+    private fun hasAvailableFileDescriptors(): Boolean {
+        // Only check if we have available file descriptors after a set amount of decodes since it's expensive.
+        if (decodesSinceLastFileDescriptorCheck++ >= FILE_DESCRIPTOR_CHECK_INTERVAL) {
+            decodesSinceLastFileDescriptorCheck = 0
+            val numUsedFileDescriptors = fileDescriptorList.list().count()
+            hasAvailableFileDescriptors = numUsedFileDescriptors < FILE_DESCRIPTOR_LIMIT
+
+            if (hasAvailableFileDescriptors) {
+                log(TAG, Log.WARN) {
+                    "Unable to allocate more hardware bitmaps. Number of used file descriptors: $numUsedFileDescriptors"
+                }
+            }
+        }
+
+        return hasAvailableFileDescriptors
+    }
+}

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -69,7 +69,8 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
 
     @Synchronized
     private fun hasAvailableFileDescriptors(): Boolean {
-        // Only check if we have available file descriptors after a set amount of decodes since it's expensive.
+        // Only check if we have available file descriptors after a
+        // set amount of decodes since it's expensive (1-2 milliseconds).
         if (decodesSinceLastFileDescriptorCheck++ >= FILE_DESCRIPTOR_CHECK_INTERVAL) {
             decodesSinceLastFileDescriptorCheck = 0
 

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -51,7 +51,7 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
 
     private const val MIN_SIZE_DIMENSION = 128
     private const val FILE_DESCRIPTOR_LIMIT = 768
-    private const val FILE_DESCRIPTOR_CHECK_INTERVAL = 32
+    private const val FILE_DESCRIPTOR_CHECK_INTERVAL = 64
 
     private val fileDescriptorList = File("/proc/self/fd")
 

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -50,8 +50,8 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
     private const val TAG = "LimitedFileDescriptorHardwareBitmapService"
 
     private const val MIN_SIZE_DIMENSION = 128
-    private const val FILE_DESCRIPTOR_LIMIT = 768
-    private const val FILE_DESCRIPTOR_CHECK_INTERVAL = 64
+    private const val FILE_DESCRIPTOR_LIMIT = 700
+    private const val FILE_DESCRIPTOR_CHECK_INTERVAL = 50
 
     private val fileDescriptorList = File("/proc/self/fd")
 

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -72,6 +72,7 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
         // Only check if we have available file descriptors after a set amount of decodes since it's expensive.
         if (decodesSinceLastFileDescriptorCheck++ >= FILE_DESCRIPTOR_CHECK_INTERVAL) {
             decodesSinceLastFileDescriptorCheck = 0
+
             val numUsedFileDescriptors = fileDescriptorList.list().count()
             hasAvailableFileDescriptors = numUsedFileDescriptors < FILE_DESCRIPTOR_LIMIT
 

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -90,15 +90,21 @@ internal class RequestService {
         scale: Scale,
         isOnline: Boolean
     ): Options {
-        val isValidBitmapConfig = request.isConfigValidForTransformations() && request.isConfigValidForHardware(size)
-        val bitmapConfig = if (isValidBitmapConfig) request.bitmapConfig else Bitmap.Config.ARGB_8888
+        // Fall back to ARGB_8888 if the requested bitmap config does not pass the checks.
+        val isValidConfig = request.isConfigValidForTransformations() && request.isConfigValidForHardware(size)
+        val bitmapConfig = if (isValidConfig) request.bitmapConfig else Bitmap.Config.ARGB_8888
+
+        // Disable fetching from the network if we know it's offline.
         val networkCachePolicy = if (isOnline) request.networkCachePolicy else CachePolicy.DISABLED
+
+        // Disable allowRgb565 if there are transformations.
+        val allowRgb565 = request.transformations.isEmpty() && request.allowRgb565
 
         return Options(
             config = bitmapConfig,
             colorSpace = request.colorSpace,
             scale = scale,
-            allowRgb565 = request.allowRgb565,
+            allowRgb565 = allowRgb565,
             diskCachePolicy = request.diskCachePolicy,
             networkCachePolicy = networkCachePolicy
         )

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -90,9 +90,7 @@ internal class RequestService {
         scale: Scale,
         isOnline: Boolean
     ): Options {
-        val isValidBitmapConfig = request.isConfigValidForTransformations() &&
-            request.isConfigValidForAllowHardware() &&
-            request.isConfigValidForFileDescriptorLimit(size)
+        val isValidBitmapConfig = request.isConfigValidForTransformations() && request.isConfigValidForHardware(size)
         val bitmapConfig = if (isValidBitmapConfig) request.bitmapConfig else Bitmap.Config.ARGB_8888
         val networkCachePolicy = if (!isOnline) CachePolicy.DISABLED else request.networkCachePolicy
 
@@ -118,12 +116,10 @@ internal class RequestService {
         return transformations.isEmpty() || Transformation.VALID_CONFIGS.contains(bitmapConfig)
     }
 
-    private fun Request.isConfigValidForAllowHardware(): Boolean {
-        return SDK_INT < O || allowHardware || bitmapConfig != Bitmap.Config.HARDWARE
-    }
-
-    private fun Request.isConfigValidForFileDescriptorLimit(size: Size): Boolean {
-        return SDK_INT < O || bitmapConfig != Bitmap.Config.HARDWARE || hardwareBitmapService.allowHardware(size)
+    private fun Request.isConfigValidForHardware(size: Size): Boolean {
+        if (SDK_INT < O) return true
+        if (bitmapConfig != Bitmap.Config.HARDWARE) return true
+        return allowHardware && hardwareBitmapService.allowHardware(size)
     }
 
     data class LifecycleInfo(

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -92,7 +92,7 @@ internal class RequestService {
     ): Options {
         val isValidBitmapConfig = request.isConfigValidForTransformations() && request.isConfigValidForHardware(size)
         val bitmapConfig = if (isValidBitmapConfig) request.bitmapConfig else Bitmap.Config.ARGB_8888
-        val networkCachePolicy = if (!isOnline) CachePolicy.DISABLED else request.networkCachePolicy
+        val networkCachePolicy = if (isOnline) request.networkCachePolicy else CachePolicy.DISABLED
 
         return Options(
             config = bitmapConfig,

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -6,6 +6,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.O
 import android.widget.ImageView
 import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
 import androidx.lifecycle.Lifecycle
 import coil.decode.Options
 import coil.lifecycle.GlobalLifecycle
@@ -84,6 +85,7 @@ internal class RequestService {
         return Scale.FILL
     }
 
+    @WorkerThread
     fun options(
         request: Request,
         size: Size,


### PR DESCRIPTION
Guard against running out of file descriptors on Android O and O_MR1.

Glide already has code to handle this and Coil should handle it as well. Running over the file descriptor limit on Android O can often cause `SIGSEV - SEGV_MAPERR` native crashes.