### PR TITLE
Fix loading vector drawables with the hardware bitmap config.

### DIFF
--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -65,6 +65,8 @@ fun DependencyHandler.addTestDependencies(kotlinVersion: String) {
     testImplementation(kotlin("test-junit", kotlinVersion))
     testImplementation(Library.KOTLINX_COROUTINES_TEST)
 
+    testImplementation(Library.ANDROIDX_APPCOMPAT_RESOURCES)
+
     testImplementation(Library.ANDROIDX_TEST_CORE)
     testImplementation(Library.ANDROIDX_TEST_JUNIT)
     testImplementation(Library.ANDROIDX_TEST_RULES)
@@ -76,6 +78,8 @@ fun DependencyHandler.addTestDependencies(kotlinVersion: String) {
 
 fun DependencyHandler.addAndroidTestDependencies(kotlinVersion: String) {
     androidTestImplementation(kotlin("test-junit", kotlinVersion))
+
+    androidTestImplementation(Library.ANDROIDX_APPCOMPAT_RESOURCES)
 
     androidTestImplementation(Library.ANDROIDX_TEST_CORE)
     androidTestImplementation(Library.ANDROIDX_TEST_JUNIT)

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -65,8 +65,6 @@ fun DependencyHandler.addTestDependencies(kotlinVersion: String) {
     testImplementation(kotlin("test-junit", kotlinVersion))
     testImplementation(Library.KOTLINX_COROUTINES_TEST)
 
-    testImplementation(Library.ANDROIDX_APPCOMPAT_RESOURCES)
-
     testImplementation(Library.ANDROIDX_TEST_CORE)
     testImplementation(Library.ANDROIDX_TEST_JUNIT)
     testImplementation(Library.ANDROIDX_TEST_RULES)
@@ -78,8 +76,6 @@ fun DependencyHandler.addTestDependencies(kotlinVersion: String) {
 
 fun DependencyHandler.addAndroidTestDependencies(kotlinVersion: String) {
     androidTestImplementation(kotlin("test-junit", kotlinVersion))
-
-    androidTestImplementation(Library.ANDROIDX_APPCOMPAT_RESOURCES)
 
     androidTestImplementation(Library.ANDROIDX_TEST_CORE)
     androidTestImplementation(Library.ANDROIDX_TEST_JUNIT)

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -102,6 +102,13 @@ class RealImageLoaderIntegrationTest {
     }
 
     @Test
+    fun resourceIntVector() {
+        val data = R.drawable.ic_android
+        testLoad(data, PixelSize(100, 100))
+        testGet(data, PixelSize(100, 100))
+    }
+
+    @Test
     fun resourceUriInt() {
         val data = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/${R.drawable.normal}")
         testLoad(data)
@@ -109,10 +116,24 @@ class RealImageLoaderIntegrationTest {
     }
 
     @Test
+    fun resourceUriIntVector() {
+        val data = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/${R.drawable.ic_android}")
+        testLoad(data, PixelSize(100, 100))
+        testGet(data, PixelSize(100, 100))
+    }
+
+    @Test
     fun resourceUriString() {
         val data = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/drawable/normal")
         testLoad(data)
         testGet(data)
+    }
+
+    @Test
+    fun resourceUriStringVector() {
+        val data = Uri.parse("${ContentResolver.SCHEME_ANDROID_RESOURCE}://${context.packageName}/drawable/ic_android")
+        testLoad(data, PixelSize(100, 100))
+        testGet(data, PixelSize(100, 100))
     }
 
     @Test

--- a/coil-base/src/sharedTest/java/coil/bitmappool/FakeBitmapPool.kt
+++ b/coil-base/src/sharedTest/java/coil/bitmappool/FakeBitmapPool.kt
@@ -27,6 +27,8 @@ class FakeBitmapPool : BitmapPool {
     }
 
     override fun getDirtyOrNull(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {
+        require(config != Bitmap.Config.HARDWARE)
+
         gets += Get(width, height, config)
 
         val size = Utils.calculateAllocationByteCount(width, height, config)

--- a/coil-base/src/sharedTest/java/coil/bitmappool/FakeBitmapPool.kt
+++ b/coil-base/src/sharedTest/java/coil/bitmappool/FakeBitmapPool.kt
@@ -1,6 +1,8 @@
 package coil.bitmappool
 
 import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.O
 import androidx.annotation.Px
 import coil.util.Utils
 import coil.util.getAllocationByteCountCompat
@@ -27,7 +29,7 @@ class FakeBitmapPool : BitmapPool {
     }
 
     override fun getDirtyOrNull(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {
-        require(config != Bitmap.Config.HARDWARE)
+        require(SDK_INT < O || config != Bitmap.Config.HARDWARE)
 
         gets += Get(width, height, config)
 

--- a/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
+++ b/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
@@ -5,16 +5,18 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.VectorDrawable
 import androidx.test.core.app.ApplicationProvider
-import coil.base.test.R
 import coil.bitmappool.RealBitmapPool
 import coil.size.PixelSize
-import coil.util.getDrawableCompat
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@RunWith(RobolectricTestRunner::class)
 class DrawableDecoderServiceTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -26,13 +28,13 @@ class DrawableDecoderServiceTest {
         service = DrawableDecoderService(context, RealBitmapPool(0))
     }
 
-    /** This test will fail on pre-Lollipop since we don't import AppCompatResources in the base library. */
     @Test
-    fun vectorIsConvertedCorrectly() {
+    fun `vector with hardware config is converted correctly`() {
+        val input = VectorDrawable()
         val output = service.convertIfNecessary(
-            drawable = context.getDrawableCompat(R.drawable.ic_android),
+            drawable = input,
             size = PixelSize(200, 200),
-            config = Bitmap.Config.ARGB_8888
+            config = Bitmap.Config.HARDWARE
         )
 
         assertTrue(output is BitmapDrawable)
@@ -40,7 +42,7 @@ class DrawableDecoderServiceTest {
     }
 
     @Test
-    fun colorIsNotConverted() {
+    fun `color is not converted`() {
         val input = ColorDrawable(Color.BLACK)
         val output = service.convertIfNecessary(
             drawable = input,


### PR DESCRIPTION
Fixes: #88 #86 #42

Fixes the case where vector drawables would fail to load if loaded with a hardware bitmap config.