### PR TITLE
Include night mode in a resource Uri's cache key.

### DIFF
--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -13,6 +13,7 @@ import coil.size.Size
 import coil.util.getDrawableCompat
 import coil.util.getMimeTypeFromUrl
 import coil.util.getXmlDrawableCompat
+import coil.util.nightMode
 import okio.buffer
 import okio.source
 
@@ -27,7 +28,7 @@ internal class ResourceUriFetcher(
 
     override fun handles(data: Uri) = data.scheme == ContentResolver.SCHEME_ANDROID_RESOURCE
 
-    override fun key(data: Uri) = data.toString()
+    override fun key(data: Uri) = "$data-${context.resources.configuration.nightMode}"
 
     override suspend fun fetch(
         pool: BitmapPool,

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -4,6 +4,7 @@ package coil.util
 
 import android.app.ActivityManager
 import android.content.Context
+import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
@@ -191,3 +192,6 @@ internal val Uri.firstPathSegment: String?
 internal fun Resources.getDrawableCompat(@DrawableRes resId: Int, theme: Resources.Theme?): Drawable {
     return checkNotNull(ResourcesCompat.getDrawable(this, resId, theme))
 }
+
+internal val Configuration.nightMode: Int
+    get() = uiMode and Configuration.UI_MODE_NIGHT_MASK


### PR DESCRIPTION
Enabling/disabling night mode should result in a cache miss for a resource ID since the same resource ID could now resolve to a different asset.