### PR TITLE
Add Request.parameters to support passing custom data through the image pipeline.

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -43,6 +43,7 @@ import coil.request.BaseTargetRequestDisposable
 import coil.request.EmptyRequestDisposable
 import coil.request.GetRequest
 import coil.request.LoadRequest
+import coil.request.Parameters
 import coil.request.Request
 import coil.request.RequestDisposable
 import coil.request.ViewTargetRequestDisposable
@@ -273,21 +274,25 @@ internal class RealImageLoader(
     private fun <T : Any> computeCacheKey(
         fetcher: Fetcher<T>,
         data: T,
-        parameters: Map<String, Any>,
+        parameters: Parameters,
         transformations: List<Transformation>
     ): String? {
         val baseCacheKey = fetcher.key(data) ?: return null
+
         return buildString {
             append(baseCacheKey)
+
             if (parameters.isNotEmpty()) {
-                parameters.forEach { (key, value) ->
-                    append(';')
+                for ((key, entry) in parameters) {
+                    val cacheKey = entry.cacheKey ?: continue
+                    append('#')
                     append(key)
-                    append(',')
-                    append(value)
+                    append('=')
+                    append(cacheKey)
                 }
-                append(';')
+                append('#')
             }
+
             transformations.forEach { append(it.key()) }
         }
     }

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -201,7 +201,7 @@ internal class RealImageLoader(
 
             // Compute the cache key.
             val fetcher = registry.requireFetcher(mappedData)
-            val cacheKey = request.key ?: computeCacheKey(fetcher, mappedData, request.transformations)
+            val cacheKey = request.key ?: computeCacheKey(fetcher, mappedData, request.parameters, request.transformations)
 
             // Check the memory cache and set the placeholder.
             val cachedValue = takeIf(request.memoryCachePolicy.readEnabled) {
@@ -268,16 +268,26 @@ internal class RealImageLoader(
     }
 
     /**
-     * Compute the cache key for the [data] + [transformations].
+     * Compute the cache key for the [data] + [parameters] + [transformations].
      */
     private fun <T : Any> computeCacheKey(
         fetcher: Fetcher<T>,
         data: T,
+        parameters: Map<String, Any>,
         transformations: List<Transformation>
     ): String? {
         val baseCacheKey = fetcher.key(data) ?: return null
         return buildString {
             append(baseCacheKey)
+            if (parameters.isNotEmpty()) {
+                parameters.forEach { (key, value) ->
+                    append(';')
+                    append(key)
+                    append(',')
+                    append(value)
+                }
+                append(';')
+            }
             transformations.forEach { append(it.key()) }
         }
     }

--- a/coil-base/src/main/java/coil/collection/GroupedLinkedMap.kt
+++ b/coil-base/src/main/java/coil/collection/GroupedLinkedMap.kt
@@ -1,6 +1,5 @@
 package coil.collection
 
-import coil.util.orEmpty
 import coil.util.removeLast
 import java.util.HashMap
 
@@ -111,7 +110,7 @@ internal class GroupedLinkedMap<K, V> {
         fun size(): Int = values?.count() ?: 0
 
         fun add(value: V) {
-            values = values.orEmpty().apply { add(value) }
+            values = (values ?: mutableListOf()).apply { add(value) }
         }
     }
 }

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -19,6 +19,7 @@ import okhttp3.Headers
  * @param headers The headers for any network operations.
  * @param networkCachePolicy Used to determine if this request is allowed to read from the network.
  * @param diskCachePolicy Used to determine if this request is allowed to read/write from/to disk.
+ * @param parameters A map of custom parameters. These are used to pass custom data to [Fetcher]s and [Decoder]s.
  */
 data class Options(
     val config: Bitmap.Config,
@@ -27,5 +28,6 @@ data class Options(
     val allowRgb565: Boolean,
     val headers: Headers,
     val networkCachePolicy: CachePolicy,
-    val diskCachePolicy: CachePolicy
+    val diskCachePolicy: CachePolicy,
+    val parameters: Map<String, Any>
 )

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.ColorSpace
 import coil.fetch.Fetcher
 import coil.request.CachePolicy
+import coil.request.Parameters
 import coil.size.Scale
 import okhttp3.Headers
 
@@ -17,9 +18,9 @@ import okhttp3.Headers
  * @param scale Determines if the image should be loaded to fit or fill the target's dimensions.
  * @param allowRgb565 True if the [Fetcher] is allowed to use [Bitmap.Config.RGB_565] as an optimization.
  * @param headers The headers for any network operations.
+ * @param parameters A map of custom parameters. These are used to pass custom data to [Fetcher]s and [Decoder]s.
  * @param networkCachePolicy Used to determine if this request is allowed to read from the network.
  * @param diskCachePolicy Used to determine if this request is allowed to read/write from/to disk.
- * @param parameters A map of custom parameters. These are used to pass custom data to [Fetcher]s and [Decoder]s.
  */
 data class Options(
     val config: Bitmap.Config,
@@ -27,7 +28,7 @@ data class Options(
     val scale: Scale,
     val allowRgb565: Boolean,
     val headers: Headers,
-    val parameters: Map<String, Any>,
+    val parameters: Parameters,
     val networkCachePolicy: CachePolicy,
     val diskCachePolicy: CachePolicy
 )

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -27,7 +27,7 @@ data class Options(
     val scale: Scale,
     val allowRgb565: Boolean,
     val headers: Headers,
+    val parameters: Map<String, Any>,
     val networkCachePolicy: CachePolicy,
-    val diskCachePolicy: CachePolicy,
-    val parameters: Map<String, Any>
+    val diskCachePolicy: CachePolicy
 )

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -109,7 +109,8 @@ internal class RequestService {
             allowRgb565 = allowRgb565,
             headers = request.headers,
             diskCachePolicy = request.diskCachePolicy,
-            networkCachePolicy = networkCachePolicy
+            networkCachePolicy = networkCachePolicy,
+            parameters = request.parameters
         )
     }
 

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -108,9 +108,9 @@ internal class RequestService {
             scale = scale,
             allowRgb565 = allowRgb565,
             headers = request.headers,
+            parameters = request.parameters,
             diskCachePolicy = request.diskCachePolicy,
-            networkCachePolicy = networkCachePolicy,
-            parameters = request.parameters
+            networkCachePolicy = networkCachePolicy
         )
     }
 

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -33,7 +33,7 @@ class Parameters private constructor(
      * @param cacheKey The parameter's cache key. If not null, this value will be added to a request's cache key.
      */
     data class Entry(
-        val value: Any,
+        val value: Any?,
         val cacheKey: String?
     )
 
@@ -57,7 +57,7 @@ class Parameters private constructor(
          * @param cacheKey The parameter's cache key. If not null, this value will be added to a request's cache key.
          */
         @JvmOverloads
-        fun set(key: String, value: Any, cacheKey: String? = null) = apply {
+        fun set(key: String, value: Any?, cacheKey: String? = null) = apply {
             this.map[key] = Entry(value, cacheKey)
         }
 

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -1,0 +1,67 @@
+package coil.request
+
+import androidx.collection.arrayMapOf
+import coil.decode.Decoder
+import coil.fetch.Fetcher
+import coil.util.toArrayMap
+
+/** A map of generic values that can be used to pass custom data to [Fetcher]s and [Decoder]s. */
+class Parameters private constructor(
+    private val map: Map<String, Entry>
+): Map<String, Parameters.Entry> by map {
+
+    companion object {
+        @JvmField
+        val EMPTY = Parameters()
+
+        /** Create a new [Parameters] instance. */
+        inline operator fun invoke(
+            builder: Builder.() -> Unit = {}
+        ): Parameters = Builder().apply(builder).build()
+    }
+
+    fun newBuilder() = Builder(this)
+
+    /**
+     * @param value The parameter's value.
+     * @param cacheKey The parameter's cache key. If not null, this value will be added to a request's cache key.
+     */
+    data class Entry(
+        val value: Any,
+        val cacheKey: String?
+    )
+
+    class Builder {
+
+        private val map: MutableMap<String, Entry>
+
+        constructor() {
+            map = arrayMapOf()
+        }
+
+        constructor(parameters: Parameters) {
+            map = parameters.map.toArrayMap()
+        }
+
+        /**
+         * Set a parameter.
+         *
+         * @param key The parameter's key.
+         * @param value The parameter's value.
+         * @param cacheKey The parameter's cache key. If not null, this value will be added to a request's cache key.
+         */
+        @JvmOverloads
+        fun set(key: String, value: Any, cacheKey: String? = null) = apply {
+            this.map[key] = Entry(value, cacheKey)
+        }
+
+        /**
+         * Remove a parameter.
+         */
+        fun remove(key: String) = apply {
+            this.map.remove(key)
+        }
+
+        fun build() = Parameters(map)
+    }
+}

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -20,6 +20,12 @@ class Parameters private constructor(
         ): Parameters = Builder().apply(builder).build()
     }
 
+    override fun equals(other: Any?) = map == other
+
+    override fun hashCode() = map.hashCode()
+
+    override fun toString() = map.toString()
+
     fun newBuilder() = Builder(this)
 
     /**

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -8,7 +8,7 @@ import coil.util.toArrayMap
 /** A map of generic values that can be used to pass custom data to [Fetcher]s and [Decoder]s. */
 class Parameters private constructor(
     private val map: Map<String, Entry>
-): Map<String, Parameters.Entry> by map {
+) : Map<String, Parameters.Entry> by map {
 
     companion object {
         @JvmField

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -52,6 +52,8 @@ sealed class Request {
     abstract val allowHardware: Boolean
     abstract val allowRgb565: Boolean
 
+    abstract val parameters: Map<String, Any>
+
     abstract val placeholder: Drawable?
     abstract val error: Drawable?
 
@@ -127,6 +129,7 @@ class LoadRequest internal constructor(
     override val memoryCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
     override val allowRgb565: Boolean,
+    override val parameters: Map<String, Any>,
     @DrawableRes internal val placeholderResId: Int,
     @DrawableRes internal val errorResId: Int,
     internal val placeholderDrawable: Drawable?,
@@ -202,7 +205,8 @@ class GetRequest internal constructor(
     override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
-    override val allowRgb565: Boolean
+    override val allowRgb565: Boolean,
+    override val parameters: Map<String, Any>
 ) : Request() {
 
     companion object {

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -44,7 +44,7 @@ sealed class Request {
     abstract val bitmapConfig: Bitmap.Config
     abstract val colorSpace: ColorSpace?
     abstract val headers: Headers
-    abstract val parameters: Map<String, Any>
+    abstract val parameters: Parameters
 
     abstract val networkCachePolicy: CachePolicy
     abstract val diskCachePolicy: CachePolicy
@@ -123,7 +123,7 @@ class LoadRequest internal constructor(
     override val bitmapConfig: Bitmap.Config,
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
-    override val parameters: Map<String, Any>,
+    override val parameters: Parameters,
     override val networkCachePolicy: CachePolicy,
     override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
@@ -200,7 +200,7 @@ class GetRequest internal constructor(
     override val bitmapConfig: Bitmap.Config,
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
-    override val parameters: Map<String, Any>,
+    override val parameters: Parameters,
     override val networkCachePolicy: CachePolicy,
     override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -44,6 +44,7 @@ sealed class Request {
     abstract val bitmapConfig: Bitmap.Config
     abstract val colorSpace: ColorSpace?
     abstract val headers: Headers
+    abstract val parameters: Map<String, Any>
 
     abstract val networkCachePolicy: CachePolicy
     abstract val diskCachePolicy: CachePolicy
@@ -51,8 +52,6 @@ sealed class Request {
 
     abstract val allowHardware: Boolean
     abstract val allowRgb565: Boolean
-
-    abstract val parameters: Map<String, Any>
 
     abstract val placeholder: Drawable?
     abstract val error: Drawable?
@@ -124,12 +123,12 @@ class LoadRequest internal constructor(
     override val bitmapConfig: Bitmap.Config,
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
+    override val parameters: Map<String, Any>,
     override val networkCachePolicy: CachePolicy,
     override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
     override val allowRgb565: Boolean,
-    override val parameters: Map<String, Any>,
     @DrawableRes internal val placeholderResId: Int,
     @DrawableRes internal val errorResId: Int,
     internal val placeholderDrawable: Drawable?,
@@ -201,12 +200,12 @@ class GetRequest internal constructor(
     override val bitmapConfig: Bitmap.Config,
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
+    override val parameters: Map<String, Any>,
     override val networkCachePolicy: CachePolicy,
     override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
-    override val allowRgb565: Boolean,
-    override val parameters: Map<String, Any>
+    override val allowRgb565: Boolean
 ) : Request() {
 
     companion object {

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -12,6 +12,7 @@ import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.annotation.Px
 import androidx.annotation.RequiresApi
+import androidx.collection.arrayMapOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import coil.ComponentRegistry
@@ -34,6 +35,7 @@ import coil.transform.Transformation
 import coil.util.Utils
 import coil.util.orEmpty
 import coil.util.self
+import coil.util.toArrayMap
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.Headers
 import okio.BufferedSource
@@ -319,7 +321,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * NOTE: Parameters are added to the cache key.
      */
     fun parameters(parameters: Map<String, Any>) {
-        this.parameters = parameters.toMutableMap()
+        this.parameters = parameters.toArrayMap()
     }
 
     /**
@@ -330,7 +332,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * NOTE: Parameters are added to the cache key.
      */
     fun setParameter(key: String, value: Any): T = self {
-        this.parameters = (this.parameters ?: mutableMapOf()).apply { set(key, value) }
+        this.parameters = (this.parameters ?: arrayMapOf()).apply { set(key, value) }
     }
 
     /**
@@ -341,7 +343,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * NOTE: Parameters are added to the cache key.
      */
     fun removeParameter(key: String): T = self {
-        this.parameters = (this.parameters ?: mutableMapOf()).apply { remove(key) }
+        this.parameters = (this.parameters ?: arrayMapOf()).apply { remove(key) }
     }
 }
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -315,6 +315,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * Set the parameters for this request.
      *
      * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     *
+     * NOTE: Parameters are added to the cache key.
      */
     fun parameters(parameters: Map<String, Any>) {
         this.parameters = parameters.toMutableMap()
@@ -324,6 +326,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * Set a parameter for this request.
      *
      * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     *
+     * NOTE: Parameters are added to the cache key.
      */
     fun setParameter(key: String, value: Any): T = self {
         this.parameters = (this.parameters ?: mutableMapOf()).apply { set(key, value) }
@@ -333,6 +337,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * Remove a parameter from this request.
      *
      * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     *
+     * NOTE: Parameters are added to the cache key.
      */
     fun removeParameter(key: String): T = self {
         this.parameters = (this.parameters ?: mutableMapOf()).apply { remove(key) }

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -343,7 +343,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * NOTE: Parameters are added to the cache key.
      */
     fun removeParameter(key: String): T = self {
-        this.parameters = (this.parameters ?: arrayMapOf()).apply { remove(key) }
+        this.parameters?.remove(key)
     }
 }
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -250,7 +250,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     /**
      * Set the cache key for this request.
      *
-     * By default, the cache key is computed by the [Fetcher] and any [Transformation]s.
+     * By default, the cache key is computed by the [Fetcher], any [parameters], and any [Transformation]s.
      */
     fun key(key: String?): T = self {
         this.key = key

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -33,6 +33,8 @@ import coil.target.Target
 import coil.transform.Transformation
 import coil.util.Utils
 import coil.util.orEmpty
+import coil.util.minus
+import coil.util.plus
 import coil.util.self
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.Headers
@@ -62,6 +64,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     protected var allowHardware: Boolean
     protected var allowRgb565: Boolean
 
+    protected var parameters: Map<String, Any>
+
     constructor(defaults: DefaultRequestOptions) {
         data = null
 
@@ -84,6 +88,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
 
         allowHardware = defaults.allowHardware
         allowRgb565 = defaults.allowRgb565
+
+        parameters = emptyMap()
     }
 
     constructor(request: Request) {
@@ -108,6 +114,8 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
 
         allowHardware = request.allowHardware
         allowRgb565 = request.allowRgb565
+
+        parameters = request.parameters
     }
 
     /**
@@ -145,7 +153,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * Set the list of [Transformation]s to be applied to this request.
      */
     fun transformations(transformations: List<Transformation>): T = self {
-        this.transformations = transformations
+        this.transformations = transformations.toList()
     }
 
     /**
@@ -254,7 +262,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     }
 
     /**
-     * Enable/disable reading/writing from/to the network.
+     * Enable/disable reading from the network.
      *
      * NOTE: Disabling writes has no effect.
      */
@@ -270,7 +278,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     }
 
     /**
-     * Enable/disable reading/writing from/to the memory.
+     * Enable/disable reading/writing from/to the memory cache.
      */
     fun memoryCachePolicy(policy: CachePolicy): T = self {
         this.memoryCachePolicy = policy
@@ -306,6 +314,33 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      */
     fun removeHeader(name: String): T = self {
         this.headers = this.headers?.removeAll(name)
+    }
+
+    /**
+     * Set the parameters for this request.
+     *
+     * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     */
+    fun parameters(parameters: Map<String, Any>) {
+        this.parameters = parameters.toMap()
+    }
+
+    /**
+     * Add a parameter to this request.
+     *
+     * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     */
+    fun addParameter(key: String, value: Any): T = self {
+        this.parameters = this.parameters.plus(key, value)
+    }
+
+    /**
+     * Remove a parameter from this request.
+     *
+     * Parameters can be used to pass custom data to [Fetcher]s and [Decoder]s.
+     */
+    fun removeParameter(key: String): T = self {
+        this.parameters = this.parameters.minus(key)
     }
 }
 
@@ -475,6 +510,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
             memoryCachePolicy,
             allowHardware,
             allowRgb565,
+            parameters,
             placeholderResId,
             errorResId,
             placeholderDrawable,
@@ -515,7 +551,8 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
             diskCachePolicy,
             memoryCachePolicy,
             allowHardware,
-            allowRgb565
+            allowRgb565,
+            parameters
         )
     }
 }

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -250,7 +250,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     /**
      * Set the cache key for this request.
      *
-     * By default, the cache key is computed by the [Fetcher], any [parameters], and any [Transformation]s.
+     * By default, the cache key is computed by the [Fetcher], any [Parameters], and any [Transformation]s.
      */
     fun key(key: String?): T = self {
         this.key = key
@@ -323,7 +323,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      *
      * @see Parameters.Builder.set
      */
-    fun setParameter(key: String, value: Any, cacheKey: String? = null): T = self {
+    fun setParameter(key: String, value: Any?, cacheKey: String? = null): T = self {
         this.parameters = (this.parameters ?: Parameters.Builder()).apply { set(key, value, cacheKey) }
     }
 

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -36,6 +36,7 @@ import okhttp3.Call
 import okhttp3.Headers
 import okhttp3.Response
 import java.io.Closeable
+import java.util.Collections
 
 internal suspend inline fun Call.await(): Response {
     return suspendCancellableCoroutine { continuation ->
@@ -212,3 +213,22 @@ internal val Configuration.nightMode: Int
 private val EMPTY_HEADERS = Headers.Builder().build()
 
 internal fun Headers?.orEmpty() = this ?: EMPTY_HEADERS
+
+internal inline fun <K, V> mapOf(key: K, value: V): Map<K, V> = Collections.singletonMap(key, value)
+
+/** NOTE: This method can return the same [Map] instance if [this] is a [MutableMap]. */
+internal fun <K, V> Map<K, V>.plus(key: K, value: V): Map<K, V> {
+    return when {
+        this is MutableMap -> this.apply { put(key, value) }
+        isEmpty() -> mapOf(key, value)
+        else -> LinkedHashMap(this).apply { put(key, value) }
+    }
+}
+
+/** NOTE: This method can return the same [Map] instance if [this] is a [MutableMap]. */
+internal fun <K, V> Map<K, V>.minus(key: K): Map<K, V> {
+    return when (this) {
+        is MutableMap -> this.apply { remove(key) }
+        else -> LinkedHashMap<K, V>(this).apply { remove(key) }
+    }
+}

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -36,7 +36,6 @@ import okhttp3.Call
 import okhttp3.Headers
 import okhttp3.Response
 import java.io.Closeable
-import java.util.Collections
 
 internal suspend inline fun Call.await(): Response {
     return suspendCancellableCoroutine { continuation ->
@@ -56,8 +55,6 @@ internal fun Bitmap.Config?.getBytesPerPixel(): Int {
         else -> 4
     }
 }
-
-internal inline fun <T> MutableList<T>?.orEmpty(): MutableList<T> = this ?: mutableListOf()
 
 internal inline fun <T> MutableList<T>.removeLast(): T? = if (isNotEmpty()) removeAt(lastIndex) else null
 
@@ -213,22 +210,3 @@ internal val Configuration.nightMode: Int
 private val EMPTY_HEADERS = Headers.Builder().build()
 
 internal fun Headers?.orEmpty() = this ?: EMPTY_HEADERS
-
-internal inline fun <K, V> mapOf(key: K, value: V): Map<K, V> = Collections.singletonMap(key, value)
-
-/** NOTE: This method can return the same [Map] instance if [this] is a [MutableMap]. */
-internal fun <K, V> Map<K, V>.plus(key: K, value: V): Map<K, V> {
-    return when {
-        this is MutableMap -> this.apply { put(key, value) }
-        isEmpty() -> mapOf(key, value)
-        else -> LinkedHashMap(this).apply { put(key, value) }
-    }
-}
-
-/** NOTE: This method can return the same [Map] instance if [this] is a [MutableMap]. */
-internal fun <K, V> Map<K, V>.minus(key: K): Map<K, V> {
-    return when (this) {
-        is MutableMap -> this.apply { remove(key) }
-        else -> LinkedHashMap<K, V>(this).apply { remove(key) }
-    }
-}

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -22,6 +22,7 @@ import android.widget.ImageView.ScaleType.FIT_CENTER
 import android.widget.ImageView.ScaleType.FIT_END
 import android.widget.ImageView.ScaleType.FIT_START
 import androidx.annotation.DrawableRes
+import androidx.collection.ArrayMap
 import androidx.collection.arraySetOf
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toDrawable
@@ -59,6 +60,12 @@ internal fun Bitmap.Config?.getBytesPerPixel(): Int {
 internal inline fun <T> MutableList<T>.removeLast(): T? = if (isNotEmpty()) removeAt(lastIndex) else null
 
 internal inline fun <T> arraySetOf(builder: MutableSet<T>.() -> Unit): Set<T> = arraySetOf<T>().apply(builder)
+
+internal fun <K, V> Map<out K, V>.toArrayMap(): ArrayMap<K, V> {
+    val map = ArrayMap<K, V>(count())
+    map.putAll(this)
+    return map
+}
 
 internal inline fun ActivityManager.isLowRawDeviceCompat(): Boolean {
     return SDK_INT < KITKAT || isLowRamDevice

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -30,6 +30,7 @@ import coil.base.R
 import coil.decode.DataSource
 import coil.memory.MemoryCache
 import coil.memory.ViewTargetRequestManager
+import coil.request.Parameters
 import coil.size.Scale
 import coil.target.ViewTarget
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -217,3 +218,5 @@ internal val Configuration.nightMode: Int
 private val EMPTY_HEADERS = Headers.Builder().build()
 
 internal fun Headers?.orEmpty() = this ?: EMPTY_HEADERS
+
+internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY

--- a/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
+++ b/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
@@ -11,6 +11,7 @@ import coil.request.GetRequest
 import coil.request.GetRequestBuilder
 import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
+import coil.request.Parameters
 import coil.size.Scale
 import okhttp3.Headers
 import okhttp3.mockwebserver.MockResponse
@@ -37,7 +38,7 @@ fun createOptions(): Options {
         scale = Scale.FILL,
         allowRgb565 = false,
         headers = Headers.Builder().build(),
-        parameters = emptyMap(),
+        parameters = Parameters.Builder().build(),
         networkCachePolicy = CachePolicy.ENABLED,
         diskCachePolicy = CachePolicy.ENABLED
     )

--- a/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
+++ b/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
@@ -37,9 +37,9 @@ fun createOptions(): Options {
         scale = Scale.FILL,
         allowRgb565 = false,
         headers = Headers.Builder().build(),
+        parameters = emptyMap(),
         networkCachePolicy = CachePolicy.ENABLED,
-        diskCachePolicy = CachePolicy.ENABLED,
-        parameters = emptyMap()
+        diskCachePolicy = CachePolicy.ENABLED
     )
 }
 

--- a/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
+++ b/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
@@ -38,7 +38,8 @@ fun createOptions(): Options {
         allowRgb565 = false,
         headers = Headers.Builder().build(),
         networkCachePolicy = CachePolicy.ENABLED,
-        diskCachePolicy = CachePolicy.ENABLED
+        diskCachePolicy = CachePolicy.ENABLED,
+        parameters = emptyMap()
     )
 }
 


### PR DESCRIPTION
Adds the ability to add custom params to a request that are passed to `Fetcher`s and `Decoder`s.

I think this will be useful for adding params to extension libraries. For instance, we might eventually want to support loading a frame from a video as an extension library. This gives us a hook to pass in the time code.

EDIT: Ended up going forward with the video frame decoder idea here: https://github.com/coil-kt/coil/pull/122.