### PR TITLE
Tweak Parameters API. Add tests.

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -17,6 +17,7 @@ import coil.decode.BitmapFactoryDecoder
 import coil.decode.DataSource
 import coil.decode.DrawableDecoderService
 import coil.decode.EmptyDecoder
+import coil.extension.isNotEmpty
 import coil.fetch.AssetUriFetcher
 import coil.fetch.BitmapFetcher
 import coil.fetch.ContentUriFetcher
@@ -268,10 +269,9 @@ internal class RealImageLoader(
         return@outerJob deferred.await()
     }
 
-    /**
-     * Compute the cache key for the [data] + [parameters] + [transformations].
-     */
-    private fun <T : Any> computeCacheKey(
+    /** Compute the cache key for the [data] + [parameters] + [transformations]. */
+    @VisibleForTesting
+    internal fun <T : Any> computeCacheKey(
         fetcher: Fetcher<T>,
         data: T,
         parameters: Parameters,
@@ -282,24 +282,19 @@ internal class RealImageLoader(
         return buildString {
             append(baseCacheKey)
 
+            // Check isNotEmpty first to avoid allocating an Iterator.
             if (parameters.isNotEmpty()) {
                 for ((key, entry) in parameters) {
                     val cacheKey = entry.cacheKey ?: continue
-                    append('#')
-                    append(key)
-                    append('=')
-                    append(cacheKey)
+                    append('#').append(key).append('=').append(cacheKey)
                 }
-                append('#')
             }
 
-            transformations.forEach { append(it.key()) }
+            transformations.forEach { append('#').append(it.key()) }
         }
     }
 
-    /**
-     * Return true if the [Bitmap] returned from [MemoryCache] satisfies the [Request].
-     */
+    /** Return true if the [Bitmap] returned from [MemoryCache] satisfies the [Request]. */
     @VisibleForTesting
     internal fun isCachedDrawableValid(
         cached: BitmapDrawable,
@@ -330,9 +325,7 @@ internal class RealImageLoader(
         return false
     }
 
-    /**
-     * Load the [data] as a [Drawable]. Apply any [Transformation]s.
-     */
+    /** Load the [data] as a [Drawable]. Apply any [Transformation]s. */
     private suspend inline fun loadData(
         data: Any,
         request: Request,

--- a/coil-base/src/main/java/coil/extension/Parameters.kt
+++ b/coil-base/src/main/java/coil/extension/Parameters.kt
@@ -1,0 +1,10 @@
+@file:JvmName("Parameters")
+@file:Suppress("NOTHING_TO_INLINE", "unused")
+
+package coil.extension
+
+import coil.request.Parameters
+
+inline fun Parameters.isNotEmpty(): Boolean = !isEmpty()
+
+inline operator fun Parameters.get(key: String): Any? = value(key)

--- a/coil-base/src/main/java/coil/extension/SparseIntArraySets.kt
+++ b/coil-base/src/main/java/coil/extension/SparseIntArraySets.kt
@@ -1,7 +1,9 @@
 @file:JvmName("SparseIntArraySets")
 @file:Suppress("NOTHING_TO_INLINE", "unused")
 
-package coil.collection
+package coil.extension
+
+import coil.collection.SparseIntArraySet
 
 inline operator fun SparseIntArraySet.plusAssign(element: Int) {
     add(element)

--- a/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
@@ -9,7 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.util.set
 import coil.bitmappool.BitmapPool
 import coil.collection.SparseIntArraySet
-import coil.collection.plusAssign
+import coil.extension.plusAssign
 import coil.util.log
 import java.lang.ref.WeakReference
 

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -1,3 +1,5 @@
+@file:Suppress("unused")
+
 package coil.request
 
 import androidx.collection.arrayMapOf
@@ -8,7 +10,7 @@ import coil.util.toArrayMap
 /** A map of generic values that can be used to pass custom data to [Fetcher]s and [Decoder]s. */
 class Parameters private constructor(
     private val map: Map<String, Entry>
-) : Map<String, Parameters.Entry> by map {
+): Iterable<Map.Entry<String, Parameters.Entry>> {
 
     companion object {
         @JvmField
@@ -20,6 +22,24 @@ class Parameters private constructor(
         ): Parameters = Builder().apply(builder).build()
     }
 
+    /** Returns the value associated with [key] or null if [key] has no mapping. */
+    fun value(key: String): Any? = map[key]?.value
+
+    /** Returns the cache key associated with [key] or null if [key] has no mapping. */
+    fun cacheKey(key: String): String? = map[key]?.cacheKey
+
+    /** Returns the entry associated with [key] or null if [key] has no mapping. */
+    fun entry(key: String): Entry? = map[key]
+
+    /** Returns the number of parameters in this object. */
+    fun count(): Int = map.count()
+
+    /** Returns true if this object has no parameters. */
+    fun isEmpty(): Boolean = map.isEmpty()
+
+    /** Returns an [Iterator] over the entries in the [Parameters]. */
+    override operator fun iterator(): Iterator<Map.Entry<String, Entry>> = map.iterator()
+
     override fun equals(other: Any?) = map == other
 
     override fun hashCode() = map.hashCode()
@@ -28,10 +48,6 @@ class Parameters private constructor(
 
     fun newBuilder() = Builder(this)
 
-    /**
-     * @param value The parameter's value.
-     * @param cacheKey The parameter's cache key. If not null, this value will be added to a request's cache key.
-     */
     data class Entry(
         val value: Any?,
         val cacheKey: String?
@@ -63,11 +79,14 @@ class Parameters private constructor(
 
         /**
          * Remove a parameter.
+         *
+         * @param key The parameter's key.
          */
         fun remove(key: String) = apply {
             this.map.remove(key)
         }
 
+        /** Create a new [Parameters] instance. */
         fun build() = Parameters(map)
     }
 }

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -10,7 +10,7 @@ import coil.util.toArrayMap
 /** A map of generic values that can be used to pass custom data to [Fetcher]s and [Decoder]s. */
 class Parameters private constructor(
     private val map: Map<String, Entry>
-): Iterable<Map.Entry<String, Parameters.Entry>> {
+) : Iterable<Map.Entry<String, Parameters.Entry>> {
 
     companion object {
         @JvmField

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -5,7 +5,13 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import androidx.test.core.app.ApplicationProvider
+import coil.bitmappool.BitmapPool
+import coil.decode.Options
+import coil.fetch.Fetcher
+import coil.request.Parameters
 import coil.size.PixelSize
+import coil.size.Size
+import coil.transform.Transformation
 import coil.util.createBitmap
 import coil.util.createGetRequest
 import coil.util.toDrawable
@@ -14,7 +20,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -100,5 +108,83 @@ class RealImageLoaderBasicTest {
 
         assertFalse(isBitmapConfigValid(Bitmap.Config.HARDWARE))
         assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888))
+    }
+
+    @Test
+    fun `null key`() {
+        val fetcher = createFakeFetcher(key = null)
+        val key = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList())
+
+        assertNull(key)
+    }
+
+    @Test
+    fun `basic key`() {
+        val fetcher = createFakeFetcher()
+        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList())
+
+        assertEquals("base_key", result)
+    }
+
+    @Test
+    fun `params only`() {
+        val fetcher = createFakeFetcher()
+        val parameters = createFakeParameters()
+        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, emptyList())
+
+        assertEquals("base_key#key2=cached2#key3=cached3", result)
+    }
+
+    @Test
+    fun `transformations only`() {
+        val fetcher = createFakeFetcher()
+        val transformations = createFakeTransformations()
+        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, transformations)
+
+        assertEquals("base_key#key1#key2", result)
+    }
+
+    @Test
+    fun `complex key`() {
+        val fetcher = createFakeFetcher()
+        val parameters = createFakeParameters()
+        val transformations = createFakeTransformations()
+        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, transformations)
+
+        assertEquals("base_key#key2=cached2#key3=cached3#key1#key2", result)
+    }
+
+    private fun createFakeTransformations(): List<Transformation> {
+        return listOf(
+            object : Transformation {
+                override fun key() = "key1"
+                override suspend fun transform(pool: BitmapPool, input: Bitmap) = throw UnsupportedOperationException()
+            },
+            object : Transformation {
+                override fun key() = "key2"
+                override suspend fun transform(pool: BitmapPool, input: Bitmap) = throw UnsupportedOperationException()
+            }
+        )
+    }
+
+    private fun createFakeParameters(): Parameters {
+        return Parameters {
+            set("key1", "no_cache")
+            set("key2", "cached2", "cached2")
+            set("key3", "cached3", "cached3")
+        }
+    }
+
+    private fun createFakeFetcher(key: String? = "base_key"): Fetcher<Any> {
+        return object : Fetcher<Any> {
+            override fun key(data: Any) = key
+
+            override suspend fun fetch(
+                pool: BitmapPool,
+                data: Any,
+                size: Size,
+                options: Options
+            ) = throw UnsupportedOperationException()
+        }
     }
 }

--- a/coil-default/src/main/java/coil/Coil.kt
+++ b/coil-default/src/main/java/coil/Coil.kt
@@ -1,4 +1,3 @@
-@file:JvmName("Coil")
 @file:Suppress("MemberVisibilityCanBePrivate", "unused")
 
 package coil


### PR DESCRIPTION
This also moves `SparseIntArraySets` to the `coil.extension` package, which will contain all future public extensions.