### PR TITLE
Fix GIFs not resuming in onStart.

### DIFF
--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -116,16 +116,15 @@ class CrossfadeDrawable(
     override fun isRunning() = isRunning
 
     override fun start() {
+        (start as? Animatable)?.start()
+        (end as? Animatable)?.start()
+
         if (isRunning || isDone) {
             return
         }
 
         isRunning = true
         startTimeMillis = SystemClock.uptimeMillis()
-
-        (start as? Animatable)?.start()
-        (end as? Animatable)?.start()
-
         invalidateSelf()
     }
 

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -64,6 +64,7 @@ class MovieDrawable(
 
     private var isRunning = false
     private var startTimeMillis = 0L
+    private var frameTimeMillis = 0L
 
     private var repeatCount = REPEAT_INFINITE
     private var loopIteration = 0
@@ -79,7 +80,10 @@ class MovieDrawable(
             invalidate = false
             time = 0
         } else {
-            val elapsedTime = (SystemClock.uptimeMillis() - startTimeMillis).toInt()
+            if (isRunning) {
+                frameTimeMillis = SystemClock.uptimeMillis()
+            }
+            val elapsedTime = (frameTimeMillis - startTimeMillis).toInt()
             loopIteration = elapsedTime / duration
             invalidate = repeatCount == REPEAT_INFINITE || loopIteration <= repeatCount
             time = if (invalidate) elapsedTime - loopIteration * duration else duration


### PR DESCRIPTION
This is a two part fix:
- `CrossfadeDrawable` wasn't propagating `Animatable.start` if it had already finished its animation.
- `MovieDrawable` wasn't stopping its timer when stopped. This caused it to draw a different frame when redrawn, for example, if it is scrolled in a list.