### PR TITLE
Add more devices to hardware bitmap blacklist.

### DIFF
--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -128,14 +128,17 @@ private object HardwareBitmapBlacklist {
                 // BLU VIVO XI+
                 "Vivo XI PLUS", "Vivo XI+",
 
-                // Revvl 2 Plus
-                "REVVL 2 PLUS", "6062W",
+                // T-Mobile Revvl 2
+                "REVVL 2", "REVVL_2_5052W",
+
+                // T-Mobile Revvl 2 Plus
+                "REVVL 2 PLUS",
 
                 // LG Stylo 4
                 "LM-Q710(FGN)", "LM-Q710.FG", "LM-Q710.FGN", "LML713DL", "LG-Q710AL", "LG-Q710PL",
 
                 // LG Tribute Empire
-                "LM-X220PM", "X220PM",
+                "LM-X220PM",
 
                 // LG K11
                 "LM-X410(FN)", "LM-X410.F", "LM-X410.FN",
@@ -167,14 +170,14 @@ private object HardwareBitmapBlacklist {
                 // RCA Atlas 10
                 "RCT6B03W13",
 
-                // HTC One Max
-                "HTC One max", "HTC_One_max", "HTC0P3P7",
-
                 // Wiko Life
                 "C210AE",
 
                 // Blackview BV9500Pro
-                "BV9500Pro"
+                "BV9500Pro",
+
+                // Umidigi One Max
+                "One Max"
             )
         }
 

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -102,17 +102,19 @@ private object HardwareBitmapBlacklist {
 
         if (SDK_INT == O) {
             // Samsung Galaxy (ALL)
-            if (model.startsWith("SM-")) {
+            if (model.removePrefix("SAMSUNG-").startsWith("SM-")) {
                 return@run true
             }
 
-            return@run model in arrayOf(
-                // Moto G6 Play
-                "Moto G Play", "moto g(6) play",
+            // Moto E5
+            if (model in arrayOf("Moto E", "XT1924-9") || model.startsWith("moto e5", ignoreCase = true)) {
+                return@run true
+            }
 
-                // Moto E5 Play/Cruise
-                "Moto E", "moto e5 cruise", "moto e5 play"
-            )
+            // Moto G6
+            if (model in arrayOf("Moto G Play", "XT1925-10") || model.startsWith("moto g(6)", ignoreCase = true)) {
+                return@run true
+            }
         }
 
         if (SDK_INT == O_MR1) {
@@ -156,6 +158,9 @@ private object HardwareBitmapBlacklist {
                 // Alcatel TCL LX
                 "A502DL",
 
+                // Alcatel TCL XL2
+                "A503DL",
+
                 // Alcatel ONYX
                 "Alcatel_5008R", "5008R",
 
@@ -166,7 +171,10 @@ private object HardwareBitmapBlacklist {
                 "HTC One max", "HTC_One_max", "HTC0P3P7",
 
                 // Wiko Life
-                "C210AE"
+                "C210AE",
+
+                // Blackview BV9500Pro
+                "BV9500Pro"
             )
         }
 

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -97,59 +97,26 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
  */
 private object HardwareBitmapBlacklist {
 
-    val IS_BLACKLISTED = isBlacklisted()
-
-    private fun isBlacklisted(): Boolean {
-        val model = Build.MODEL ?: return false
+    val IS_BLACKLISTED = run {
+        val model = Build.MODEL ?: return@run false
 
         if (SDK_INT == O) {
-            return model in arrayOf(
+            // Samsung Galaxy (ALL)
+            if (model.startsWith("SM-")) {
+                return@run true
+            }
+
+            return@run model in arrayOf(
                 // Moto G6 Play
                 "Moto G Play", "moto g(6) play",
 
                 // Moto E5 Play/Cruise
-                "Moto E", "moto e5 cruise", "moto e5 play",
-
-                // Samsung Galaxy Amp Prime 3
-                "SM-J337AZ",
-
-                // Samsung Galaxy A5 (2017)
-                "SM-A520F", "SM-A520X", "SM-A520W", "SM-A520K", "SM-A520L", "SM-A520S",
-
-                // Samsung Galaxy A8 (2018)
-                "SM-A530F", "SM-A530X", "SM-A530W", "SM-A530N",
-
-                // Samsung Galaxy J7 Duo
-                "SM-J720F", "SM-J720M",
-
-                // Samsung Galaxy J7 Crown
-                "SM-S767VL", "SM-S757BL",
-
-                // Samsung Galaxy S7
-                "SM-G930F", "SM-G930X", "SM-G930W8", "SM-G930K", "SM-G930L", "SM-G930S", "SM-G930R7", "SAMSUNG-SM-G930AZ",
-                "SAMSUNG-SM-G930A", "SM-G930VC", "SM-G9300", "SM-G9308", "SM-G930R6", "SM-G930T1", "SM-G930P", "SM-G930VL",
-                "SM-G930T", "SM-G930U", "SM-G930R4", "SM-G930V",
-
-                // Samsung Galaxy S7 Edge
-                "SC-02H", "SCV33", "SM-G935X", "SM-G935W8", "SM-G935K", "SM-G935S", "SAMSUNG-SM-G935A", "SM-G935VC", "SM-G935P",
-                "SM-G935T", "SM-G935R4", "SM-G935V", "SM-G935F", "SM-G935L", "SM-G9350", "SM-G935U",
-
-                // Samsung Galaxy Note 7 FE
-                "SM-N935F", "SM-N935K", "SM-N935L", "SM-N935S",
-
-                // Samsung Galaxy Note 8
-                "GT-N5100", "GT-N5105", "GT-N5120", "SAMSUNG-SGH-I467", "SGH-I467M", "GT-N5110", "SHW-M500W",
-
-                // Samsung Galaxy S9
-                "SC-02K", "SCV38", "SM-G960F", "SM-G960N", "SM-G9600", "SM-G9608", "SM-G960W", "SM-G960U", "SM-G960U1",
-
-                // Samsung Galaxy S9+
-                "SC-03K", "SCV39", "SM-G965F", "SM-G965N", "SM-G9650", "SM-G965W", "SM-G965U", "SM-G965U1"
+                "Moto E", "moto e5 cruise", "moto e5 play"
             )
         }
 
         if (SDK_INT == O_MR1) {
-            return model in arrayOf(
+            return@run model in arrayOf(
                 // Nuu A7L
                 "N5002L",
 
@@ -166,7 +133,7 @@ private object HardwareBitmapBlacklist {
                 "LM-Q710(FGN)", "LM-Q710.FG", "LM-Q710.FGN", "LML713DL", "LG-Q710AL", "LG-Q710PL",
 
                 // LG Tribute Empire
-                "LM-X220PM",
+                "LM-X220PM", "X220PM",
 
                 // LG K11
                 "LM-X410(FN)", "LM-X410.F", "LM-X410.FN",
@@ -203,6 +170,6 @@ private object HardwareBitmapBlacklist {
             )
         }
 
-        return false
+        return@run false
     }
 }

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -90,25 +90,117 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
     }
 }
 
-/** Maintains a list of devices with broken/incomplete hardware bitmap implementations. */
+/**
+ * Maintains a list of devices with broken/incomplete/unstable hardware bitmap implementations.
+ *
+ * Model names are retrieved from [Google's official device list](https://support.google.com/googleplay/answer/1727131?hl=en).
+ */
 private object HardwareBitmapBlacklist {
 
     val IS_BLACKLISTED = isBlacklisted()
 
-    /** Modified from Glide's HardwareConfigState. */
     private fun isBlacklisted(): Boolean {
-        val model = Build.MODEL
-            ?.takeIf { it.count() >= 7 }
-            ?.substring(0, 7)
-            ?: return false
-
-        if (model == "LG-Q710") {
-            return true
-        }
+        val model = Build.MODEL ?: return false
 
         if (SDK_INT == O) {
-            val models = arrayOf("SM-N935", "SM-J720", "SM-G960", "SM-G965", "SM-G935", "SM-G930", "SM-A520")
-            return models.contains(model)
+            return model in arrayOf(
+                // Moto G6 Play
+                "Moto G Play", "moto g(6) play",
+
+                // Moto E5 Play/Cruise
+                "Moto E", "moto e5 cruise", "moto e5 play",
+
+                // Samsung Galaxy Amp Prime 3
+                "SM-J337AZ",
+
+                // Samsung Galaxy A5 (2017)
+                "SM-A520F", "SM-A520X", "SM-A520W", "SM-A520K", "SM-A520L", "SM-A520S",
+
+                // Samsung Galaxy A8 (2018)
+                "SM-A530F", "SM-A530X", "SM-A530W", "SM-A530N",
+
+                // Samsung Galaxy J7 Duo
+                "SM-J720F", "SM-J720M",
+
+                // Samsung Galaxy J7 Crown
+                "SM-S767VL", "SM-S757BL",
+
+                // Samsung Galaxy S7
+                "SM-G930F", "SM-G930X", "SM-G930W8", "SM-G930K", "SM-G930L", "SM-G930S", "SM-G930R7", "SAMSUNG-SM-G930AZ",
+                "SAMSUNG-SM-G930A", "SM-G930VC", "SM-G9300", "SM-G9308", "SM-G930R6", "SM-G930T1", "SM-G930P", "SM-G930VL",
+                "SM-G930T", "SM-G930U", "SM-G930R4", "SM-G930V",
+
+                // Samsung Galaxy S7 Edge
+                "SC-02H", "SCV33", "SM-G935X", "SM-G935W8", "SM-G935K", "SM-G935S", "SAMSUNG-SM-G935A", "SM-G935VC", "SM-G935P",
+                "SM-G935T", "SM-G935R4", "SM-G935V", "SM-G935F", "SM-G935L", "SM-G9350", "SM-G935U",
+
+                // Samsung Galaxy Note 7 FE
+                "SM-N935F", "SM-N935K", "SM-N935L", "SM-N935S",
+
+                // Samsung Galaxy Note 8
+                "GT-N5100", "GT-N5105", "GT-N5120", "SAMSUNG-SGH-I467", "SGH-I467M", "GT-N5110", "SHW-M500W",
+
+                // Samsung Galaxy S9
+                "SC-02K", "SCV38", "SM-G960F", "SM-G960N", "SM-G9600", "SM-G9608", "SM-G960W", "SM-G960U", "SM-G960U1",
+
+                // Samsung Galaxy S9+
+                "SC-03K", "SCV39", "SM-G965F", "SM-G965N", "SM-G9650", "SM-G965W", "SM-G965U", "SM-G965U1"
+            )
+        }
+
+        if (SDK_INT == O_MR1) {
+            return model in arrayOf(
+                // Nuu A7L
+                "N5002L",
+
+                // Cubot King Kong 3
+                "KING_KONG_3",
+
+                // BLU VIVO XI+
+                "Vivo XI PLUS", "Vivo XI+",
+
+                // Revvl 2 Plus
+                "REVVL 2 PLUS", "6062W",
+
+                // LG Stylo 4
+                "LM-Q710(FGN)", "LM-Q710.FG", "LM-Q710.FGN", "LML713DL", "LG-Q710AL", "LG-Q710PL",
+
+                // LG Tribute Empire
+                "LM-X220PM",
+
+                // LG K11
+                "LM-X410(FN)", "LM-X410.F", "LM-X410.FN",
+
+                // LG Q7
+                "LM-Q610.FG", "LM-Q610.FGN", "LM-Q617.FGN",
+
+                // Alcatel A30/3T
+                "9027W",
+
+                // Alcatel Tetra
+                "5041C",
+
+                // Alcatel 1X
+                "5059Z",
+
+                // Alcatel TCL A1
+                "A501DL",
+
+                // Alcatel TCL LX
+                "A502DL",
+
+                // Alcatel ONYX
+                "Alcatel_5008R", "5008R",
+
+                // RCA Atlas 10
+                "RCT6B03W13",
+
+                // HTC One Max
+                "HTC One max", "HTC_One_max", "HTC0P3P7",
+
+                // Wiko Life
+                "C210AE"
+            )
         }
 
         return false


### PR DESCRIPTION
Update the hardware bitmap blacklist with specific device models we've found to have issues.