### PR TITLE
Preserve aspect ratio when converting a Drawable to a Bitmap.

### DIFF
--- a/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
+++ b/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
@@ -28,6 +28,10 @@ internal class DrawableDecoderService(
     private val bitmapPool: BitmapPool
 ) {
 
+    companion object {
+        private const val DEFAULT_SIZE = 512
+    }
+
     @WorkerThread
     fun convertIfNecessary(
         drawable: Drawable,
@@ -61,8 +65,10 @@ internal class DrawableDecoderService(
 
         val width: Int
         val height: Int
-        val intrinsicWidth = drawable.intrinsicWidth
-        val intrinsicHeight = drawable.intrinsicHeight
+        val unsafeIntrinsicWidth = drawable.intrinsicWidth
+        val unsafeIntrinsicHeight = drawable.intrinsicHeight
+        val intrinsicWidth = if (unsafeIntrinsicWidth > 0) unsafeIntrinsicWidth else DEFAULT_SIZE
+        val intrinsicHeight = if (unsafeIntrinsicHeight > 0) unsafeIntrinsicHeight else DEFAULT_SIZE
         when (size) {
             is OriginalSize -> {
                 width = intrinsicWidth

--- a/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
+++ b/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
@@ -17,11 +17,11 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.bitmappool.BitmapPool
 import coil.size.OriginalSize
 import coil.size.PixelSize
+import coil.size.Scale
 import coil.size.Size
-import coil.util.height
 import coil.util.normalize
 import coil.util.toDrawable
-import coil.util.width
+import kotlin.math.roundToInt
 
 internal class DrawableDecoderService(
     private val context: Context,
@@ -59,9 +59,26 @@ internal class DrawableDecoderService(
             }
         }
 
-        val (width, height) = when (size) {
-            is OriginalSize -> PixelSize(drawable.width, drawable.height)
-            is PixelSize -> size
+        val width: Int
+        val height: Int
+        val intrinsicWidth = drawable.intrinsicWidth
+        val intrinsicHeight = drawable.intrinsicHeight
+        when (size) {
+            is OriginalSize -> {
+                width = intrinsicWidth
+                height = intrinsicHeight
+            }
+            is PixelSize -> {
+                val multiplier = DecodeUtils.computeSizeMultiplier(
+                    srcWidth = intrinsicWidth.toFloat(),
+                    srcHeight = intrinsicHeight.toFloat(),
+                    destWidth = size.width.toFloat(),
+                    destHeight = size.height.toFloat(),
+                    scale = Scale.FIT
+                )
+                width = (multiplier * intrinsicWidth).roundToInt()
+                height = (multiplier * intrinsicHeight).roundToInt()
+            }
         }
 
         val (oldLeft, oldTop, oldRight, oldBottom) = drawable.bounds

--- a/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
+++ b/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
@@ -38,7 +38,24 @@ class DrawableDecoderServiceTest {
         )
 
         assertTrue(output is BitmapDrawable)
+        assertEquals(Bitmap.Config.ARGB_8888, output.bitmap.config)
         assertTrue(output.bitmap.run { width == 200 && height == 200 })
+    }
+
+    @Test
+    fun `aspect ratio is preserved`() {
+        val input = object : ColorDrawable() {
+            override fun getIntrinsicWidth() = 125
+            override fun getIntrinsicHeight() = 250
+        }
+        val output = service.convert(
+            drawable = input,
+            size = PixelSize(200, 200),
+            config = Bitmap.Config.ARGB_8888
+        )
+
+        assertEquals(Bitmap.Config.ARGB_8888, output.config)
+        assertTrue(output.width == 100 && output.height == 200)
     }
 
     @Test

--- a/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
+++ b/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
@@ -30,7 +30,27 @@ class DrawableDecoderServiceTest {
 
     @Test
     fun `vector with hardware config is converted correctly`() {
-        val input = VectorDrawable()
+        val input = object : VectorDrawable() {
+            override fun getIntrinsicWidth() = 100
+            override fun getIntrinsicHeight() = 100
+        }
+        val output = service.convertIfNecessary(
+            drawable = input,
+            size = PixelSize(200, 200),
+            config = Bitmap.Config.HARDWARE
+        )
+
+        assertTrue(output is BitmapDrawable)
+        assertEquals(Bitmap.Config.ARGB_8888, output.bitmap.config)
+        assertTrue(output.bitmap.run { width == 200 && height == 200 })
+    }
+
+    @Test
+    fun `unimplemented intrinsic size does not crash`() {
+        val input = object : VectorDrawable() {
+            override fun getIntrinsicWidth() = -1
+            override fun getIntrinsicHeight() = -1
+        }
         val output = service.convertIfNecessary(
             drawable = input,
             size = PixelSize(200, 200),
@@ -44,7 +64,7 @@ class DrawableDecoderServiceTest {
 
     @Test
     fun `aspect ratio is preserved`() {
-        val input = object : ColorDrawable() {
+        val input = object : VectorDrawable() {
             override fun getIntrinsicWidth() = 125
             override fun getIntrinsicHeight() = 250
         }


### PR DESCRIPTION
Fixes: #158 