### PR TITLE
Add support for aliasKeys.

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -63,6 +63,7 @@ import coil.util.Emoji
 import coil.util.cancel
 import coil.util.closeQuietly
 import coil.util.emoji
+import coil.util.firstNotNull
 import coil.util.getValue
 import coil.util.isDiskPreload
 import coil.util.log
@@ -216,7 +217,7 @@ internal class RealImageLoader(
 
             // Check the memory cache and set the placeholder.
             val cachedValue = takeIf(request.memoryCachePolicy.readEnabled) {
-                memoryCache.getValue(cacheKey)
+                memoryCache.getValue(cacheKey) ?: request.commonKeys.firstNotNull { memoryCache.getValue(it) }
             }
             val cachedDrawable = cachedValue?.bitmap?.toDrawable(context)
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -215,9 +215,9 @@ internal class RealImageLoader(
             val fetcher = registry.requireFetcher(mappedData)
             val cacheKey = request.key ?: computeCacheKey(fetcher, mappedData, request.parameters, request.transformations)
 
-            // Check the memory cache and set the placeholder.
+            // Check the memory cache.
             val cachedValue = takeIf(request.memoryCachePolicy.readEnabled) {
-                memoryCache.getValue(cacheKey) ?: request.commonKeys.firstNotNull { memoryCache.getValue(it) }
+                memoryCache.getValue(cacheKey) ?: request.aliasKeys.firstNotNull { memoryCache.getValue(it) }
             }
             val cachedDrawable = cachedValue?.bitmap?.toDrawable(context)
 

--- a/coil-base/src/main/java/coil/collection/SparseIntArraySet.kt
+++ b/coil-base/src/main/java/coil/collection/SparseIntArraySet.kt
@@ -5,7 +5,10 @@ package coil.collection
 import android.util.SparseIntArray
 
 /**
- * A collection of unordered, unique [Int]s. [Int]s are stored as primitives in an [Array], which reduces memory usage.
+ * A collection of unordered, unique [Int]s.
+ *
+ * This data structure is intended to be more memory efficient than using a [Set] to store [Int]s, both
+ * because it avoids auto-boxing elements and it doesn't allocate a hash table.
  *
  * @see SparseIntArray
  */

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -39,7 +39,7 @@ sealed class Request {
     abstract val transitionFactory: Transition.Factory?
 
     abstract val key: String?
-    abstract val commonKeys: List<String>
+    abstract val aliasKeys: List<String>
     abstract val listener: Listener?
     abstract val sizeResolver: SizeResolver?
     abstract val scale: Scale?
@@ -123,7 +123,7 @@ class LoadRequest internal constructor(
     override val lifecycle: Lifecycle?,
     override val transitionFactory: Transition.Factory?,
     override val key: String?,
-    override val commonKeys: List<String>,
+    override val aliasKeys: List<String>,
     override val listener: Listener?,
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,
@@ -201,7 +201,7 @@ class LoadRequest internal constructor(
 class GetRequest internal constructor(
     override val data: Any,
     override val key: String?,
-    override val commonKeys: List<String>,
+    override val aliasKeys: List<String>,
     override val listener: Listener?,
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -39,6 +39,7 @@ sealed class Request {
     abstract val transitionFactory: Transition.Factory?
 
     abstract val key: String?
+    abstract val commonKeys: List<String>
     abstract val listener: Listener?
     abstract val sizeResolver: SizeResolver?
     abstract val scale: Scale?
@@ -122,6 +123,7 @@ class LoadRequest internal constructor(
     override val lifecycle: Lifecycle?,
     override val transitionFactory: Transition.Factory?,
     override val key: String?,
+    override val commonKeys: List<String>,
     override val listener: Listener?,
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,
@@ -199,6 +201,7 @@ class LoadRequest internal constructor(
 class GetRequest internal constructor(
     override val data: Any,
     override val key: String?,
+    override val commonKeys: List<String>,
     override val listener: Listener?,
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -49,6 +49,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     protected var data: Any?
 
     protected var key: String?
+    protected var commonKeys: List<String>
     protected var listener: Request.Listener?
     protected var sizeResolver: SizeResolver?
     protected var scale: Scale?
@@ -71,6 +72,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         data = null
 
         key = null
+        commonKeys = emptyList()
         listener = null
         sizeResolver = null
         scale = null
@@ -96,6 +98,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         data = request.data
 
         key = request.key
+        commonKeys = request.commonKeys
         listener = request.listener
         sizeResolver = request.sizeResolver
         scale = request.scale
@@ -258,6 +261,14 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      */
     fun key(key: String?): T = self {
         this.key = key
+    }
+
+    fun commonKeys(vararg commonKeys: String): T = self {
+        this.commonKeys = commonKeys.toList()
+    }
+
+    fun commonKeys(commonKeys: List<String>): T = self {
+        this.commonKeys = commonKeys.toList()
     }
 
     /**
@@ -498,6 +509,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
             lifecycle,
             transitionFactory,
             key,
+            commonKeys,
             listener,
             sizeResolver,
             scale,
@@ -540,6 +552,7 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
         return GetRequest(
             checkNotNull(data) { "data == null" },
             key,
+            commonKeys,
             listener,
             sizeResolver,
             scale,

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -49,7 +49,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     protected var data: Any?
 
     protected var key: String?
-    protected var commonKeys: List<String>
+    protected var aliasKeys: List<String>
     protected var listener: Request.Listener?
     protected var sizeResolver: SizeResolver?
     protected var scale: Scale?
@@ -72,7 +72,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         data = null
 
         key = null
-        commonKeys = emptyList()
+        aliasKeys = emptyList()
         listener = null
         sizeResolver = null
         scale = null
@@ -98,7 +98,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         data = request.data
 
         key = request.key
-        commonKeys = request.commonKeys
+        aliasKeys = request.aliasKeys
         listener = request.listener
         sizeResolver = request.sizeResolver
         scale = request.scale
@@ -263,12 +263,22 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         this.key = key
     }
 
-    fun commonKeys(vararg commonKeys: String): T = self {
-        this.commonKeys = commonKeys.toList()
+    /**
+     * Set a list of supplementary cache keys that are used to check if this request is cached in the memory cache.
+     *
+     * Requests are still written to the memory cache as [key].
+     */
+    fun aliasKeys(vararg aliasKeys: String): T = self {
+        this.aliasKeys = aliasKeys.toList()
     }
 
-    fun commonKeys(commonKeys: List<String>): T = self {
-        this.commonKeys = commonKeys.toList()
+    /**
+     * Set a list of supplementary cache keys that are used to check if this request is cached in the memory cache.
+     *
+     * Requests are still written to the memory cache as [key].
+     */
+    fun aliasKeys(aliasKeys: List<String>): T = self {
+        this.aliasKeys = aliasKeys.toList()
     }
 
     /**
@@ -500,7 +510,9 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
         this.errorResId = 0
     }
 
-    /** Create a new [LoadRequest] instance. */
+    /**
+     * Create a new [LoadRequest] instance.
+     */
     fun build(): LoadRequest {
         return LoadRequest(
             context,
@@ -509,7 +521,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
             lifecycle,
             transitionFactory,
             key,
-            commonKeys,
+            aliasKeys,
             listener,
             sizeResolver,
             scale,
@@ -547,12 +559,14 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
         this.data = data
     }
 
-    /** Create a new [GetRequest] instance. */
+    /**
+     * Create a new [GetRequest] instance.
+     */
     fun build(): GetRequest {
         return GetRequest(
             checkNotNull(data) { "data == null" },
             key,
-            commonKeys,
+            aliasKeys,
             listener,
             sizeResolver,
             scale,

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -226,3 +226,8 @@ internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY
 internal fun Request.isDiskPreload(): Boolean {
     return this is LoadRequest && target == null && !memoryCachePolicy.writeEnabled
 }
+
+inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
+    for (element in this) transform(element)?.let { return it }
+    return null
+}

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -227,7 +227,7 @@ internal fun Request.isDiskPreload(): Boolean {
     return this is LoadRequest && target == null && !memoryCachePolicy.writeEnabled
 }
 
-inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
+internal inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
     for (element in this) transform(element)?.let { return it }
     return null
 }


### PR DESCRIPTION
`aliasKeys` is a list of supplementary cache keys that are used to check if this request is cached in the memory cache.

This allows consumers have requests match multiple keys in the memory cache.