### PR TITLE
Remove Java 8 setup step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ jobs:
         runs-on: macOS-latest
         steps:
             - uses: actions/checkout@v1
-            - uses: actions/setup-java@v1
-              with:
-                  java-version: 1.8
 
             # Ensure .gradle/caches is empty before writing to it.
             # This helps us stay within Github's cache size limits.


### PR DESCRIPTION
Java 8 is installed as the default JDK in the macOS instance: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#macos-1015