### PR TITLE
Fix Instrumentation tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
               with:
                   api-level: 25
                   arch: x86
+                  emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim -camera-back emulated
                   script: ./gradlew connectedDebugAndroidTest
 
             - name: Deploy Snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,10 @@ jobs:
               run: ./gradlew testDebugUnitTest
 
             - name: Instrumentation Tests
-              uses: reactivecircus/android-emulator-runner@v2
+              uses: reactivecircus/android-emulator-runner@v2.0.0
               with:
                   api-level: 25
                   arch: x86
-                  emulator-options: -no-window -no-snapshot -noaudio -no-boot-anim -camera-back emulated
                   script: ./gradlew connectedDebugAndroidTest
 
             - name: Deploy Snapshot


### PR DESCRIPTION
Pin the task to `2.0.0` until https://github.com/ReactiveCircus/android-emulator-runner/issues/12 is resolved.