### PR TITLE
Fix CrossfadeDrawable and MovieDrawable scaling.

### DIFF
--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -237,7 +237,8 @@ class CrossfadeDrawable(
 
     /**
      * Update the [Drawable]'s bounds inside [targetBounds] preserving aspect ratio.
-     * Return the scale to apply when rendering [drawable] to the [Canvas].
+     *
+     * @return The scale to apply when rendering [drawable] to the [Canvas].
      */
     @VisibleForTesting
     internal fun updateBounds(drawable: Drawable, targetBounds: Rect): Float {

--- a/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
+++ b/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
@@ -1,8 +1,11 @@
 package coil.drawable
 
+import android.content.Context
 import android.graphics.Rect
-import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.BitmapDrawable
+import androidx.test.core.app.ApplicationProvider
 import coil.size.Scale
+import coil.util.createBitmap
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -11,8 +14,11 @@ import kotlin.test.assertEquals
 @RunWith(RobolectricTestRunner::class)
 class CrossfadeDrawableTest {
 
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
     @Test
     fun `FILL drawable in bounds SAME aspect ratio`() {
+        val position = CrossfadeDrawable.Position()
         val start = TestDrawable(100, 100)
         val end = TestDrawable(25, 25)
         val drawable = CrossfadeDrawable(start, end, Scale.FILL)
@@ -22,15 +28,16 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        drawable.updateBounds(start, bounds)
+        drawable.updateBounds(start, position, bounds)
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        drawable.updateBounds(end, bounds)
+        drawable.updateBounds(end, position, bounds)
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
     @Test
     fun `FIT drawable in bounds SAME aspect ratio`() {
+        val position = CrossfadeDrawable.Position()
         val start = TestDrawable(100, 100)
         val end = TestDrawable(25, 25)
         val drawable = CrossfadeDrawable(start, end, Scale.FIT)
@@ -40,15 +47,16 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        drawable.updateBounds(start, bounds)
+        drawable.updateBounds(start, position, bounds)
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        drawable.updateBounds(end, bounds)
+        drawable.updateBounds(end, position, bounds)
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
     @Test
     fun `FILL drawable in bounds DIFFERENT aspect ratio`() {
+        val position = CrossfadeDrawable.Position()
         val start = TestDrawable(40, 100)
         val end = TestDrawable(25, 20)
         val drawable = CrossfadeDrawable(start, end, Scale.FILL)
@@ -58,15 +66,16 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 40, 100)
 
-        drawable.updateBounds(start, bounds)
+        drawable.updateBounds(start, position, bounds)
         assertEquals(Rect(0, 0, 40, 100), start.bounds)
 
-        drawable.updateBounds(end, bounds)
+        drawable.updateBounds(end, position, bounds)
         assertEquals(Rect(-42, 0, 82, 100), end.bounds)
     }
 
     @Test
     fun `FIT drawable in bounds DIFFERENT aspect ratio`() {
+        val position = CrossfadeDrawable.Position()
         val start = TestDrawable(200, 65)
         val end = TestDrawable(80, 210)
         val drawable = CrossfadeDrawable(start, end, Scale.FIT)
@@ -76,17 +85,17 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 200, 210)
 
-        drawable.updateBounds(start, bounds)
+        drawable.updateBounds(start, position, bounds)
         assertEquals(Rect(0, 73, 200, 137), start.bounds)
 
-        drawable.updateBounds(end, bounds)
+        drawable.updateBounds(end, position, bounds)
         assertEquals(Rect(60, 0, 140, 210), end.bounds)
     }
 
-    private class TestDrawable(
+    private inner class TestDrawable(
         private val width: Int,
         private val height: Int
-    ) : ColorDrawable() {
+    ) : BitmapDrawable(context.resources, createBitmap()) {
         override fun getIntrinsicWidth() = width
         override fun getIntrinsicHeight() = height
     }

--- a/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
+++ b/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
@@ -3,6 +3,7 @@ package coil.drawable
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.ColorDrawable
 import androidx.test.core.app.ApplicationProvider
 import coil.size.Scale
 import coil.util.createBitmap
@@ -17,10 +18,9 @@ class CrossfadeDrawableTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     @Test
-    fun `FILL drawable in bounds SAME aspect ratio`() {
-        val position = CrossfadeDrawable.Position()
-        val start = TestDrawable(100, 100)
-        val end = TestDrawable(25, 25)
+    fun `SAME aspect ratio - FILL`() {
+        val start = TestBitmapDrawable(100, 100)
+        val end = TestBitmapDrawable(25, 25)
         val drawable = CrossfadeDrawable(start, end, Scale.FILL)
 
         assertEquals(100, drawable.intrinsicWidth)
@@ -28,18 +28,17 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        drawable.updateBounds(start, position, bounds)
+        assertEquals(1f, drawable.updateBounds(start, bounds))
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        drawable.updateBounds(end, position, bounds)
+        assertEquals(1f, drawable.updateBounds(end, bounds))
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
     @Test
-    fun `FIT drawable in bounds SAME aspect ratio`() {
-        val position = CrossfadeDrawable.Position()
-        val start = TestDrawable(100, 100)
-        val end = TestDrawable(25, 25)
+    fun `SAME aspect ratio - FIT`() {
+        val start = TestBitmapDrawable(100, 100)
+        val end = TestBitmapDrawable(25, 25)
         val drawable = CrossfadeDrawable(start, end, Scale.FIT)
 
         assertEquals(100, drawable.intrinsicWidth)
@@ -47,18 +46,17 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        drawable.updateBounds(start, position, bounds)
+        assertEquals(1f, drawable.updateBounds(start, bounds))
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        drawable.updateBounds(end, position, bounds)
+        assertEquals(1f, drawable.updateBounds(end, bounds))
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
     @Test
-    fun `FILL drawable in bounds DIFFERENT aspect ratio`() {
-        val position = CrossfadeDrawable.Position()
-        val start = TestDrawable(40, 100)
-        val end = TestDrawable(25, 20)
+    fun `DIFFERENT aspect ratio - FILL`() {
+        val start = TestBitmapDrawable(40, 100)
+        val end = TestBitmapDrawable(25, 20)
         val drawable = CrossfadeDrawable(start, end, Scale.FILL)
 
         assertEquals(40, drawable.intrinsicWidth)
@@ -66,18 +64,17 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 40, 100)
 
-        drawable.updateBounds(start, position, bounds)
+        assertEquals(1f, drawable.updateBounds(start, bounds))
         assertEquals(Rect(0, 0, 40, 100), start.bounds)
 
-        drawable.updateBounds(end, position, bounds)
+        assertEquals(1f, drawable.updateBounds(end, bounds))
         assertEquals(Rect(-42, 0, 82, 100), end.bounds)
     }
 
     @Test
-    fun `FIT drawable in bounds DIFFERENT aspect ratio`() {
-        val position = CrossfadeDrawable.Position()
-        val start = TestDrawable(200, 65)
-        val end = TestDrawable(80, 210)
+    fun `DIFFERENT aspect ratio - FIT`() {
+        val start = TestBitmapDrawable(200, 65)
+        val end = TestBitmapDrawable(80, 210)
         val drawable = CrossfadeDrawable(start, end, Scale.FIT)
 
         assertEquals(200, drawable.intrinsicWidth)
@@ -85,14 +82,86 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 200, 210)
 
-        drawable.updateBounds(start, position, bounds)
+        assertEquals(1f, drawable.updateBounds(start, bounds))
         assertEquals(Rect(0, 73, 200, 137), start.bounds)
 
-        drawable.updateBounds(end, position, bounds)
+        assertEquals(1f, drawable.updateBounds(end, bounds))
         assertEquals(Rect(60, 0, 140, 210), end.bounds)
     }
 
-    private inner class TestDrawable(
+    @Test
+    fun `NULL drawable - FILL`() {
+        val end = TestBitmapDrawable(25, 20)
+        val drawable = CrossfadeDrawable(null, end, Scale.FILL)
+
+        assertEquals(25, drawable.intrinsicWidth)
+        assertEquals(20, drawable.intrinsicHeight)
+
+        val bounds = Rect(0, 0, 40, 100)
+
+        assertEquals(1f, drawable.updateBounds(end, bounds))
+        assertEquals(Rect(-42, 0, 82, 100), end.bounds)
+    }
+
+    @Test
+    fun `NULL start drawable - FIT`() {
+        val end = TestBitmapDrawable(80, 210)
+        val drawable = CrossfadeDrawable(null, end, Scale.FIT)
+
+        assertEquals(80, drawable.intrinsicWidth)
+        assertEquals(210, drawable.intrinsicHeight)
+
+        val bounds = Rect(0, 0, 200, 210)
+
+        assertEquals(1f, drawable.updateBounds(end, bounds))
+        assertEquals(Rect(60, 0, 140, 210), end.bounds)
+    }
+
+    @Test
+    fun `non bitmap drawable - FILL`() {
+        val start = TestBitmapDrawable(240, 290)
+        val end = TestDrawable(400, 300)
+        val drawable = CrossfadeDrawable(start, end, Scale.FILL)
+
+        assertEquals(400, drawable.intrinsicWidth)
+        assertEquals(300, drawable.intrinsicHeight)
+
+        val bounds = Rect(0, 0, 40, 100)
+
+        assertEquals(1f, drawable.updateBounds(start, bounds))
+        assertEquals(Rect(-21, 0, 61, 100), start.bounds)
+
+        assertEquals(1 / 3f, drawable.updateBounds(end, bounds))
+        assertEquals(Rect(-47, 0, 353, 300), end.bounds)
+    }
+
+    @Test
+    fun `non bitmap drawable - FIT`() {
+        val start = TestDrawable(200, 120)
+        val end = TestDrawable(500, 175)
+        val drawable = CrossfadeDrawable(start, end, Scale.FIT)
+
+        assertEquals(500, drawable.intrinsicWidth)
+        assertEquals(175, drawable.intrinsicHeight)
+
+        val bounds = Rect(0, 0, 200, 210)
+
+        assertEquals(1f, drawable.updateBounds(start, bounds))
+        assertEquals(Rect(0, 45, 200, 165), start.bounds)
+
+        assertEquals(0.4f, drawable.updateBounds(end, bounds))
+        assertEquals(Rect(0, 70, 500, 245), end.bounds)
+    }
+
+    private class TestDrawable(
+        private val width: Int,
+        private val height: Int
+    ) : ColorDrawable() {
+        override fun getIntrinsicWidth() = width
+        override fun getIntrinsicHeight() = height
+    }
+
+    private inner class TestBitmapDrawable(
         private val width: Int,
         private val height: Int
     ) : BitmapDrawable(context.resources, createBitmap()) {

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -1,9 +1,7 @@
 @file:Suppress("DEPRECATION", "unused")
-@file:SuppressLint("SupportAnnotationUsage")
 
 package coil.drawable
 
-import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color

--- a/coil-sample/src/main/java/coil/sample/MainActivity.kt
+++ b/coil-sample/src/main/java/coil/sample/MainActivity.kt
@@ -1,6 +1,5 @@
 package coil.sample
 
-import android.graphics.drawable.ColorDrawable
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.Q
 import android.os.Bundle
@@ -64,9 +63,7 @@ class MainActivity : AppCompatActivity() {
             is Screen.Detail -> {
                 list.isVisible = false
                 detail.isVisible = true
-                detail.load(screen.image.url) {
-                    placeholder(ColorDrawable(screen.image.color))
-                }
+                detail.load(screen.image.url)
             }
         }
     }


### PR DESCRIPTION
BitmapDrawables automatically scale their content to fit their bounds, however other drawables (like AnimatedImageDrawable don't. Manually scale non-BitmapDrawables when drawing to the canvas.