### PR TITLE
Add request size to Transformation. Rework RoundedCornersTransformation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_size=4
 insert_final_newline=true
-max_line_length=135
+max_line_length=130
 
 # ktlint
 disabled_rules=import-ordering,experimental:annotation,experimental:indent

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_size=4
 insert_final_newline=true
-max_line_length=130
+max_line_length=135
 
 # ktlint
 disabled_rules=import-ordering,experimental:annotation,experimental:indent

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -287,7 +287,6 @@ class RealImageLoaderIntegrationTest {
         val size = PixelSize(100, 100)
         val result = runBlocking {
             imageLoader.applyTransformations(
-                scope = this,
                 result = DrawableResult(
                     drawable = drawable,
                     isSampled = false,
@@ -310,7 +309,6 @@ class RealImageLoaderIntegrationTest {
         val size = PixelSize(100, 100)
         val result = runBlocking {
             imageLoader.applyTransformations(
-                scope = this,
                 result = DrawableResult(
                     drawable = drawable,
                     isSampled = false,

--- a/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.BitmapPool
+import coil.size.OriginalSize
 import coil.util.isSimilarTo
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -29,7 +30,7 @@ class CircleCropTransformationTest {
         val expected = BitmapFactory.decodeStream(context.assets.open("normal_small_circle.png"))
 
         val actual = runBlocking {
-            transformation.transform(pool, input)
+            transformation.transform(pool, input, OriginalSize)
         }
 
         assertTrue(actual.isSimilarTo(expected))

--- a/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.BitmapFactory
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.BitmapPool
+import coil.size.OriginalSize
 import coil.util.getPixels
 import coil.util.isSimilarTo
 import kotlinx.coroutines.runBlocking
@@ -30,7 +31,7 @@ class GrayscaleTransformationTest {
         val expected = BitmapFactory.decodeStream(context.assets.open("normal_grayscale.jpg"))
 
         val actual = runBlocking {
-            transformation.transform(pool, input)
+            transformation.transform(pool, input, OriginalSize)
         }
 
         val (_, red, green, blue) = actual.getPixels()

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -270,7 +270,7 @@ internal class RealImageLoader(
         var mappedData = data
         for ((type, mapper) in registry.measuredMappers) {
             if (type.isAssignableFrom(mappedData::class.java) && (mapper as MeasuredMapper<Any, *>).handles(mappedData)) {
-                mappedData = mapper.map(mappedData, lazySizeResolver.size(null))
+                mappedData = mapper.map(mappedData, lazySizeResolver.size())
             }
         }
         for ((type, mapper) in registry.mappers) {
@@ -307,7 +307,7 @@ internal class RealImageLoader(
                 transformations.forEach { append('#').append(it.key()) }
 
                 // Append the size if there are any transformations. Size must not be null here.
-                append('#').append(lazySizeResolver.size(null))
+                append('#').append(lazySizeResolver.size())
             }
         }
     }
@@ -484,7 +484,7 @@ internal class RealImageLoader(
         private var size: Size? = null
 
         @MainThread
-        suspend fun size(cached: BitmapDrawable?): Size = coroutineScope {
+        suspend fun size(cached: BitmapDrawable? = null): Size = coroutineScope {
             size?.let { return@coroutineScope it }
 
             // Call the target's onStart before resolving the size.

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -190,6 +190,7 @@ internal class RealImageLoader(
             var mappedData: Any = data
             for ((type, mapper) in registry.measuredMappers) {
                 if (type.isAssignableFrom(mappedData::class.java) && (mapper as MeasuredMapper<Any, *>).handles(mappedData)) {
+                    // Resolve the size.
                     if (sizeResolver == null || size == null) {
                         targetDelegate.start(null, request.placeholder)
                         sizeResolver = requestService.sizeResolver(request, context)
@@ -210,6 +211,7 @@ internal class RealImageLoader(
                 request.key
             } else {
                 if (request.transformations.isNotEmpty()) {
+                    // Resolve the size.
                     if (sizeResolver == null || size == null) {
                         targetDelegate.start(null, request.placeholder)
                         sizeResolver = requestService.sizeResolver(request, context)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -473,10 +473,7 @@ internal class RealImageLoader(
         check(!isShutdown) { "The image loader is shutdown!" }
     }
 
-    /**
-     * Lazily resolves and caches a request's size.
-     * Responsible for calling [Target.onStart] before suspending to resolve the size.
-     */
+    /** Lazily resolves and caches a request's size. Responsible for calling [Target.onStart]. */
     @VisibleForTesting
     internal class LazySizeResolver(
         private val sizeResolver: SizeResolver,

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -435,7 +435,7 @@ internal class RealImageLoader(
         }
 
         val transformedBitmap = transformations.fold(baseBitmap) { bitmap, transformation ->
-            transformation.transform(bitmapPool, bitmap).also { ensureActive() }
+            transformation.transform(bitmapPool, bitmap, size).also { ensureActive() }
         }
         return@run result.copy(drawable = transformedBitmap.toDrawable(context))
     }

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -6,6 +6,7 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.collection.LruCache
+import coil.memory.MemoryCache.Value
 import coil.util.getAllocationByteCountCompat
 import coil.util.log
 
@@ -47,7 +48,7 @@ internal interface MemoryCache {
 /** A [MemoryCache] implementation that caches nothing. */
 private object EmptyMemoryCache : MemoryCache {
 
-    override fun get(key: String): MemoryCache.Value? = null
+    override fun get(key: String): Value? = null
 
     override fun set(key: String, value: Bitmap, isSampled: Boolean) {}
 
@@ -70,18 +71,18 @@ private class RealMemoryCache(
         private const val TAG = "RealMemoryCache"
     }
 
-    private val cache = object : LruCache<String, MemoryCache.Value>(maxSize) {
+    private val cache = object : LruCache<String, Value>(maxSize) {
         override fun entryRemoved(
             evicted: Boolean,
             key: String,
-            oldValue: MemoryCache.Value,
-            newValue: MemoryCache.Value?
+            oldValue: Value,
+            newValue: Value?
         ) = referenceCounter.decrement(oldValue.bitmap)
 
-        override fun sizeOf(key: String, value: MemoryCache.Value) = value.size
+        override fun sizeOf(key: String, value: Value) = value.size
     }
 
-    override fun get(key: String): MemoryCache.Value? = cache.get(key)
+    override fun get(key: String): Value? = cache.get(key)
 
     override fun set(key: String, value: Bitmap, isSampled: Boolean) {
         // If the bitmap is too big for the cache, don't even attempt to store it. Doing so will cause
@@ -93,7 +94,7 @@ private class RealMemoryCache(
         }
 
         referenceCounter.increment(value)
-        cache.put(key, MemoryCache.Value(value, isSampled, size))
+        cache.put(key, Value(value, isSampled, size))
     }
 
     override fun size(): Int = cache.size()

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -12,7 +12,10 @@ import coil.request.RequestBuilder
 sealed class Size
 
 /** Represents the width and height of the source image. */
-object OriginalSize : Size()
+object OriginalSize : Size() {
+
+    override fun toString() = "OriginalSize"
+}
 
 /** A positive width and height in pixels. */
 data class PixelSize(

--- a/coil-base/src/main/java/coil/transform/BlurTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/BlurTransformation.kt
@@ -13,6 +13,7 @@ import android.renderscript.ScriptIntrinsicBlur
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.applyCanvas
 import coil.bitmappool.BitmapPool
+import coil.size.Size
 
 /**
  * A [Transformation] that applies a Gaussian blur to an image.
@@ -41,7 +42,7 @@ class BlurTransformation(
 
     override fun key(): String = "${BlurTransformation::class.java.name}-$radius-$sampling"
 
-    override suspend fun transform(pool: BitmapPool, input: Bitmap): Bitmap {
+    override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
         val scaledWidth = (input.width / sampling).toInt()

--- a/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import androidx.core.graphics.applyCanvas
 import coil.bitmappool.BitmapPool
+import coil.size.Size
 import kotlin.math.min
 
 /**
@@ -21,7 +22,7 @@ class CircleCropTransformation : Transformation {
 
     override fun key(): String = CircleCropTransformation::class.java.name
 
-    override suspend fun transform(pool: BitmapPool, input: Bitmap): Bitmap {
+    override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
         val minSize = min(input.width, input.height)

--- a/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
@@ -22,7 +22,8 @@ class GrayscaleTransformation : Transformation {
     override fun key(): String = GrayscaleTransformation::class.java.name
 
     override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG).apply { colorFilter = COLOR_FILTER }
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+        paint.colorFilter = COLOR_FILTER
 
         val output = pool.get(input.width, input.height, input.config)
         output.applyCanvas {

--- a/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
@@ -8,6 +8,7 @@ import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import androidx.core.graphics.applyCanvas
 import coil.bitmappool.BitmapPool
+import coil.size.Size
 
 /**
  * A [Transformation] that converts an image to shades of gray.
@@ -20,7 +21,7 @@ class GrayscaleTransformation : Transformation {
 
     override fun key(): String = GrayscaleTransformation::class.java.name
 
-    override suspend fun transform(pool: BitmapPool, input: Bitmap): Bitmap {
+    override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG).apply { colorFilter = COLOR_FILTER }
 
         val output = pool.get(input.width, input.height, input.config)

--- a/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
@@ -10,8 +10,15 @@ import android.graphics.Path
 import android.graphics.PorterDuff
 import android.graphics.RectF
 import android.graphics.Shader
+import androidx.annotation.FloatRange
 import androidx.core.graphics.applyCanvas
 import coil.bitmappool.BitmapPool
+import coil.decode.DecodeUtils
+import coil.size.OriginalSize
+import coil.size.PixelSize
+import coil.size.Scale
+import coil.size.Size
+import kotlin.math.roundToInt
 
 /**
  * A [Transformation] that rounds the corners of an image.
@@ -22,13 +29,17 @@ import coil.bitmappool.BitmapPool
  * @param bottomRight The radius for the bottom right corner.
  */
 class RoundedCornersTransformation(
-    private val topLeft: Float = 0f,
-    private val topRight: Float = 0f,
-    private val bottomLeft: Float = 0f,
-    private val bottomRight: Float = 0f
+    @FloatRange(from = 0.0, to = 1.0) private val topLeft: Float = 0f,
+    @FloatRange(from = 0.0, to = 1.0) private val topRight: Float = 0f,
+    @FloatRange(from = 0.0, to = 1.0) private val bottomLeft: Float = 0f,
+    @FloatRange(from = 0.0, to = 1.0) private val bottomRight: Float = 0f
 ) : Transformation {
 
-    constructor(radius: Float) : this(radius, radius, radius, radius)
+    companion object {
+        private const val DEFAULT_RADIUS = 0.05f
+    }
+
+    constructor(@FloatRange(from = 0.0, to = 1.0) radius: Float = DEFAULT_RADIUS) : this(radius, radius, radius, radius)
 
     init {
         require(topLeft >= 0 && topRight >= 0 && bottomLeft >= 0 && bottomRight >= 0) { "All radii must be >= 0." }
@@ -36,16 +47,37 @@ class RoundedCornersTransformation(
 
     override fun key() = "${RoundedCornersTransformation::class.java}-$topLeft,$topRight,$bottomLeft,$bottomRight"
 
-    override suspend fun transform(pool: BitmapPool, input: Bitmap): Bitmap {
+    override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
         paint.shader = BitmapShader(input, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
 
-        val output = pool.get(input.width, input.height, input.config)
-        val rect = RectF(0f, 0f, output.width.toFloat(), output.height.toFloat())
+        val outputWidth: Int
+        val outputHeight: Int
+        when (size) {
+            is PixelSize -> {
+                val multiplier = DecodeUtils.computeSizeMultiplier(
+                    srcWidth = input.width.toFloat(),
+                    srcHeight = input.height.toFloat(),
+                    destWidth = size.width.toFloat(),
+                    destHeight = size.height.toFloat(),
+                    scale = Scale.FILL
+                )
+                outputWidth = (multiplier * size.width).roundToInt()
+                outputHeight = (multiplier * size.height).roundToInt()
+            }
+            is OriginalSize -> {
+                outputWidth = input.width
+                outputHeight = input.height
+            }
+        }
+
+        val output = pool.get(outputWidth, outputHeight, input.config)
         output.applyCanvas {
             drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
 
+            val normalizedTopLeft = 0
             val radii = floatArrayOf(topLeft, topLeft, topRight, topRight, bottomRight, bottomRight, bottomLeft, bottomLeft)
+            val rect = RectF(0f, 0f, output.width.toFloat(), output.height.toFloat())
             val path = Path().apply { addRoundRect(rect, radii, Path.Direction.CW) }
             drawPath(path, paint)
         }

--- a/coil-base/src/main/java/coil/transform/Transformation.kt
+++ b/coil-base/src/main/java/coil/transform/Transformation.kt
@@ -37,11 +37,11 @@ interface Transformation {
     fun key(): String
 
     /**
-     * Apply the transformation to [Bitmap].
+     * Apply the transformation to [input].
      *
      * For optimal performance, do not use [Bitmap.createBitmap] inside this method. Instead, use the provided
-     * [BitmapPool] to get new [Bitmap]s. Also, you should return every Bitmap except the output [Bitmap] to the
-     * pool so that they can be reused.
+     * [BitmapPool] to get new [Bitmap]s. Also, you should return every bitmp except the output bitmap to [pool]
+     * so that they can be reused.
      *
      * @param pool A [BitmapPool] which can be used to request [Bitmap] instances.
      * @param input The input [Bitmap] to transform. Its config will always be one of [VALID_CONFIGS].

--- a/coil-base/src/main/java/coil/transform/Transformation.kt
+++ b/coil-base/src/main/java/coil/transform/Transformation.kt
@@ -8,6 +8,7 @@ import coil.bitmappool.BitmapPool
 import coil.decode.DecodeResult
 import coil.fetch.DrawableResult
 import coil.request.RequestBuilder
+import coil.size.Size
 
 /**
  * An interface for making transformations to an image's pixel data.
@@ -42,8 +43,12 @@ interface Transformation {
      * [BitmapPool] to get new [Bitmap]s. Also, you should return every Bitmap except the output [Bitmap] to the
      * pool so that they can be reused.
      *
+     * @param pool A [BitmapPool] which can be used to request [Bitmap] instances.
+     * @param input The input [Bitmap] to transform.
+     * @param size The size for the image request.
+     *
      * @see BitmapPool.get
      * @see BitmapPool.put
      */
-    suspend fun transform(pool: BitmapPool, input: Bitmap): Bitmap
+    suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size): Bitmap
 }

--- a/coil-base/src/main/java/coil/transform/Transformation.kt
+++ b/coil-base/src/main/java/coil/transform/Transformation.kt
@@ -44,8 +44,8 @@ interface Transformation {
      * pool so that they can be reused.
      *
      * @param pool A [BitmapPool] which can be used to request [Bitmap] instances.
-     * @param input The input [Bitmap] to transform.
-     * @param size The size for the image request.
+     * @param input The input [Bitmap] to transform. Its config will always be one of [VALID_CONFIGS].
+     * @param size The size of the image request.
      *
      * @see BitmapPool.get
      * @see BitmapPool.put

--- a/coil-base/src/main/java/coil/util/ContinuationCallback.kt
+++ b/coil-base/src/main/java/coil/util/ContinuationCallback.kt
@@ -9,6 +9,7 @@ import java.io.IOException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
+/** @see [Call.await]. */
 internal class ContinuationCallback(
     private val call: Call,
     private val continuation: CancellableContinuation<Response>

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -9,6 +9,7 @@ import coil.bitmappool.BitmapPool
 import coil.decode.Options
 import coil.fetch.Fetcher
 import coil.request.Parameters
+import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Precision
 import coil.size.Scale
@@ -18,6 +19,7 @@ import coil.util.createBitmap
 import coil.util.createGetRequest
 import coil.util.createLoadRequest
 import coil.util.toDrawable
+import coil.util.unsupported
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -291,7 +293,7 @@ class RealImageLoaderBasicTest {
     @Test
     fun `computeCacheKey - null key`() {
         val fetcher = createFakeFetcher(key = null)
-        val key = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList())
+        val key = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList(), null)
 
         assertNull(key)
     }
@@ -299,7 +301,7 @@ class RealImageLoaderBasicTest {
     @Test
     fun `computeCacheKey - basic key`() {
         val fetcher = createFakeFetcher()
-        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList())
+        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList(), null)
 
         assertEquals("base_key", result)
     }
@@ -308,7 +310,7 @@ class RealImageLoaderBasicTest {
     fun `computeCacheKey - params only`() {
         val fetcher = createFakeFetcher()
         val parameters = createFakeParameters()
-        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, emptyList())
+        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, emptyList(), null)
 
         assertEquals("base_key#key2=cached2#key3=cached3", result)
     }
@@ -317,9 +319,9 @@ class RealImageLoaderBasicTest {
     fun `computeCacheKey - transformations only`() {
         val fetcher = createFakeFetcher()
         val transformations = createFakeTransformations()
-        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, transformations)
+        val result = imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, transformations, PixelSize(123, 332))
 
-        assertEquals("base_key#key1#key2", result)
+        assertEquals("base_key#key1#key2#PixelSize(width=123, height=332)", result)
     }
 
     @Test
@@ -327,20 +329,20 @@ class RealImageLoaderBasicTest {
         val fetcher = createFakeFetcher()
         val parameters = createFakeParameters()
         val transformations = createFakeTransformations()
-        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, transformations)
+        val result = imageLoader.computeCacheKey(fetcher, Unit, parameters, transformations, OriginalSize)
 
-        assertEquals("base_key#key2=cached2#key3=cached3#key1#key2", result)
+        assertEquals("base_key#key2=cached2#key3=cached3#key1#key2#OriginalSize", result)
     }
 
     private fun createFakeTransformations(): List<Transformation> {
         return listOf(
             object : Transformation {
                 override fun key() = "key1"
-                override suspend fun transform(pool: BitmapPool, input: Bitmap) = throw UnsupportedOperationException()
+                override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size) = unsupported()
             },
             object : Transformation {
                 override fun key() = "key2"
-                override suspend fun transform(pool: BitmapPool, input: Bitmap) = throw UnsupportedOperationException()
+                override suspend fun transform(pool: BitmapPool, input: Bitmap, size: Size) = unsupported()
             }
         )
     }
@@ -362,7 +364,7 @@ class RealImageLoaderBasicTest {
                 data: Any,
                 size: Size,
                 options: Options
-            ) = throw UnsupportedOperationException()
+            ) = unsupported()
         }
     }
 }

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -352,6 +352,23 @@ class RealImageLoaderBasicTest {
         assertEquals("base_key#key2=cached2#key3=cached3#key1#key2#OriginalSize", result)
     }
 
+    @Test
+    fun `lazySizeResolver - resolves at most once`() {
+        var isFirstResolve = true
+        val lazySizeResolver = createFakeLazySizeResolver {
+            if (isFirstResolve) {
+                isFirstResolve = false
+                PixelSize(100, 100)
+            } else {
+                throw IllegalStateException()
+            }
+        }
+
+        runBlocking {
+            assertEquals(lazySizeResolver.size(), lazySizeResolver.size())
+        }
+    }
+
     private fun createFakeTransformations(): List<Transformation> {
         return listOf(
             object : Transformation {

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -386,8 +386,8 @@ class RealImageLoaderBasicTest {
         }
     }
 
-    private fun createFakeSizeLazy(block: suspend () -> Size = { unsupported() }): RealImageLoader.SizeLazy {
-        return RealImageLoader.SizeLazy(
+    private fun createFakeSizeLazy(block: suspend () -> Size = { unsupported() }): RealImageLoader.LazySizeResolver {
+        return RealImageLoader.LazySizeResolver(
             sizeResolver = object : SizeResolver {
                 override suspend fun size() = block()
             },

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -296,7 +296,7 @@ class RealImageLoaderBasicTest {
     @Test
     fun `computeCacheKey - null key`() {
         val fetcher = createFakeFetcher(key = null)
-        val size = createFakeSizeLazy()
+        val size = createFakeLazySizeResolver()
         val key = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList(), size)
         }
@@ -307,7 +307,7 @@ class RealImageLoaderBasicTest {
     @Test
     fun `computeCacheKey - basic key`() {
         val fetcher = createFakeFetcher()
-        val size = createFakeSizeLazy()
+        val size = createFakeLazySizeResolver()
         val result = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList(), size)
         }
@@ -319,7 +319,7 @@ class RealImageLoaderBasicTest {
     fun `computeCacheKey - params only`() {
         val fetcher = createFakeFetcher()
         val parameters = createFakeParameters()
-        val size = createFakeSizeLazy()
+        val size = createFakeLazySizeResolver()
         val result = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, parameters, emptyList(), size)
         }
@@ -331,7 +331,7 @@ class RealImageLoaderBasicTest {
     fun `computeCacheKey - transformations only`() {
         val fetcher = createFakeFetcher()
         val transformations = createFakeTransformations()
-        val size = createFakeSizeLazy { PixelSize(123, 332) }
+        val size = createFakeLazySizeResolver { PixelSize(123, 332) }
         val result = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, transformations, size)
         }
@@ -344,7 +344,7 @@ class RealImageLoaderBasicTest {
         val fetcher = createFakeFetcher()
         val parameters = createFakeParameters()
         val transformations = createFakeTransformations()
-        val size = createFakeSizeLazy { OriginalSize }
+        val size = createFakeLazySizeResolver { OriginalSize }
         val result = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, parameters, transformations, size)
         }
@@ -386,7 +386,7 @@ class RealImageLoaderBasicTest {
         }
     }
 
-    private fun createFakeSizeLazy(block: suspend () -> Size = { unsupported() }): RealImageLoader.LazySizeResolver {
+    private fun createFakeLazySizeResolver(block: suspend () -> Size = { unsupported() }): RealImageLoader.LazySizeResolver {
         return RealImageLoader.LazySizeResolver(
             sizeResolver = object : SizeResolver {
                 override suspend fun size() = block()

--- a/coil-base/src/test/java/coil/util/TestFunctions.kt
+++ b/coil-base/src/test/java/coil/util/TestFunctions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE", "unused", "NOTHING_TO_INLINE")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "NOTHING_TO_INLINE", "unused")
 
 package coil.util
 

--- a/coil-base/src/test/java/coil/util/TestFunctions.kt
+++ b/coil-base/src/test/java/coil/util/TestFunctions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE", "unused")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "unused", "NOTHING_TO_INLINE")
 
 package coil.util
 
@@ -24,3 +24,5 @@ fun createBitmap(
 fun createTestMainDispatcher(): TestCoroutineDispatcher {
     return TestCoroutineDispatcher().apply { Dispatchers.setMain(this) }
 }
+
+inline fun unsupported(): Nothing = throw UnsupportedOperationException()


### PR DESCRIPTION
This PR includes two main behaviour / breaking changes:

- `Transformation` is now passed the resolved `Size` of the target. This is often different than the size of the `input` Bitmap. For instance, the target and the source image can have different aspect ratios.
- Any requests with transformations are now ineligible for [image sampling](https://coil-kt.github.io/coil/getting_started/#image-sampling). This is because we can't guarantee that a transformation results in the same image given different target sizes.

This PR also refactors some duplicate code into a `SizeLazy` object, which simplifies the `RealImageLoader.execute` method.

Fixes #126.