### PR TITLE
Avoid extra coroutineScope calls.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 indent_size=4
 insert_final_newline=true
-max_line_length=130
+max_line_length=120
 
 # ktlint
-disabled_rules=import-ordering,experimental:annotation,experimental:indent
+disabled_rules=import-ordering,max-line-length,experimental:annotation,experimental:indent

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -287,6 +287,7 @@ class RealImageLoaderIntegrationTest {
         val size = PixelSize(100, 100)
         val result = runBlocking {
             imageLoader.applyTransformations(
+                scope = this,
                 result = DrawableResult(
                     drawable = drawable,
                     isSampled = false,
@@ -309,6 +310,7 @@ class RealImageLoaderIntegrationTest {
         val size = PixelSize(100, 100)
         val result = runBlocking {
             imageLoader.applyTransformations(
+                scope = this,
                 result = DrawableResult(
                     drawable = drawable,
                     isSampled = false,

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -22,6 +22,8 @@ import coil.util.createGetRequest
 import coil.util.createLoadRequest
 import coil.util.toDrawable
 import coil.util.unsupported
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -403,8 +405,11 @@ class RealImageLoaderBasicTest {
         }
     }
 
-    private fun createFakeLazySizeResolver(block: suspend () -> Size = { unsupported() }): RealImageLoader.LazySizeResolver {
+    private fun createFakeLazySizeResolver(
+        block: suspend () -> Size = { unsupported() }
+    ): RealImageLoader.LazySizeResolver {
         return RealImageLoader.LazySizeResolver(
+            scope = CoroutineScope(Job()), // Pass a fake scope.
             sizeResolver = object : SizeResolver {
                 override suspend fun size() = block()
             },


### PR DESCRIPTION
Pass the scope explicitly.

Also disables the max-line-length check.