### PR TITLE
Rework Transitions API. Remove Transition.Factory.

### DIFF
--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
  */
 data class DefaultRequestOptions(
     val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    val transitionFactory: Transition.Factory? = null,
+    val transition: Transition? = null,
     val precision: Precision = Precision.AUTOMATIC,
     val allowHardware: Boolean = true,
     val allowRgb565: Boolean = false,

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -176,16 +176,16 @@ class ImageLoaderBuilder(private val context: Context) {
      * @see `crossfade(Boolean)`
      */
     fun crossfade(durationMillis: Int) = apply {
-        val factory = if (durationMillis > 0) CrossfadeTransition.Factory(durationMillis) else null
-        this.defaults = this.defaults.copy(transitionFactory = factory)
+        val factory = if (durationMillis > 0) CrossfadeTransition(durationMillis) else null
+        this.defaults = this.defaults.copy(transition = factory)
     }
 
     /**
-     * Set the default [Transition.Factory] for each request.
+     * Set the default [Transition] for each request.
      */
     @ExperimentalCoil
-    fun transitionFactory(factory: Transition.Factory?) = apply {
-        this.defaults = this.defaults.copy(transitionFactory = factory)
+    fun transition(transition: Transition?) = apply {
+        this.defaults = this.defaults.copy(transition = transition)
     }
 
     /**

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -62,7 +62,6 @@ import coil.size.SizeResolver
 import coil.target.Target
 import coil.target.ViewTarget
 import coil.transform.Transformation
-import coil.transition.Transition
 import coil.util.ComponentCallbacks
 import coil.util.Emoji
 import coil.util.closeQuietly
@@ -212,8 +211,7 @@ internal class RealImageLoader(
             // Short circuit if the cached drawable is valid for the target.
             if (cachedDrawable != null && isCachedDrawableValid(cachedDrawable, cachedValue.isSampled, size, scale, request)) {
                 log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
-                val transition = request.transitionFactory?.newTransition(Transition.Event.CACHED)
-                targetDelegate.success(cachedDrawable, transition)
+                targetDelegate.success(cachedDrawable, true, request.transition)
                 request.listener?.onSuccess(data, DataSource.MEMORY)
                 return@innerJob cachedDrawable
             }
@@ -228,8 +226,7 @@ internal class RealImageLoader(
 
             // Set the final result on the target.
             log(TAG, Log.INFO) { "${source.emoji} Successful (${source.name}) - $data" }
-            val transition = request.transitionFactory?.newTransition(Transition.Event.SUCCESS)
-            targetDelegate.success(drawable, transition)
+            targetDelegate.success(drawable, false, request.transition)
             request.listener?.onSuccess(data, source)
 
             return@innerJob drawable
@@ -250,8 +247,7 @@ internal class RealImageLoader(
                 } else {
                     log(TAG, Log.INFO) { "${Emoji.SIREN} Failed - $data - $throwable" }
                     val drawable = if (throwable is NullRequestDataException) request.fallback else request.error
-                    val transition = request.transitionFactory?.newTransition(Transition.Event.ERROR)
-                    targetDelegate.error(drawable, transition)
+                    targetDelegate.error(drawable, request.transition)
                     request.listener?.onError(data, throwable)
                 }
             }

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -37,7 +37,7 @@ sealed class Request {
 
     abstract val target: Target?
     abstract val lifecycle: Lifecycle?
-    abstract val transitionFactory: Transition.Factory?
+    abstract val transition: Transition?
 
     abstract val key: String?
     abstract val aliasKeys: List<String>
@@ -98,7 +98,7 @@ sealed class Request {
 /**
  * A value object that represents a *load* image request.
  *
- * Instances can be created ad hoc:
+ * Instances can be created and executed ad hoc:
  * ```
  * imageLoader.load(context, "https://www.example.com/image.jpg") {
  *     crossfade(true)
@@ -124,7 +124,7 @@ class LoadRequest internal constructor(
     override val data: Any?,
     override val target: Target?,
     override val lifecycle: Lifecycle?,
-    override val transitionFactory: Transition.Factory?,
+    override val transition: Transition?,
     override val key: String?,
     override val aliasKeys: List<String>,
     override val listener: Listener?,
@@ -188,7 +188,7 @@ class LoadRequest internal constructor(
 /**
  * A value object that represents a *get* image request.
  *
- * Instances can be created ad hoc:
+ * Instances can be created and executed ad hoc:
  * ```
  * val drawable = imageLoader.get("https://www.example.com/image.jpg") {
  *     size(1080, 1920)
@@ -247,7 +247,7 @@ class GetRequest internal constructor(
 
     override val lifecycle: Lifecycle? = null
 
-    override val transitionFactory: Transition.Factory? = null
+    override val transition: Transition? = null
 
     override val placeholder: Drawable? = null
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -389,7 +389,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
 
     private var target: Target?
     private var lifecycle: Lifecycle?
-    private var transitionFactory: Transition.Factory?
+    private var transition: Transition?
 
     @DrawableRes private var placeholderResId: Int
     @DrawableRes private var errorResId: Int
@@ -403,7 +403,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
 
         target = null
         lifecycle = null
-        transitionFactory = defaults.transitionFactory
+        transition = defaults.transition
 
         placeholderResId = 0
         errorResId = 0
@@ -418,7 +418,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
 
         target = request.target
         lifecycle = request.lifecycle
-        transitionFactory = request.transitionFactory
+        transition = request.transition
 
         placeholderResId = request.placeholderResId
         errorResId = request.errorResId
@@ -493,15 +493,15 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
      * See: [ImageLoaderBuilder.crossfade]
      */
     fun crossfade(durationMillis: Int) = apply {
-        this.transitionFactory = CrossfadeTransition.Factory(durationMillis)
+        this.transition = CrossfadeTransition(durationMillis)
     }
 
     /**
-     * See: [ImageLoaderBuilder.transitionFactory]
+     * See: [ImageLoaderBuilder.transition]
      */
     @ExperimentalCoil
-    fun transitionFactory(factory: Transition.Factory?) = apply {
-        this.transitionFactory = factory
+    fun transition(transition: Transition?) = apply {
+        this.transition = transition
     }
 
     /**
@@ -561,7 +561,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
             data,
             target,
             lifecycle,
-            transitionFactory,
+            transition,
             key,
             aliasKeys,
             listener,

--- a/coil-base/src/main/java/coil/target/ImageViewTarget.kt
+++ b/coil-base/src/main/java/coil/target/ImageViewTarget.kt
@@ -8,26 +8,25 @@ import android.widget.ImageView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import coil.annotation.ExperimentalCoil
-import coil.transition.Transition
+import coil.transition.TransitionTarget
 
 /** A [Target] that handles setting images on an [ImageView]. */
 open class ImageViewTarget(
     override val view: ImageView
-) : PoolableViewTarget<ImageView>, DefaultLifecycleObserver, Transition.Adapter {
+) : PoolableViewTarget<ImageView>, TransitionTarget<ImageView>, DefaultLifecycleObserver {
 
     private var isStarted = false
 
-    override var drawable: Drawable?
+    override val drawable: Drawable?
         get() = view.drawable
-        set(value) = updateDrawable(value)
 
-    override fun onStart(placeholder: Drawable?) = updateDrawable(placeholder)
+    override fun onStart(placeholder: Drawable?) = setDrawable(placeholder)
 
-    override fun onSuccess(result: Drawable) = updateDrawable(result)
+    override fun onSuccess(result: Drawable) = setDrawable(result)
 
-    override fun onError(error: Drawable?) = updateDrawable(error)
+    override fun onError(error: Drawable?) = setDrawable(error)
 
-    override fun onClear() = updateDrawable(null)
+    override fun onClear() = setDrawable(null)
 
     override fun onStart(owner: LifecycleOwner) {
         isStarted = true
@@ -40,13 +39,13 @@ open class ImageViewTarget(
     }
 
     /** Replace the [ImageView]'s current drawable with [drawable]. */
-    protected open fun updateDrawable(drawable: Drawable?) {
+    protected open fun setDrawable(drawable: Drawable?) {
         (view.drawable as? Animatable)?.stop()
         view.setImageDrawable(drawable)
         updateAnimation()
     }
 
-    /** Start/stop the current [Drawable]'s animation based on the lifecycle state. */
+    /** Start/stop the current [Drawable]'s animation based on the current lifecycle state. */
     protected open fun updateAnimation() {
         val animatable = view.drawable as? Animatable ?: return
         if (isStarted) animatable.start() else animatable.stop()

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -6,6 +6,8 @@ import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import coil.annotation.ExperimentalCoil
 import coil.drawable.CrossfadeDrawable
 import coil.size.Scale
+import coil.transition.TransitionResult.Error
+import coil.transition.TransitionResult.Success
 import coil.util.scale
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CompletionHandler
@@ -23,19 +25,37 @@ class CrossfadeTransition(
     }
 
     override suspend fun transition(
-        adapter: Transition.Adapter,
-        drawable: Drawable?
+        target: TransitionTarget<*>,
+        result: TransitionResult
     ) = suspendCancellableCoroutine<Unit> { continuation ->
+        when (result) {
+            is Success -> if (result.isMemoryCache) {
+                target.onSuccess(result.drawable)
+            } else {
+                target.onSuccess(createCrossfade(continuation, target, result.drawable))
+            }
+            is Error -> {
+                target.onError(createCrossfade(continuation, target, result.drawable))
+            }
+        }
+    }
+
+    /** Create a [CrossfadeDrawable]. [continuation] will suspend until the crossfade animation completes. */
+    private fun createCrossfade(
+        continuation: CancellableContinuation<Unit>,
+        target: TransitionTarget<*>,
+        drawable: Drawable?
+    ): CrossfadeDrawable {
         val crossfade = CrossfadeDrawable(
-            start = adapter.drawable,
+            start = target.drawable,
             end = drawable,
-            scale = (adapter.view as? ImageView)?.scale ?: Scale.FILL,
+            scale = (target.view as? ImageView)?.scale ?: Scale.FILL,
             durationMillis = durationMillis
         )
         val callback = Callback(crossfade, continuation)
         crossfade.registerAnimationCallback(callback)
         continuation.invokeOnCancellation(callback)
-        adapter.drawable = crossfade
+        return crossfade
     }
 
     /** Handle cancellation of the continuation and completion of the animation in one object. */
@@ -50,15 +70,5 @@ class CrossfadeTransition(
         }
 
         override fun invoke(cause: Throwable?) = crossfade.stop()
-    }
-
-    class Factory(durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION) : Transition.Factory {
-
-        // CrossfadeTransition is stateless so we can reuse the same instance.
-        private val transition = CrossfadeTransition(durationMillis)
-
-        override fun newTransition(event: Transition.Event): Transition? {
-            return transition.takeIf { event != Transition.Event.CACHED }
-        }
     }
 }

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -30,6 +30,7 @@ class CrossfadeTransition(
     ) = suspendCancellableCoroutine<Unit> { continuation ->
         when (result) {
             is Success -> if (result.isMemoryCache) {
+                // Don't animate if the request was fulfilled by the memory cache.
                 target.onSuccess(result.drawable)
             } else {
                 target.onSuccess(createCrossfade(continuation, target, result.drawable))

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -1,8 +1,6 @@
 package coil.transition
 
 import android.graphics.Bitmap
-import android.graphics.drawable.Drawable
-import android.view.View
 import androidx.annotation.MainThread
 import coil.annotation.ExperimentalCoil
 import coil.target.Target
@@ -10,8 +8,8 @@ import coil.target.Target
 /**
  * A class to animate between a [Target]'s current drawable and the result of an image request.
  *
- * NOTE: A [Target] must implement [Transition.Adapter] to support applying [Transition]s.
- * If the [Target] does not implement [Transition.Adapter], any [Transition]s will be ignored.
+ * NOTE: A [Target] must implement [TransitionTarget] to support applying [Transition]s.
+ * If the [Target] does not implement [TransitionTarget], any [Transition]s will be ignored.
  */
 @ExperimentalCoil
 interface Transition {
@@ -20,46 +18,14 @@ interface Transition {
      * Start the transition animation and suspend until it completes or is cancelled.
      *
      * Failure to suspend until the animation is complete can cause the [drawable]'s [Bitmap] (if any)
-     * to be pooled while it is still in use. See [CrossfadeTransition] for an example.
+     * to be pooled while it is still in use.
      *
-     * @param adapter The adapter to apply this transition to.
-     * @param drawable The drawable to transition to.
+     * NOTE: Implementations are responsible for calling the correct [Target] lifecycle callback.
+     * See [CrossfadeTransition] for an example.
+     *
+     * @param target The target to apply this transition to.
+     * @param result The result of the image request.
      */
     @MainThread
-    suspend fun transition(adapter: Adapter, drawable: Drawable?)
-
-    /** A [Target] that supports applying [Transition]s. */
-    interface Adapter {
-
-        /** The underlying [View] that this [Transition] is being applied to. */
-        val view: View
-
-        /** The [view]'s current [Drawable]. */
-        var drawable: Drawable?
-    }
-
-    /** The result of the image request. */
-    enum class Event {
-
-        /** The image request was fulfilled from the memory cache. */
-        CACHED,
-
-        /** The image request was fulfilled from the image pipeline. */
-        SUCCESS,
-
-        /** The image request failed to complete successfully. */
-        ERROR
-    }
-
-    /** A class that creates new [Transition]s depending on the result of an image request. */
-    interface Factory {
-
-        /**
-         * Return a [Transition] to be applied to the [Transition.Adapter].
-         *
-         * @param event The result context of the image request.
-         * @return Return the [Transition] to be applied to the [Transition.Adapter]. Return null to perform no transition.
-         */
-        fun newTransition(event: Event): Transition?
-    }
+    suspend fun transition(target: TransitionTarget<*>, result: TransitionResult)
 }

--- a/coil-base/src/main/java/coil/transition/TransitionResult.kt
+++ b/coil-base/src/main/java/coil/transition/TransitionResult.kt
@@ -1,0 +1,36 @@
+package coil.transition
+
+import android.graphics.drawable.Drawable
+import coil.annotation.ExperimentalCoil
+import coil.target.Target
+
+/**
+ * Represents the result of an image request.
+ */
+@ExperimentalCoil
+sealed class TransitionResult {
+
+    /**
+     * Represents a *successful* image request.
+     *
+     * When passed to [Transition.transition], implementations should call [Target.onSuccess] exactly once.
+     *
+     * @param drawable The [Drawable] to transition to.
+     * @param isMemoryCache True if the request was fulfilled from the memory cache.
+     */
+    class Success(
+        val drawable: Drawable,
+        val isMemoryCache: Boolean
+    ) : TransitionResult()
+
+    /**
+     * Represents a *failed* image request.
+     *
+     * When passed to [Transition.transition], implementations should call [Target.onError] exactly once.
+     *
+     * @param drawable The [Drawable] to transition to.
+     */
+    class Error(
+        val drawable: Drawable?
+    ) : TransitionResult()
+}

--- a/coil-base/src/main/java/coil/transition/TransitionTarget.kt
+++ b/coil-base/src/main/java/coil/transition/TransitionTarget.kt
@@ -1,0 +1,19 @@
+package coil.transition
+
+import android.graphics.drawable.Drawable
+import android.view.View
+import coil.annotation.ExperimentalCoil
+import coil.target.Target
+import coil.target.ViewTarget
+
+/**
+ * A [Target] that supports applying [Transition]s.
+ */
+@ExperimentalCoil
+interface TransitionTarget<T : View> : ViewTarget<T> {
+
+    /**
+     * The [view]'s current [Drawable].
+     */
+    val drawable: Drawable?
+}

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -1,7 +1,6 @@
 package coil.memory
 
 import android.content.Context
-import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
@@ -10,6 +9,8 @@ import coil.bitmappool.FakeBitmapPool
 import coil.target.FakeTarget
 import coil.target.ImageViewTarget
 import coil.transition.Transition
+import coil.transition.TransitionResult
+import coil.transition.TransitionTarget
 import coil.util.createBitmap
 import coil.util.createGetRequest
 import coil.util.createLoadRequest
@@ -70,7 +71,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), null)
+            delegate.success(bitmap.toDrawable(context), false, null)
             assertFalse(counter.invalid(bitmap))
         }
     }
@@ -82,7 +83,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), null)
+            delegate.success(bitmap.toDrawable(context), false, null)
             assertTrue(counter.invalid(bitmap))
         }
     }
@@ -105,7 +106,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), null)
+            delegate.success(bitmap.toDrawable(context), false, null)
             assertTrue(target.success)
             assertTrue(counter.invalid(bitmap))
         }
@@ -133,7 +134,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), null)
+            delegate.success(bitmap.toDrawable(context), false, null)
             assertFalse(counter.invalid(bitmap))
             assertTrue(pool.bitmaps.contains(initialBitmap))
         }
@@ -156,14 +157,14 @@ class TargetDelegateTest {
             val bitmap = createBitmap()
             var isRunning = true
             val transition = object : Transition {
-                override suspend fun transition(adapter: Transition.Adapter, drawable: Drawable?) {
+                override suspend fun transition(target: TransitionTarget<*>, result: TransitionResult) {
                     assertFalse(pool.bitmaps.contains(initialBitmap))
                     delay(100) // Simulate an animation.
                     assertFalse(pool.bitmaps.contains(initialBitmap))
                     isRunning = false
                 }
             }
-            delegate.success(bitmap.toDrawable(context), transition)
+            delegate.success(bitmap.toDrawable(context), false, transition)
 
             // Ensure that the animation completed and the initial bitmap was not pooled until this method completes.
             assertFalse(isRunning)


### PR DESCRIPTION
Following up on some changes suggested in #170. These are the main changes:

- Preserve the `Target` lifecycle callbacks. Before, `Target`s had to implement `Transition.Adapter.drawable` and set the drawable without knowing if it's due to a success/fail. Now, the correct `Target` lifecycle callback is called directly.
- Remove `Transition.Factory`. This added confusion and removing it creates a simpler API. There's more discussion about the factory in #170.