### PR TITLE
Add Github actions status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: coil
 on:
     push:
         branches:

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="BlockingMethodInNonBlockingContext" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="false" level="INFO" enabled_by_default="false" />
-  </profile>
-</component>

--- a/README-ko.md
+++ b/README-ko.md
@@ -1,4 +1,6 @@
-﻿![Coil](logo.svg)
+﻿![Github Actions status](https://github.com/nuhkoca/coil/workflows/coil/badge.svg)
+
+![Coil](logo.svg)
 
 Coil은 Android 백앤드를 위해 Kotlin Coroutines으로 만들어진 이미지 로딩 라이브러리입니다. Coil 은:
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -1,4 +1,4 @@
-﻿![Github Actions status](https://github.com/nuhkoca/coil/workflows/coil/badge.svg)
+﻿![Github Actions status](https://github.com/coil-kt/coil/workflows/coil/badge.svg)
 
 ![Coil](logo.svg)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-﻿![Coil](logo.svg)
+﻿![Github Actions status](https://github.com/nuhkoca/coil/workflows/coil/badge.svg)
+
+![Coil](logo.svg)
 
 An image loading library for Android backed by Kotlin Coroutines. Coil is:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿![Github Actions status](https://github.com/nuhkoca/coil/workflows/coil/badge.svg)
+﻿![Github Actions status](https://github.com/coil-kt/coil/workflows/coil/badge.svg)
 
 ![Coil](logo.svg)
 


### PR DESCRIPTION
This PR aims to have a Github Actions status badge for those who want to benefit from the repository to give a status insight for them. I changed the name of the workflow to a meaningful one.

A sample outlook:
![Screen Shot 2020-01-04 at 11 48 45 PM](https://user-images.githubusercontent.com/5719389/71772536-df624200-2f4c-11ea-8234-535046f8ed2c.png)