### PR TITLE
Fix rasterized vector drawables not being marked as sampled.

### DIFF
--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -60,7 +60,7 @@ class ResourceUriFetcherTest {
 
         assertTrue(result is DrawableResult)
         assertTrue(result.drawable is BitmapDrawable)
-        assertFalse(result.isSampled)
+        assertTrue(result.isSampled)
     }
 
     @Test
@@ -96,6 +96,6 @@ class ResourceUriFetcherTest {
 
         assertTrue(result is DrawableResult)
         assertTrue(result.drawable is BitmapDrawable)
-        assertFalse(result.isSampled)
+        assertTrue(result.isSampled)
     }
 }

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -123,7 +123,7 @@ internal class RealImageLoader(
         .add(AssetUriFetcher(context))
         .add(ContentUriFetcher(context))
         .add(ResourceUriFetcher(context, drawableDecoder))
-        .add(DrawableFetcher(drawableDecoder))
+        .add(DrawableFetcher(context, drawableDecoder))
         .add(BitmapFetcher(context))
         // Decoders
         .add(BitmapFactoryDecoder(context))

--- a/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
+++ b/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
@@ -5,22 +5,17 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.VectorDrawable
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.LOLLIPOP
 import androidx.annotation.WorkerThread
 import androidx.core.graphics.component1
 import androidx.core.graphics.component2
 import androidx.core.graphics.component3
 import androidx.core.graphics.component4
-import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.bitmappool.BitmapPool
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Scale
 import coil.size.Size
 import coil.util.normalize
-import coil.util.toDrawable
 import kotlin.math.roundToInt
 
 internal class DrawableDecoderService(
@@ -30,19 +25,6 @@ internal class DrawableDecoderService(
 
     companion object {
         private const val DEFAULT_SIZE = 512
-    }
-
-    @WorkerThread
-    fun convertIfNecessary(
-        drawable: Drawable,
-        size: Size,
-        config: Bitmap.Config
-    ): Drawable {
-        return if (shouldConvertToBitmap(drawable)) {
-            convert(drawable, size, config).toDrawable(context)
-        } else {
-            drawable
-        }
     }
 
     /** Convert the provided [Drawable] into a [Bitmap]. */
@@ -98,9 +80,5 @@ internal class DrawableDecoderService(
         }
 
         return bitmap
-    }
-
-    private fun shouldConvertToBitmap(drawable: Drawable): Boolean {
-        return (drawable is VectorDrawableCompat) || (SDK_INT > LOLLIPOP && drawable is VectorDrawable)
     }
 }

--- a/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
@@ -23,7 +23,7 @@ internal class DrawableFetcher(
         size: Size,
         options: Options
     ): FetchResult {
-        val isVector = data.isVector()
+        val isVector = data.isVector
         return DrawableResult(
             drawable = if (isVector) {
                 drawableDecoder.convert(data, size, options.config).toDrawable(context)

--- a/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
@@ -1,13 +1,17 @@
 package coil.fetch
 
+import android.content.Context
 import android.graphics.drawable.Drawable
 import coil.bitmappool.BitmapPool
 import coil.decode.DataSource
 import coil.decode.DrawableDecoderService
 import coil.decode.Options
 import coil.size.Size
+import coil.util.isVector
+import coil.util.toDrawable
 
 internal class DrawableFetcher(
+    private val context: Context,
     private val drawableDecoder: DrawableDecoderService
 ) : Fetcher<Drawable> {
 
@@ -20,7 +24,11 @@ internal class DrawableFetcher(
         options: Options
     ): FetchResult {
         return DrawableResult(
-            drawable = drawableDecoder.convertIfNecessary(data, size, options.config),
+            drawable = if (data.isVector()) {
+                drawableDecoder.convert(data, size, options.config).toDrawable(context)
+            } else {
+                data
+            },
             isSampled = false,
             dataSource = DataSource.MEMORY
         )

--- a/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
@@ -23,13 +23,14 @@ internal class DrawableFetcher(
         size: Size,
         options: Options
     ): FetchResult {
+        val isVector = data.isVector()
         return DrawableResult(
-            drawable = if (data.isVector()) {
+            drawable = if (isVector) {
                 drawableDecoder.convert(data, size, options.config).toDrawable(context)
             } else {
                 data
             },
-            isSampled = false,
+            isSampled = isVector,
             dataSource = DataSource.MEMORY
         )
     }

--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -13,7 +13,9 @@ import coil.size.Size
 import coil.util.getDrawableCompat
 import coil.util.getMimeTypeFromUrl
 import coil.util.getXmlDrawableCompat
+import coil.util.isVector
 import coil.util.nightMode
+import coil.util.toDrawable
 import okio.buffer
 import okio.source
 
@@ -53,9 +55,14 @@ internal class ResourceUriFetcher(
                 context.getXmlDrawableCompat(resources, resId)
             }
 
+            val isVector = drawable.isVector()
             DrawableResult(
-                drawable = drawableDecoder.convertIfNecessary(drawable, size, options.config),
-                isSampled = false,
+                drawable = if (isVector) {
+                    drawableDecoder.convert(drawable, size, options.config).toDrawable(context)
+                } else {
+                    drawable
+                },
+                isSampled = isVector,
                 dataSource = DataSource.MEMORY
             )
         } else {

--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -55,7 +55,7 @@ internal class ResourceUriFetcher(
                 context.getXmlDrawableCompat(resources, resId)
             }
 
-            val isVector = drawable.isVector()
+            val isVector = drawable.isVector
             DrawableResult(
                 drawable = if (isVector) {
                     drawableDecoder.convert(drawable, size, options.config).toDrawable(context)

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -9,10 +9,12 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.VectorDrawable
 import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.JELLY_BEAN_MR2
 import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.LOLLIPOP
 import android.os.Build.VERSION_CODES.O
 import android.os.Looper
 import android.os.StatFs
@@ -26,6 +28,7 @@ import android.widget.ImageView.ScaleType.FIT_START
 import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toDrawable
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.base.R
 import coil.decode.DataSource
 import coil.memory.MemoryCache
@@ -220,3 +223,7 @@ internal inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
 }
 
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()
+
+internal fun Drawable.isVector(): Boolean {
+    return (this is VectorDrawableCompat) || (SDK_INT > LOLLIPOP && this is VectorDrawable)
+}

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -150,6 +150,9 @@ internal val Drawable.width: Int
 internal val Drawable.height: Int
     get() = (this as? BitmapDrawable)?.bitmap?.width ?: intrinsicWidth
 
+internal val Drawable.isVector: Boolean
+    get() = (this is VectorDrawableCompat) || (SDK_INT > LOLLIPOP && this is VectorDrawable)
+
 internal fun Closeable.closeQuietly() {
     try {
         close()
@@ -223,7 +226,3 @@ internal inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
 }
 
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()
-
-internal fun Drawable.isVector(): Boolean {
-    return (this is VectorDrawableCompat) || (SDK_INT > LOLLIPOP && this is VectorDrawable)
-}

--- a/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
+++ b/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
@@ -2,9 +2,6 @@ package coil.decode
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.Color
-import android.graphics.drawable.BitmapDrawable
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.VectorDrawable
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.RealBitmapPool
@@ -34,15 +31,14 @@ class DrawableDecoderServiceTest {
             override fun getIntrinsicWidth() = 100
             override fun getIntrinsicHeight() = 100
         }
-        val output = service.convertIfNecessary(
+        val output = service.convert(
             drawable = input,
             size = PixelSize(200, 200),
             config = Bitmap.Config.HARDWARE
         )
 
-        assertTrue(output is BitmapDrawable)
-        assertEquals(Bitmap.Config.ARGB_8888, output.bitmap.config)
-        assertTrue(output.bitmap.run { width == 200 && height == 200 })
+        assertEquals(Bitmap.Config.ARGB_8888, output.config)
+        assertTrue(output.run { width == 200 && height == 200 })
     }
 
     @Test
@@ -51,15 +47,14 @@ class DrawableDecoderServiceTest {
             override fun getIntrinsicWidth() = -1
             override fun getIntrinsicHeight() = -1
         }
-        val output = service.convertIfNecessary(
+        val output = service.convert(
             drawable = input,
             size = PixelSize(200, 200),
             config = Bitmap.Config.HARDWARE
         )
 
-        assertTrue(output is BitmapDrawable)
-        assertEquals(Bitmap.Config.ARGB_8888, output.bitmap.config)
-        assertTrue(output.bitmap.run { width == 200 && height == 200 })
+        assertEquals(Bitmap.Config.ARGB_8888, output.config)
+        assertTrue(output.run { width == 200 && height == 200 })
     }
 
     @Test
@@ -76,17 +71,5 @@ class DrawableDecoderServiceTest {
 
         assertEquals(Bitmap.Config.ARGB_8888, output.config)
         assertTrue(output.width == 100 && output.height == 200)
-    }
-
-    @Test
-    fun `color is not converted`() {
-        val input = ColorDrawable(Color.BLACK)
-        val output = service.convertIfNecessary(
-            drawable = input,
-            size = PixelSize(200, 200),
-            config = Bitmap.Config.ARGB_8888
-        )
-
-        assertEquals(input, output)
     }
 }


### PR DESCRIPTION
Fixes #188.

Rasterized vector drawables need to be marked as sampled, as they can be redrawn at a higher quality.