### PR TITLE
Fix CrossfadeTransition not being resumed for a memory cache event.

### DIFF
--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -19,6 +19,7 @@ import androidx.core.graphics.withSave
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import coil.decode.DecodeUtils
 import coil.size.Scale
+import coil.util.forEachIndices
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -287,6 +288,6 @@ class CrossfadeDrawable(
     private fun markDone() {
         state = STATE_DONE
         start = null
-        callbacks.forEach { it.onAnimationEnd(this) }
+        callbacks.forEachIndices { it.onAnimationEnd(this) }
     }
 }

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -62,6 +62,13 @@ internal fun Bitmap.Config?.getBytesPerPixel(): Int {
     }
 }
 
+/** Functionally the same as [Iterable.forEach] except it generates an index-based loop that doesn't use an [Iterator]. */
+internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
+    for (i in indices) {
+        action(get(i))
+    }
+}
+
 internal inline fun <T> MutableList<T>.removeLast(): T? = if (isNotEmpty()) removeAt(lastIndex) else null
 
 internal inline fun ActivityManager.isLowRawDeviceCompat(): Boolean {

--- a/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
+++ b/coil-base/src/sharedTest/java/coil/util/SharedTestFunctions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE", "unused")
+@file:Suppress("EXPERIMENTAL_API_USAGE", "unused", "NOTHING_TO_INLINE")
 
 package coil.util
 
@@ -64,3 +64,5 @@ inline fun createLoadRequest(
     context: Context,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): LoadRequest = LoadRequestBuilder(context, DefaultRequestOptions()).data(Unit).apply(builder).build()
+
+inline fun error(): Nothing = throw IllegalStateException()

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -1,0 +1,127 @@
+package coil.transition
+
+import android.content.Context
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import androidx.test.core.app.ApplicationProvider
+import coil.annotation.ExperimentalCoil
+import coil.drawable.CrossfadeDrawable
+import coil.util.createTestMainDispatcher
+import coil.util.error
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@UseExperimental(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
+class CrossfadeTransitionTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private lateinit var mainDispatcher: TestCoroutineDispatcher
+    private lateinit var transition: CrossfadeTransition
+
+    @Before
+    fun before() {
+        mainDispatcher = createTestMainDispatcher()
+        transition = CrossfadeTransition()
+    }
+
+    @After
+    fun after() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `success - isMemoryCache=true`() {
+        val drawable = ColorDrawable()
+        var onSuccessCalled = false
+
+        runBlocking {
+            transition.transition(
+                target = createTransitionTarget(
+                    onSuccess = { result ->
+                        onSuccessCalled = true
+                        assertEquals(drawable, result)
+                    }
+                ),
+                result = TransitionResult.Success(drawable, true)
+            )
+        }
+
+        assertTrue(onSuccessCalled)
+    }
+
+    @Test
+    fun `success - isMemoryCache=false`() {
+        val drawable = ColorDrawable()
+        var onSuccessCalled = false
+
+        runBlocking {
+            transition.transition(
+                target = createTransitionTarget(
+                    onSuccess = { result ->
+                        onSuccessCalled = true
+                        assertTrue(result is CrossfadeDrawable)
+                        assertEquals(drawable, result.end)
+
+                        // Stop the transition early to simulate the end of the animation.
+                        result.stop()
+                    }
+                ),
+                result = TransitionResult.Success(drawable, false)
+            )
+        }
+
+        assertTrue(onSuccessCalled)
+    }
+
+    @Test
+    fun failure() {
+        val drawable = ColorDrawable()
+        var onSuccessCalled = false
+
+        runBlocking {
+            transition.transition(
+                target = createTransitionTarget(
+                    onError = { error ->
+                        onSuccessCalled = true
+                        assertTrue(error is CrossfadeDrawable)
+                        assertEquals(drawable, error.end)
+
+                        // Stop the transition early to simulate the end of the animation.
+                        error.stop()
+                    }
+                ),
+                result = TransitionResult.Error(drawable)
+            )
+        }
+
+        assertTrue(onSuccessCalled)
+    }
+
+    private inline fun createTransitionTarget(
+        crossinline onStart: (placeholder: Drawable?) -> Unit = { error() },
+        crossinline onError: (error: Drawable?) -> Unit = { error() },
+        crossinline onSuccess: (result: Drawable) -> Unit = { error() }
+    ): TransitionTarget<*> {
+        return object : TransitionTarget<ImageView> {
+            override val view = ImageView(context)
+            override val drawable: Drawable?
+                get() = view.drawable
+            override fun onStart(placeholder: Drawable?) = onStart(placeholder)
+            override fun onError(error: Drawable?) = onError(error)
+            override fun onSuccess(result: Drawable) = onSuccess(result)
+        }
+    }
+}


### PR DESCRIPTION
Add regression tests for `CrossfadeTransition` as well.