### PR TITLE
Replace loops that allocate an Iterator with index-based loops.

### DIFF
--- a/coil-base/src/main/java/coil/ComponentRegistry.kt
+++ b/coil-base/src/main/java/coil/ComponentRegistry.kt
@@ -9,6 +9,7 @@ import coil.map.Mapper
 import coil.map.MeasuredMapper
 import coil.util.MultiList
 import coil.util.MultiMutableList
+import coil.util.findIndices
 import okio.BufferedSource
 
 /**
@@ -47,7 +48,7 @@ class ComponentRegistry private constructor(
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> getMapper(data: T): Mapper<T, *>? {
-        val result = mappers.find { (type, mapper) ->
+        val result = mappers.findIndices { (type, mapper) ->
             type.isAssignableFrom(data::class.java) && (mapper as Mapper<Any, *>).handles(data)
         }
         return result?.second as Mapper<T, *>?
@@ -55,7 +56,7 @@ class ComponentRegistry private constructor(
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> getMeasuredMapper(data: T): MeasuredMapper<T, *>? {
-        val result = measuredMappers.find { (type, mapper) ->
+        val result = measuredMappers.findIndices { (type, mapper) ->
             type.isAssignableFrom(data::class.java) && (mapper as MeasuredMapper<Any, *>).handles(data)
         }
         return result?.second as MeasuredMapper<T, *>?
@@ -63,7 +64,7 @@ class ComponentRegistry private constructor(
 
     @Suppress("UNCHECKED_CAST")
     fun <T : Any> requireFetcher(data: T): Fetcher<T> {
-        val result = fetchers.find { (type, fetcher) ->
+        val result = fetchers.findIndices { (type, fetcher) ->
             type.isAssignableFrom(data::class.java) && (fetcher as Fetcher<Any>).handles(data)
         }
         checkNotNull(result) { "Unable to fetch data. No fetcher supports: $data" }
@@ -75,7 +76,7 @@ class ComponentRegistry private constructor(
         source: BufferedSource,
         mimeType: String?
     ): Decoder {
-        val decoder = decoders.find { it.handles(source, mimeType) }
+        val decoder = decoders.findIndices { it.handles(source, mimeType) }
         return checkNotNull(decoder) { "Unable to decode data. No decoder supports: $data" }
     }
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -66,7 +66,8 @@ import coil.util.ComponentCallbacks
 import coil.util.Emoji
 import coil.util.closeQuietly
 import coil.util.emoji
-import coil.util.firstNotNull
+import coil.util.firstNotNullIndices
+import coil.util.forEachIndices
 import coil.util.getValue
 import coil.util.isDiskPreload
 import coil.util.log
@@ -196,7 +197,7 @@ internal class RealImageLoader(
 
             // Check the memory cache.
             val cachedValue = takeIf(request.memoryCachePolicy.readEnabled) {
-                memoryCache.getValue(cacheKey) ?: request.aliasKeys.firstNotNull { memoryCache.getValue(it) }
+                memoryCache.getValue(cacheKey) ?: request.aliasKeys.firstNotNullIndices { memoryCache.getValue(it) }
             }
             val cachedDrawable = cachedValue?.bitmap?.toDrawable(context)
 
@@ -260,12 +261,12 @@ internal class RealImageLoader(
     @VisibleForTesting
     internal suspend inline fun mapData(data: Any, lazySizeResolver: LazySizeResolver): Any {
         var mappedData = data
-        for ((type, mapper) in registry.measuredMappers) {
+        registry.measuredMappers.forEachIndices { (type, mapper) ->
             if (type.isAssignableFrom(mappedData::class.java) && (mapper as MeasuredMapper<Any, *>).handles(mappedData)) {
                 mappedData = mapper.map(mappedData, lazySizeResolver.size())
             }
         }
-        for ((type, mapper) in registry.mappers) {
+        registry.mappers.forEachIndices { (type, mapper) ->
             if (type.isAssignableFrom(mappedData::class.java) && (mapper as Mapper<Any, *>).handles(mappedData)) {
                 mappedData = mapper.map(mappedData)
             }
@@ -296,7 +297,7 @@ internal class RealImageLoader(
             }
 
             if (transformations.isNotEmpty()) {
-                transformations.forEach { append('#').append(it.key()) }
+                transformations.forEachIndices { append('#').append(it.key()) }
 
                 // Append the size if there are any transformations.
                 append('#').append(lazySizeResolver.size())

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -212,7 +212,7 @@ class CrossfadeDrawable(
 
         state = STATE_RUNNING
         startTimeMillis = SystemClock.uptimeMillis()
-        callbacks.forEach { it.onAnimationStart(this) }
+        callbacks.forEachIndices { it.onAnimationStart(this) }
 
         invalidateSelf()
     }

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -69,6 +69,25 @@ internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
     }
 }
 
+/** Return the first non-null value returned by [transform]. Generate an index-based loop that doesn't use an [Iterator]. */
+internal inline fun <R, T> List<R>.firstNotNullIndices(transform: (R) -> T?): T? {
+    for (i in indices) {
+        transform(get(i))?.let { return it }
+    }
+    return null
+}
+
+/** Functionally the same as [Iterable.find] except it generates an index-based loop that doesn't use an [Iterator]. */
+internal inline fun <T> List<T>.findIndices(predicate: (T) -> Boolean): T? {
+    for (i in indices) {
+        val value = get(i)
+        if (predicate(value)) {
+            return value
+        }
+    }
+    return null
+}
+
 internal inline fun <T> MutableList<T>.removeLast(): T? = if (isNotEmpty()) removeAt(lastIndex) else null
 
 internal inline fun ActivityManager.isLowRawDeviceCompat(): Boolean {
@@ -225,11 +244,6 @@ internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY
 
 internal fun Request.isDiskPreload(): Boolean {
     return this is LoadRequest && target == null && !memoryCachePolicy.writeEnabled
-}
-
-internal inline fun <R, T> Iterable<R>.firstNotNull(transform: (R) -> T?): T? {
-    for (element in this) transform(element)?.let { return it }
-    return null
 }
 
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -184,7 +184,10 @@ class MovieDrawable(
 
         loopIteration = 0
         startTimeMillis = SystemClock.uptimeMillis()
-        callbacks.forEach { it.onAnimationStart(this) }
+
+        for (i in callbacks.indices) {
+            callbacks[i].onAnimationStart(this)
+        }
 
         invalidateSelf()
     }
@@ -193,7 +196,9 @@ class MovieDrawable(
         if (!isRunning) return
         isRunning = false
 
-        callbacks.forEach { it.onAnimationEnd(this) }
+        for (i in callbacks.indices) {
+            callbacks[i].onAnimationEnd(this)
+        }
     }
 
     override fun registerAnimationCallback(callback: Animatable2Compat.AnimationCallback) {


### PR DESCRIPTION
Kotlin typically allocates an `Iterator` to iterate through a list (https://kotlinlang.org/docs/reference/control-flow.html#for-loops). This unnecessary for `ArrayLists` where it's faster to iterate over them using an index.