### PR TITLE
Remove automatic scaling from CrossfadeDrawable.

### DIFF
--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -152,15 +152,15 @@ class CrossfadeDrawable(
         end?.let { updateBounds(it, bounds) }
     }
 
-    override fun onStateChange(state: IntArray): Boolean {
-        val startChanged = start?.setState(state) ?: false
-        val endChanged = end?.setState(state) ?: false
-        return startChanged || endChanged
-    }
-
     override fun onLevelChange(level: Int): Boolean {
         val startChanged = start?.setLevel(level) ?: false
         val endChanged = end?.setLevel(level) ?: false
+        return startChanged || endChanged
+    }
+
+    override fun onStateChange(state: IntArray): Boolean {
+        val startChanged = start?.setState(state) ?: false
+        val endChanged = end?.setState(state) ?: false
         return startChanged || endChanged
     }
 

--- a/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
+++ b/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
@@ -28,10 +28,10 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
@@ -46,10 +46,10 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 100, 100)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(0, 0, 100, 100), start.bounds)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(0, 0, 100, 100), end.bounds)
     }
 
@@ -64,10 +64,10 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 40, 100)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(0, 0, 40, 100), start.bounds)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(-42, 0, 82, 100), end.bounds)
     }
 
@@ -82,10 +82,10 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 200, 210)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(0, 73, 200, 137), start.bounds)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(60, 0, 140, 210), end.bounds)
     }
 
@@ -99,7 +99,7 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 40, 100)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(-42, 0, 82, 100), end.bounds)
     }
 
@@ -113,7 +113,7 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 200, 210)
 
-        assertEquals(1f, drawable.updateBounds(end, bounds))
+        drawable.updateBounds(end, bounds)
         assertEquals(Rect(60, 0, 140, 210), end.bounds)
     }
 
@@ -128,11 +128,11 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 40, 100)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(-21, 0, 61, 100), start.bounds)
 
-        assertEquals(1 / 3f, drawable.updateBounds(end, bounds))
-        assertEquals(Rect(-47, 0, 353, 300), end.bounds)
+        drawable.updateBounds(end, bounds)
+        assertEquals(Rect(-47, 0, 87, 100), end.bounds)
     }
 
     @Test
@@ -146,11 +146,11 @@ class CrossfadeDrawableTest {
 
         val bounds = Rect(0, 0, 200, 210)
 
-        assertEquals(1f, drawable.updateBounds(start, bounds))
+        drawable.updateBounds(start, bounds)
         assertEquals(Rect(0, 45, 200, 165), start.bounds)
 
-        assertEquals(0.4f, drawable.updateBounds(end, bounds))
-        assertEquals(Rect(0, 70, 500, 245), end.bounds)
+        drawable.updateBounds(end, bounds)
+        assertEquals(Rect(0, 70, 200, 140), end.bounds)
     }
 
     private class TestDrawable(

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -26,7 +26,7 @@ import kotlin.math.roundToInt
  */
 class ScaleDrawable(
     val child: Drawable,
-    private val scale: Scale
+    private val scale: Scale = Scale.FIT
 ) : Drawable(), Drawable.Callback, Animatable {
 
     private var childScale = 1f

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -19,7 +19,7 @@ import coil.size.Scale
 import kotlin.math.roundToInt
 
 /**
- * A [Drawable] that scales the [child] to fill its bounds.
+ * A [Drawable] that scales its [child] to fill its bounds.
  *
  * This allows drawables that only draw within their intrinsic dimensions
  * (e.g. [AnimatedImageDrawable]) to fill their entire bounds.

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -1,0 +1,119 @@
+package coil.drawable
+
+import android.content.res.ColorStateList
+import android.graphics.BlendMode
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.PorterDuff
+import android.graphics.Rect
+import android.graphics.drawable.Animatable
+import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build.VERSION_CODES.KITKAT
+import android.os.Build.VERSION_CODES.LOLLIPOP
+import android.os.Build.VERSION_CODES.Q
+import androidx.annotation.RequiresApi
+import androidx.core.graphics.withSave
+import coil.decode.DecodeUtils
+import coil.size.Scale
+import kotlin.math.roundToInt
+
+/**
+ * A [Drawable] that scales the [child] to fill its bounds.
+ *
+ * This allows drawables that only draw within their intrinsic dimensions
+ * (e.g. [AnimatedImageDrawable]) to fill their entire bounds.
+ */
+class ScaleDrawable(
+    val child: Drawable,
+    private val scale: Scale
+): Drawable(), Drawable.Callback, Animatable {
+
+    private var childScale = 1f
+
+    override fun draw(canvas: Canvas) {
+        canvas.withSave {
+            scale(childScale, childScale)
+            child.draw(this)
+        }
+    }
+
+    @RequiresApi(KITKAT)
+    override fun getAlpha() = child.alpha
+
+    override fun setAlpha(alpha: Int) {
+        child.alpha = alpha
+    }
+
+    @Suppress("DEPRECATION")
+    override fun getOpacity() = child.opacity
+
+    @RequiresApi(LOLLIPOP)
+    override fun getColorFilter() = child.colorFilter
+
+    @RequiresApi(LOLLIPOP)
+    override fun setColorFilter(colorFilter: ColorFilter?) {
+        child.colorFilter = colorFilter
+    }
+
+    override fun onBoundsChange(bounds: Rect) {
+        val width = child.intrinsicWidth
+        val height = child.intrinsicHeight
+        if (width <= 0 || height <= 0) {
+            child.bounds = bounds
+            childScale = 1f
+            return
+        }
+
+        val targetWidth = bounds.width()
+        val targetHeight = bounds.height()
+        val multiplier = DecodeUtils.computeSizeMultiplier(
+            srcWidth = width,
+            srcHeight = height,
+            destWidth = targetWidth,
+            destHeight = targetHeight,
+            scale = scale
+        )
+        val dx = ((targetWidth - multiplier * width) / 2).roundToInt()
+        val dy = ((targetHeight - multiplier * height) / 2).roundToInt()
+
+        val left = bounds.left + dx
+        val top = bounds.top + dy
+        val right = left + width
+        val bottom = top + height
+        child.setBounds(left, top, right, bottom)
+        childScale = multiplier.toFloat()
+    }
+
+    override fun getIntrinsicWidth() = child.intrinsicWidth
+
+    override fun getIntrinsicHeight() = child.intrinsicHeight
+
+    override fun unscheduleDrawable(who: Drawable, what: Runnable) = unscheduleSelf(what)
+
+    override fun invalidateDrawable(who: Drawable) = invalidateSelf()
+
+    override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) = scheduleSelf(what, `when`)
+
+    @RequiresApi(LOLLIPOP)
+    override fun setTint(tintColor: Int) = child.setTint(tintColor)
+
+    @RequiresApi(LOLLIPOP)
+    override fun setTintList(tint: ColorStateList?) = child.setTintList(tint)
+
+    @RequiresApi(LOLLIPOP)
+    override fun setTintMode(tintMode: PorterDuff.Mode?) = child.setTintMode(tintMode)
+
+    @RequiresApi(Q)
+    override fun setTintBlendMode(blendMode: BlendMode?) = child.setTintBlendMode(blendMode)
+
+    override fun isRunning() = if (child is Animatable) child.isRunning else false
+
+    override fun start() {
+        if (child is Animatable) child.start()
+    }
+
+    override fun stop() {
+        if (child is Animatable) child.stop()
+    }
+}

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -27,7 +27,7 @@ import kotlin.math.roundToInt
 class ScaleDrawable(
     val child: Drawable,
     private val scale: Scale
-): Drawable(), Drawable.Callback, Animatable {
+) : Drawable(), Drawable.Callback, Animatable {
 
     private var childScale = 1f
 

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -85,6 +85,10 @@ class ScaleDrawable(
         childScale = multiplier.toFloat()
     }
 
+    override fun onLevelChange(level: Int) = child.setLevel(level)
+
+    override fun onStateChange(state: IntArray) = child.setState(state)
+
     override fun getIntrinsicWidth() = child.intrinsicWidth
 
     override fun getIntrinsicHeight() = child.intrinsicHeight


### PR DESCRIPTION
`CrossfadeDrawable` will no longer automatically scale its children. `BitmapDrawable` and `MovieDrawable` already do this automatically. Create `ScaleDrawable` to wrap `AnimatedImageDrawable` to keep the behaviour consistent.