### PR TITLE
Check if view is attached to window before checking hwAcceleration

### DIFF
--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -142,7 +142,7 @@ internal class RequestService {
         if (!request.allowHardware) return false
 
         // Prevent hardware bitmaps for non-hardware accelerated targets.
-        if (request.target.run { this is ViewTarget<*> && !view.isHardwareAccelerated }) return false
+        if (request.target.run { this is ViewTarget<*> && (!view.isAttachedToWindow || !view.isHardwareAccelerated) }) return false
 
         return true
     }


### PR DESCRIPTION
I've been able to reproduce the issue *sometimes* which led me to believe this is some kind of a race condition in checking the hw acceleration capabilities for which we need the View to be attached to the window. To be safe, I now check if we're attached to window before checking for the HW acceleration.

Please test and let me know if this works for you.

Signed-off-by: Mario Danic <mario@lovelyhq.com>