### PR TITLE
Improve Java compatibility.

### DIFF
--- a/coil-base/src/main/java/coil/bitmappool/BitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmappool/BitmapPool.kt
@@ -16,6 +16,8 @@ interface BitmapPool {
          *
          * @param maxSize The maximum size of the pool in bytes.
          */
+        @JvmStatic
+        @JvmName("create")
         operator fun invoke(maxSize: Long): BitmapPool = RealBitmapPool(maxSize)
     }
 

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -32,7 +32,7 @@ import kotlin.math.roundToInt
  * @param scale The scaling algorithm for [start] and [end].
  * @param durationMillis The duration of the crossfade animation.
  */
-class CrossfadeDrawable(
+class CrossfadeDrawable @JvmOverloads constructor(
     private var start: Drawable?,
     val end: Drawable?,
     val scale: Scale = Scale.FIT,

--- a/coil-base/src/main/java/coil/size/Scale.kt
+++ b/coil-base/src/main/java/coil/size/Scale.kt
@@ -21,6 +21,8 @@ enum class Scale {
     /**
      * Fit the image to the view so that both dimensions (width and height) of the image will be **equal to or less than**
      * the corresponding dimension of the view.
+     *
+     * Generally, this is treated as the default value for functions that accept a [Scale].
      */
     FIT
 }

--- a/coil-base/src/main/java/coil/size/Scale.kt
+++ b/coil-base/src/main/java/coil/size/Scale.kt
@@ -22,7 +22,7 @@ enum class Scale {
      * Fit the image to the view so that both dimensions (width and height) of the image will be **equal to or less than**
      * the corresponding dimension of the view.
      *
-     * Generally, this is treated as the default value for functions that accept a [Scale].
+     * Generally, this is the default value for functions that accept a [Scale].
      */
     FIT
 }

--- a/coil-base/src/main/java/coil/size/SizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/SizeResolver.kt
@@ -12,6 +12,8 @@ interface SizeResolver {
 
     companion object {
         /** Construct a [SizeResolver] instance with a fixed [size]. */
+        @JvmStatic
+        @JvmName("create")
         operator fun invoke(size: Size): SizeResolver {
             return object : SizeResolver {
                 override suspend fun size() = size

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -22,7 +22,6 @@ interface ViewSizeResolver<T : View> : SizeResolver {
          * @param subtractPadding If true, the [view]'s padding will be subtracted from its size.
          */
         @JvmStatic
-        @JvmOverloads
         @JvmName("create")
         operator fun <T : View> invoke(
             view: T,

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -21,6 +21,9 @@ interface ViewSizeResolver<T : View> : SizeResolver {
          * @param view The [View] to measure.
          * @param subtractPadding If true, the [view]'s padding will be subtracted from its size.
          */
+        @JvmStatic
+        @JvmOverloads
+        @JvmName("create")
         operator fun <T : View> invoke(
             view: T,
             subtractPadding: Boolean = true

--- a/coil-base/src/main/java/coil/transform/BlurTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/BlurTransformation.kt
@@ -24,7 +24,7 @@ import coil.size.Size
  *  will downscale the image. Values between 0 and 1 will upscale the image.
  */
 @RequiresApi(JELLY_BEAN_MR2)
-class BlurTransformation(
+class BlurTransformation @JvmOverloads constructor(
     private val context: Context,
     private val radius: Float = DEFAULT_RADIUS,
     private val sampling: Float = DEFAULT_SAMPLING

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -16,7 +16,7 @@ import kotlin.coroutines.resume
 
 /** A [Transition] that crossfades from the current drawable to a new one. */
 @ExperimentalCoil
-class CrossfadeTransition(
+class CrossfadeTransition @JvmOverloads constructor(
     val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION
 ) : Transition {
 

--- a/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/ScaleDrawable.kt
@@ -24,7 +24,7 @@ import kotlin.math.roundToInt
  * This allows drawables that only draw within their intrinsic dimensions
  * (e.g. [AnimatedImageDrawable]) to fill their entire bounds.
  */
-class ScaleDrawable(
+class ScaleDrawable @JvmOverloads constructor(
     val child: Drawable,
     private val scale: Scale = Scale.FIT
 ) : Drawable(), Drawable.Callback, Animatable {


### PR DESCRIPTION
This improves the public API for Java callers. For instance `BitmapPool.Companion.invoke(1024)` becomes `BitmapPool.create(1024)`. No changes to the Kotlin API.