### PR TITLE
Add LG devices to hardware blacklist.

### DIFF
--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -114,6 +114,17 @@ private object HardwareBitmapBlacklist {
                 model.startsWith("moto g(6)", true)) return@run true
         }
 
+        if (SDK_INT == O_MR1) {
+            // LG Stylo 4 (Boost/Sprint)
+            if (model == "LG-Q710AL") return@run true
+
+            // LG Tribute Empire
+            if (model == "LM-X220PM") return@run true
+
+            // LG K11
+            if (model.startsWith("LM-X410")) return@run true
+        }
+
         return@run false
     }
 }


### PR DESCRIPTION
These devices crash if you call `Bitmap.copy` where either the input or output bitmap configs are `Bitmap.Config.HARDWARE`. Coil doesn't use `Bitmap.copy`, but better to disable this in case a user tries to copy one of Coil's bitmaps.

Confirmed manually on a test `LG Stylo 4`.