### PR TITLE
Deprecate DSL syntax in favour of Builder syntax.

### DIFF
--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -202,8 +202,8 @@ class RealImageLoaderIntegrationTest {
 
     @Test
     fun memoryCacheDisabled_preloadDoesNotDecode() {
-        val imageLoader = ImageLoader(context) {
-            componentRegistry {
+        val imageLoader = ImageLoader.Builder(context)
+            .componentRegistry {
                 add(object : Decoder {
                     override fun handles(source: BufferedSource, mimeType: String?) = true
 
@@ -215,7 +215,7 @@ class RealImageLoaderIntegrationTest {
                     ) = throw IllegalStateException("Decode should not be called.")
                 })
             }
-        }
+            .build()
 
         val url = server.url(IMAGE_NAME)
         val cacheFolder = Utils.getDefaultCacheDirectory(context).apply {
@@ -245,8 +245,8 @@ class RealImageLoaderIntegrationTest {
     @Test
     fun memoryCacheDisabled_getDoesDecode() {
         var numDecodes = 0
-        val imageLoader = ImageLoader(context) {
-            componentRegistry {
+        val imageLoader = ImageLoader.Builder(context)
+            .componentRegistry {
                 add(object : Decoder {
                     private val delegate = BitmapFactoryDecoder(context)
 
@@ -263,7 +263,7 @@ class RealImageLoaderIntegrationTest {
                     }
                 })
             }
-        }
+            .build()
 
         val url = server.url(IMAGE_NAME)
         val cacheFolder = Utils.getDefaultCacheDirectory(context).apply {

--- a/coil-base/src/main/java/coil/ComponentRegistry.kt
+++ b/coil-base/src/main/java/coil/ComponentRegistry.kt
@@ -24,22 +24,23 @@ class ComponentRegistry private constructor(
     internal val decoders: List<Decoder>
 ) {
 
+    constructor() : this(emptyList(), emptyList(), emptyList(), emptyList())
+
     companion object {
-        /**
-         * Create a new [ComponentRegistry] instance.
-         *
-         * Example:
-         * ```
-         * val registry = ComponentRegistry {
-         *     add(GifDecoder())
-         * }
-         * ```
-         */
+        /** Create a new [ComponentRegistry] instance. */
+        @Deprecated(
+            message = "Use ComponentRegistry.Builder to create new instances.",
+            replaceWith = ReplaceWith("ComponentRegistry.Builder().apply(builder).build()")
+        )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}
         ): ComponentRegistry = Builder().apply(builder).build()
 
         /** Create a new [ComponentRegistry] instance. */
+        @Deprecated(
+            message = "Use ComponentRegistry.Builder to create new instances.",
+            replaceWith = ReplaceWith("ComponentRegistry.Builder(registry).apply(builder).build()")
+        )
         inline operator fun invoke(
             registry: ComponentRegistry,
             builder: Builder.() -> Unit = {}

--- a/coil-base/src/main/java/coil/ComponentRegistry.kt
+++ b/coil-base/src/main/java/coil/ComponentRegistry.kt
@@ -30,7 +30,8 @@ class ComponentRegistry private constructor(
         /** Create a new [ComponentRegistry] instance. */
         @Deprecated(
             message = "Use ComponentRegistry.Builder to create new instances.",
-            replaceWith = ReplaceWith("ComponentRegistry.Builder().apply(builder).build()")
+            replaceWith = ReplaceWith("ComponentRegistry.Builder().apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}
@@ -39,7 +40,8 @@ class ComponentRegistry private constructor(
         /** Create a new [ComponentRegistry] instance. */
         @Deprecated(
             message = "Use ComponentRegistry.Builder to create new instances.",
-            replaceWith = ReplaceWith("ComponentRegistry.Builder(registry).apply(builder).build()")
+            replaceWith = ReplaceWith("ComponentRegistry.Builder(registry).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             registry: ComponentRegistry,

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE")
+
 package coil
 
 import android.content.Context
@@ -14,17 +16,21 @@ import coil.target.Target
 interface ImageLoader {
 
     companion object {
-        /**
-         * Create a new [ImageLoader] instance.
-         *
-         * Example:
-         * ```
-         * val loader = ImageLoader(context) {
-         *     availableMemoryPercentage(0.5)
-         *     crossfade(true)
-         * }
-         * ```
-         */
+        /** Alias function to create an [ImageLoaderBuilder]. */
+        @JvmStatic
+        @JvmName("builder")
+        inline fun Builder(context: Context) = ImageLoaderBuilder(context)
+
+        /** Convenience function to create a new [ImageLoader] without configuration */
+        @JvmStatic
+        @JvmName("create")
+        inline operator fun invoke(context: Context) = ImageLoaderBuilder(context).build()
+
+        /** Create a new [ImageLoader] instance. */
+        @Deprecated(
+            message = "Use ImageLoader.Builder to create new instances.",
+            replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()")
+        )
         inline operator fun invoke(
             context: Context,
             builder: ImageLoaderBuilder.() -> Unit = {}

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -29,7 +29,8 @@ interface ImageLoader {
         /** Create a new [ImageLoader] instance. */
         @Deprecated(
             message = "Use ImageLoader.Builder to create new instances.",
-            replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()")
+            replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             context: Context,

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -16,12 +16,12 @@ import coil.target.Target
 interface ImageLoader {
 
     companion object {
-        /** Alias function to create an [ImageLoaderBuilder]. */
+        /** Alias to create an [ImageLoaderBuilder]. */
         @JvmStatic
         @JvmName("builder")
         inline fun Builder(context: Context) = ImageLoaderBuilder(context)
 
-        /** Convenience function to create a new [ImageLoader] without configuration */
+        /** Alias to create a new [ImageLoader] without configuration */
         @JvmStatic
         @JvmName("create")
         inline operator fun invoke(context: Context) = ImageLoaderBuilder(context).build()

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -94,7 +94,7 @@ class ImageLoaderBuilder(private val context: Context) {
      */
     inline fun componentRegistry(
         builder: ComponentRegistry.Builder.() -> Unit
-    ) = componentRegistry(ComponentRegistry(builder))
+    ) = componentRegistry(ComponentRegistry.Builder().apply(builder).build())
 
     /**
      * Set the [ComponentRegistry].

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -20,7 +20,8 @@ class Parameters private constructor(
         /** Create a new [Parameters] instance. */
         @Deprecated(
             message = "Use Parameters.Builder to create new instances.",
-            replaceWith = ReplaceWith("Parameters.Builder().apply(builder).build()")
+            replaceWith = ReplaceWith("Parameters.Builder().apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -11,11 +11,17 @@ class Parameters private constructor(
     private val map: SortedMap<String, Entry>
 ) : Iterable<Pair<String, Parameters.Entry>> {
 
+    constructor() : this(sortedMapOf())
+
     companion object {
         @JvmField
         val EMPTY = Parameters()
 
         /** Create a new [Parameters] instance. */
+        @Deprecated(
+            message = "Use Parameters.Builder to create new instances.",
+            replaceWith = ReplaceWith("Parameters.Builder().apply(builder).build()")
+        )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}
         ): Parameters = Builder().apply(builder).build()

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -163,7 +163,8 @@ class LoadRequest internal constructor(
         /** Create a new [LoadRequest] instance. */
         @Deprecated(
             message = "Use LoadRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("LoadRequest.Builder(context, defaults).apply(builder).build()")
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, defaults).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             context: Context,
@@ -174,7 +175,8 @@ class LoadRequest internal constructor(
         /** Create a new [LoadRequest] instance. */
         @Deprecated(
             message = "Use LoadRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("LoadRequest.Builder(context, request).apply(builder).build()")
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, request).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             context: Context,
@@ -257,7 +259,8 @@ class GetRequest internal constructor(
         /** Create a new [GetRequest] instance. */
         @Deprecated(
             message = "Use GetRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()")
+            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             defaults: DefaultRequestOptions,
@@ -267,7 +270,8 @@ class GetRequest internal constructor(
         /** Create a new [GetRequest] instance. */
         @Deprecated(
             message = "Use GetRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()")
+            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()"),
+            level = DeprecationLevel.HIDDEN
         )
         inline operator fun invoke(
             request: GetRequest,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -1,4 +1,4 @@
-@file:Suppress("unused")
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE", "unused")
 @file:UseExperimental(ExperimentalCoil::class)
 
 package coil.request
@@ -108,11 +108,11 @@ sealed class Request {
  *
  * Or instances can be created separately from the call that executes them:
  * ```
- * val request = LoadRequest(context, imageLoader.defaults) {
- *     data("https://www.example.com/image.jpg")
- *     crossfade(true)
- *     target(imageView)
- * }
+ * val request = LoadRequest.Builder(context, imageLoader.defaults)
+ *     .data("https://www.example.com/image.jpg")
+ *     .crossfade(true)
+ *     .target(imageView)
+ *     .build()
  * imageLoader.load(request)
  * ```
  *
@@ -152,7 +152,19 @@ class LoadRequest internal constructor(
 ) : Request() {
 
     companion object {
+        @JvmStatic
+        @JvmName("builder")
+        inline fun Builder(context: Context, defaults: DefaultRequestOptions) = LoadRequestBuilder(context, defaults)
+
+        @JvmStatic
+        @JvmName("builder")
+        inline fun Builder(context: Context, request: LoadRequest) = LoadRequestBuilder(context, request)
+
         /** Create a new [LoadRequest] instance. */
+        @Deprecated(
+            message = "Use LoadRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, defaults).apply(builder).build()")
+        )
         inline operator fun invoke(
             context: Context,
             defaults: DefaultRequestOptions,
@@ -160,6 +172,10 @@ class LoadRequest internal constructor(
         ): LoadRequest = LoadRequestBuilder(context, defaults).apply(builder).build()
 
         /** Create a new [LoadRequest] instance. */
+        @Deprecated(
+            message = "Use LoadRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, request).apply(builder).build()")
+        )
         inline operator fun invoke(
             context: Context,
             request: LoadRequest,
@@ -197,10 +213,10 @@ class LoadRequest internal constructor(
  *
  * Or instances can be created separately from the call that executes them:
  * ```
- * val request = GetRequest(imageLoader.defaults) {
- *     data("https://www.example.com/image.jpg")
- *     size(1080, 1920)
- * }
+ * val request = GetRequest.Builder(imageLoader.defaults)
+ *     .data("https://www.example.com/image.jpg")
+ *     .size(1080, 1920)
+ *     .build()
  * imageLoader.get(request)
  * ```
  *
@@ -230,13 +246,29 @@ class GetRequest internal constructor(
 ) : Request() {
 
     companion object {
+        @JvmStatic
+        @JvmName("builder")
+        inline fun Builder(defaults: DefaultRequestOptions) = GetRequestBuilder(defaults)
+
+        @JvmStatic
+        @JvmName("builder")
+        inline fun Builder(request: GetRequest) = GetRequestBuilder(request)
+
         /** Create a new [GetRequest] instance. */
+        @Deprecated(
+            message = "Use GetRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()")
+        )
         inline operator fun invoke(
             defaults: DefaultRequestOptions,
             builder: GetRequestBuilder.() -> Unit = {}
         ): GetRequest = GetRequestBuilder(defaults).apply(builder).build()
 
         /** Create a new [GetRequest] instance. */
+        @Deprecated(
+            message = "Use GetRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()")
+        )
         inline operator fun invoke(
             request: GetRequest,
             builder: GetRequestBuilder.() -> Unit = {}
@@ -244,15 +276,10 @@ class GetRequest internal constructor(
     }
 
     override val target: Target? = null
-
     override val lifecycle: Lifecycle? = null
-
     override val transition: Transition? = null
-
     override val placeholder: Drawable? = null
-
     override val error: Drawable? = null
-
     override val fallback: Drawable? = null
 
     /** Create a new [GetRequestBuilder] instance using this as a base. */

--- a/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
@@ -16,13 +16,13 @@ class RequestBuilderTest {
     /** Regression test: https://github.com/coil-kt/coil/issues/221 */
     @Test
     fun `crossfade false creates no transition`() {
-        val loader = ImageLoader(context) {
-            crossfade(false)
-        }
+        val loader = ImageLoader.Builder(context)
+            .crossfade(false)
+            .build()
 
-        val request = LoadRequest(context, loader.defaults) {
-            crossfade(false)
-        }
+        val request = LoadRequest.Builder(context, loader.defaults)
+            .crossfade(false)
+            .build()
 
         assertNull(request.transition)
 

--- a/coil-gif/README.md
+++ b/coil-gif/README.md
@@ -11,15 +11,15 @@ implementation("io.coil-kt:coil-gif:0.9.5")
 And add the decoders to your component registry when constructing your `ImageLoader`:
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    componentRegistry {
+val imageLoader = ImageLoader.Builder(context)
+    .componentRegistry {
         if (SDK_INT >= P) {
             add(ImageDecoderDecoder())
         } else {
             add(GifDecoder())
         }
     }
-}
+    .build()
 ```
 
 And that's it! The `ImageLoader` will automatically detect any GIFs using their file headers and decode them correctly.

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -26,10 +26,10 @@ class Application : MultiDexApplication() {
     }
 
     private fun buildDefaultImageLoader(): ImageLoader {
-        return ImageLoader(applicationContext) {
-            availableMemoryPercentage(0.5) // Use 50% of the application's available memory.
-            crossfade(true) // Show a short crossfade when loading images from network or disk into an ImageView.
-            componentRegistry {
+        return ImageLoader.Builder(this)
+            .availableMemoryPercentage(0.5) // Use 50% of the application's available memory.
+            .crossfade(true) // Show a short crossfade when loading images from network or disk.
+            .componentRegistry {
                 // Fetchers
                 add(VideoFrameFileFetcher(applicationContext))
                 add(VideoFrameUriFetcher(applicationContext))
@@ -40,9 +40,9 @@ class Application : MultiDexApplication() {
                 } else {
                     add(GifDecoder())
                 }
-                add(SvgDecoder(applicationContext))
+                add(SvgDecoder(this@Application))
             }
-            okHttpClient {
+            .okHttpClient {
                 // Create a disk cache with "unlimited" size. Don't do this in production.
                 // To create the an optimized Coil disk cache, use CoilUtils.createDefaultCache(context).
                 val cacheDirectory = File(filesDir, "image_cache").apply { mkdirs() }
@@ -58,6 +58,6 @@ class Application : MultiDexApplication() {
                     .addNetworkInterceptor(cacheControlInterceptor)
                     .build()
             }
-        }
+            .build()
     }
 }

--- a/coil-svg/README.md
+++ b/coil-svg/README.md
@@ -9,11 +9,11 @@ implementation("io.coil-kt:coil-svg:0.9.5")
 And add the decoder to your component registry when constructing your `ImageLoader`:
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    componentRegistry {
+val imageLoader = ImageLoader.Builder(context)
+    .componentRegistry {
         add(SvgDecoder())
     }
-}
+    .build()
 ```
 
 And that's it! The `ImageLoader` will automatically detect any SVGs and decode them correctly.

--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -9,12 +9,12 @@ implementation("io.coil-kt:coil-video:0.10.0-SNAPSHOT")
 And add the two fetchers to your component registry when constructing your `ImageLoader`:
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    componentRegistry {
-        add(VideoFrameFileFetcher())
-        add(VideoFrameUriFetcher())
+val imageLoader = ImageLoader.Builder(context)
+    .componentRegistry {
+         add(VideoFrameFileFetcher())
+         add(VideoFrameUriFetcher())
     }
-}
+    .build()
 ```
 
 !!! Note

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -72,14 +72,14 @@ If you're using the `io.coil-kt:coil` artifact, you can set a default [ImageLoad
 
 ```kotlin
 Coil.setDefaultImageLoader {
-    ImageLoader(context) {
-        crossfade(true)
-        okHttpClient {
+    ImageLoader.Builder(context)
+        .crossfade(true)
+        .okHttpClient {
             OkHttpClient.Builder()
                 .cache(CoilUtils.createDefaultCache(context))
                 .build()
         }
-    }
+        .build()
 }
 ```
 

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -8,7 +8,7 @@ New instances can be created like so:
 val imageLoader = ImageLoader(context)
 ```
 
-Similar to [Requests](requests.md), `ImageLoader`s can be configured with an optional trailing lambda param:
+Similar to [Requests](requests.md), `ImageLoader`s can be configured by using a builder:
 
 ```kotlin
 val imageLoader = ImageLoader.Builder(context)

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -11,11 +11,11 @@ val imageLoader = ImageLoader(context)
 Similar to [Requests](requests.md), `ImageLoader`s can be configured with an optional trailing lambda param:
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    availableMemoryPercentage(0.5)
-    bitmapPoolPercentage(0.5)
-    crossfade(true)
-}
+val imageLoader = ImageLoader.Builder(context)
+    .availableMemoryPercentage(0.5)
+    .bitmapPoolPercentage(0.5)
+    .crossfade(true)
+    .build()
 ```
 
 Internally, this constructs a `RealImageLoader` using [ImageLoaderBuilder](../api/coil-base/coil/-image-loader-builder).
@@ -31,13 +31,13 @@ Coil relies on `OkHttpClient` to handle disk caching. **By default, every `Image
 However, if you set a custom `OkHttpClient`, you'll need to add the disk cache yourself. To get a `Cache` instance that's optimized for Coil, you can use [`CoilUtils.createDefaultCache`](../api/coil-base/coil.util/-coil-utils/create-default-cache/). Optionally, you can create your own `Cache` instance with a different size + location. Here's an example:
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    okHttpClient {
+val imageLoader = ImageLoader.Builder(context)
+    .okHttpClient {
         OkHttpClient.Builder()
             .cache(CoilUtils.createDefaultCache(context))
             .build()
     }
-}
+    .build()
 ```
 
 ## Singleton vs. Dependency Injection

--- a/docs/image_pipeline.md
+++ b/docs/image_pipeline.md
@@ -7,13 +7,13 @@ Fortunately, [ImageLoaders](image_loaders.md) support pluggable components to ad
 Custom components must be added to the `ImageLoader` when constructing it through its [ComponentRegistry](../api/coil-base/coil/-component-registry):
 
 ```kotlin
-val imageLoader = ImageLoader(context) {
-    componentRegistry {
+val imageLoader = ImageLoader.Builder(context)
+    .componentRegistry {
         add(ItemMapper())
         add(ProtocolBufferFetcher())
         add(GifDecoder())
     }
-}
+    .build()
 ```
 
 ## Mappers

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -2,19 +2,10 @@
 
 Requests are [value objects](https://publicobject.com/2019/06/10/value-objects-service-objects-and-glue/) that provide all the necessary information for an [ImageLoader](image_loaders.md) to execute an image request.
 
-Requests can be created a number of ways. This simplest way is to use the trailing lambda syntax:
+Requests can be created using a builder:
 
 ```kotlin
-val request = LoadRequest(context, imageLoader.defaults) {
-    data("https://www.example.com/image.jpg")
-    crossfade(true)
-}
-```
-
-Requests can also be created using typical builder syntax. This works best for Java:
-
-```kotlin
-val request = imageLoader.newLoadBuilder(context)
+val request = LoadRequest.Builder(context, imageLoader.defaults)
     .data("https://www.example.com/image.jpg")
     .crossfade(true)
     .build()


### PR DESCRIPTION
Looking for feedback on this!

TLDR:

```kotlin
val loader = ImageLoader(context) {
    availableMemoryPercentage(0.5)
    crossfade(true)
    componentRegistry {
        if (SDK_INT >= P) {
            add(ImageDecoderDecoder())
        } else {
            add(GifDecoder())
        }
        add(SvgDecoder(context))
    }
}
```

is becoming this:

```kotlin
val loader = ImageLoader.Builder(context)
    .availableMemoryPercentage(0.5)
    .crossfade(true)
    .componentRegistry {
        if (SDK_INT >= P) {
            add(ImageDecoderDecoder())
        } else {
            add(GifDecoder())
        }
        add(SvgDecoder(context))
    }
    .build()
```

When I started Coil I wanted to experiment with DSLs since I thought they could replace builders in Kotlin. Since then I've come to the opinion that DSLs are great, but they don't always replace builders:

- DSLs are best if you need to describe document structure/ordering of elements (e.g. [HTML DSL](https://github.com/Kotlin/kotlinx.html), [Jetpack Compose](https://developer.android.com/jetpack/compose)). Coil's DSL isn't ordered.

- DSLs mix the receiver's scope with the current scope. This means IDE autocomplete is slower as the set of available functions is much larger. It's also less clear what functions are part of the builder and what functions are part of the outer scope. Chaining functions on a builder is a much smaller scope with less functions.

- DSLs are designed to create a single instance. Builders are factories. Eventually, I'd like to get to a point where it's possible to share MemoryCaches and BitmapPools between `ImageLoader` instances similar to OkHttp's [`newBuilder`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#customize-your-client-with-newbuilder). A DSL syntax doesn't support this well.

- Builders are compatible with Java.

- Consumers can still create extension functions on top of the builder if they prefer the DSL.

Also Google, Square, Facebook, et al. continue to use builders in Kotlin - likely for some of these reasons.

~TODO: Update the docs.~