### PR TITLE
Fix case where GIFs and SVGs would not fill bounds.

### DIFF
--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -22,7 +22,6 @@ import coil.bitmappool.BitmapPool
 import coil.decode.DecodeUtils
 import coil.decode.ImageDecoderDecoder
 import coil.size.Scale
-import kotlin.math.ceil
 
 /**
  * A [Drawable] that supports rendering [Movie]s (i.e. GIFs).
@@ -149,25 +148,27 @@ class MovieDrawable(
         if (currentBounds == bounds) return
         currentBounds = bounds
 
-        val boundsWidth = bounds.width().toFloat()
-        val boundsHeight = bounds.height().toFloat()
+        val boundsWidth = bounds.width()
+        val boundsHeight = bounds.height()
 
-        val movieWidth = movie.width().toFloat()
-        val movieHeight = movie.height().toFloat()
-        if (movieWidth <= 0f || movieHeight <= 0f) return
+        // If width/height are not positive, we're unable to draw the movie.
+        val movieWidth = movie.width()
+        val movieHeight = movie.height()
+        if (movieWidth <= 0 || movieHeight <= 0) return
 
         softwareScale = DecodeUtils
             .computeSizeMultiplier(movieWidth, movieHeight, boundsWidth, boundsHeight, scale)
+            .toFloat()
             .coerceAtMost(1f)
-        val bitmapWidth = ceil(softwareScale * movieWidth)
-        val bitmapHeight = ceil(softwareScale * movieHeight)
+        val bitmapWidth = (softwareScale * movieWidth).toInt()
+        val bitmapHeight = (softwareScale * movieHeight).toInt()
 
-        val bitmap = pool.get(bitmapWidth.toInt(), bitmapHeight.toInt(), config)
+        val bitmap = pool.get(bitmapWidth, bitmapHeight, config)
         softwareBitmap?.let(pool::put)
         softwareBitmap = bitmap
         softwareCanvas = Canvas(bitmap)
 
-        hardwareScale = DecodeUtils.computeSizeMultiplier(bitmapWidth, bitmapHeight, boundsWidth, boundsHeight, scale)
+        hardwareScale = DecodeUtils.computeSizeMultiplier(bitmapWidth, bitmapHeight, boundsWidth, boundsHeight, scale).toFloat()
         hardwareDx = bounds.left + (boundsWidth - hardwareScale * bitmapWidth) / 2
         hardwareDy = bounds.top + (boundsHeight - hardwareScale * bitmapHeight) / 2
     }

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -14,7 +14,6 @@ import coil.size.PixelSize
 import coil.size.Size
 import com.caverock.androidsvg.SVG
 import okio.BufferedSource
-import kotlin.math.ceil
 
 /**
  * A [Decoder] that uses [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) to decode SVG files.
@@ -51,8 +50,8 @@ class SvgDecoder(private val context: Context) : Decoder {
                         destHeight = size.height.toFloat(),
                         scale = options.scale
                     )
-                    bitmapWidth = ceil(multiplier * svgWidth).toInt()
-                    bitmapHeight = ceil(multiplier * svgHeight).toInt()
+                    bitmapWidth = (multiplier * svgWidth).toInt()
+                    bitmapHeight = (multiplier * svgHeight).toInt()
                 } else {
                     bitmapWidth = size.width
                     bitmapHeight = size.height
@@ -60,8 +59,8 @@ class SvgDecoder(private val context: Context) : Decoder {
             }
             is OriginalSize -> {
                 if (svgWidth > 0 && svgHeight > 0) {
-                    bitmapWidth = ceil(svgWidth).toInt()
-                    bitmapHeight = ceil(svgHeight).toInt()
+                    bitmapWidth = svgWidth.toInt()
+                    bitmapHeight = svgHeight.toInt()
                 } else {
                     bitmapWidth = DEFAULT_SIZE
                     bitmapHeight = DEFAULT_SIZE


### PR DESCRIPTION
`bitmapWidth` and `bitmapHeight` in `MovieDrawable` and `SvgDecoder` need to be rounded down instead of up to ensure that we draw over the full dimensions of the bitmap instead of the bitmap's dimensions -1.

Here's what it could look like before the fix (note the white borders between GIFs):
![screen](https://user-images.githubusercontent.com/5580160/73599349-485eba80-44f7-11ea-8092-c7c6888b7451.png)
