### PR TITLE
Tweak logic for determining if a cached bitmap's config is valid.

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -349,17 +349,13 @@ internal class RealImageLoader(
         val cachedConfig = bitmap.config.normalize()
         val requestedConfig = request.bitmapConfig.normalize()
 
-        // Allow returning a bitmap with an equal or greater config.
-        if (cachedConfig >= requestedConfig) {
+        // Allow returning a cached RGB_565 bitmap if allowRgb565 is enabled.
+        if (request.allowRgb565 && cachedConfig == Bitmap.Config.RGB_565) {
             return true
         }
 
-        // Allow returning a lesser RGB_565 bitmap if enabled.
-        if (request.allowRgb565 && cachedConfig == Bitmap.Config.RGB_565 && requestedConfig != Bitmap.Config.ALPHA_8) {
-            return true
-        }
-
-        return false
+        // Ensure the cached config matches the request config (after normalization).
+        return cachedConfig == requestedConfig
     }
 
     /** Load the [data] as a [Drawable]. Apply any [Transformation]s. */

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -355,7 +355,7 @@ internal class RealImageLoader(
         }
 
         // Allow returning a lesser RGB_565 bitmap if enabled.
-        if (request.allowRgb565 && cachedConfig == Bitmap.Config.RGB_565 && requestedConfig == Bitmap.Config.ARGB_8888) {
+        if (request.allowRgb565 && cachedConfig == Bitmap.Config.RGB_565 && requestedConfig != Bitmap.Config.ALPHA_8) {
             return true
         }
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -354,7 +354,7 @@ internal class RealImageLoader(
             return true
         }
 
-        // Ensure the cached config matches the request config (after normalization).
+        // The cached bitmap is valid if its config matches the requested config.
         return cachedConfig == requestedConfig
     }
 

--- a/coil-base/src/main/java/coil/bitmappool/RealBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmappool/RealBitmapPool.kt
@@ -139,7 +139,7 @@ internal class RealBitmapPool(
     }
 
     /**
-     * Setting these two values provides Bitmaps that are essentially
+     * Setting these two values provides bitmaps that are essentially
      * equivalent to those returned from [Bitmap.createBitmap].
      */
     private fun normalize(bitmap: Bitmap) {

--- a/coil-base/src/main/java/coil/bitmappool/strategy/SizeStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmappool/strategy/SizeStrategy.kt
@@ -14,7 +14,7 @@ import java.util.TreeMap
  * A strategy for reusing bitmaps that relies on [Bitmap.reconfigure].
  *
  * Keys [Bitmap]s using [Bitmap.getAllocationByteCountCompat].
- * This improves the hit rate over [SizeConfigStrategy], as it allows re-use of Bitmaps with different configs.
+ * This improves the hit rate over [SizeConfigStrategy], as it allows re-use of bitmaps with different configs.
  *
  * Technically, the APIs for this strategy are available since [KITKAT], however we shouldn't use this strategy until
  * [M] due to framework bugs.

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -62,7 +62,7 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
         val srcWidth = if (isSwapped) outHeight else outWidth
         val srcHeight = if (isSwapped) outWidth else outHeight
 
-        // Disable hardware Bitmaps if we need to perform EXIF transformations.
+        // Disable hardware bitmaps if we need to perform EXIF transformations.
         val safeConfig = if (isFlipped || isRotated) options.config.normalize() else options.config
         inPreferredConfig = if (allowRgb565(options.allowRgb565, safeConfig, outMimeType)) Bitmap.Config.RGB_565 else safeConfig
 
@@ -129,7 +129,7 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
                 }
             }
             else -> {
-                // We can only re-use Bitmaps that exactly match the size of the image.
+                // We can only re-use bitmaps that exactly match the size of the image.
                 if (inMutable) {
                     inBitmap = pool.getDirtyOrNull(outWidth, outHeight, inPreferredConfig)
                 }

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -19,7 +19,8 @@ import okhttp3.Headers
  * @param scale The scaling algorithm for how to fit the source image's dimensions into the target's dimensions.
  * @param allowInexactSize True if the output image does not need to fit/fill the target's dimensions exactly. For instance,
  *  if true [BitmapFactoryDecoder] will not decode an image at a larger size than its source dimensions as an optimization.
- * @param allowRgb565 True if a component is allowed to use [Bitmap.Config.RGB_565] as an optimization.
+ * @param allowRgb565 True if a component is allowed to use [Bitmap.Config.RGB_565] as an optimization. As RGB_565 does
+ *  not have an alpha channel, components should only use RGB_565 if the image is guaranteed to not use alpha.
  * @param headers The header fields to use for any network requests.
  * @param parameters A map of custom parameters. These are used to pass custom data to a component.
  * @param networkCachePolicy Determines if this request is allowed to read from the network.

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -2,6 +2,8 @@ package coil.memory
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.O
 import android.widget.ImageView
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
@@ -30,6 +32,15 @@ import kotlinx.coroutines.Dispatchers
 
 /** Handles operations that act on [Request]s. */
 internal class RequestService {
+
+    companion object {
+        /** A whitelist of valid bitmap configs for the input and output bitmaps of [Transformation.transform]. */
+        private val VALID_TRANSFORMATION_CONFIGS = if (SDK_INT >= O) {
+            arrayOf(Bitmap.Config.ARGB_8888, Bitmap.Config.RGBA_F16)
+        } else {
+            arrayOf(Bitmap.Config.ARGB_8888)
+        }
+    }
 
     private val hardwareBitmapService = HardwareBitmapService()
 
@@ -117,8 +128,9 @@ internal class RequestService {
         // Disable fetching from the network if we know we're offline.
         val networkCachePolicy = if (isOnline) request.networkCachePolicy else CachePolicy.DISABLED
 
-        // Disable allowRgb565 if there are transformations.
-        val allowRgb565 = request.allowRgb565 && request.transformations.isEmpty()
+        // Disable allowRgb565 if there are transformations or the requested config is ALPHA_8.
+        // ALPHA_8 is a mask config where each pixel is 1 byte. It wouldn't make sense to use RGB_565 as an optimization.
+        val allowRgb565 = request.allowRgb565 && request.transformations.isEmpty() && bitmapConfig != Bitmap.Config.ALPHA_8
 
         return Options(
             config = bitmapConfig,
@@ -160,7 +172,7 @@ internal class RequestService {
 
     /** Return true if [Request.bitmapConfig] is valid given its [Transformation]s. */
     private fun isConfigValidForTransformations(request: Request): Boolean {
-        return request.transformations.isEmpty() || request.bitmapConfig in Transformation.VALID_CONFIGS
+        return request.transformations.isEmpty() || request.bitmapConfig in VALID_TRANSFORMATION_CONFIGS
     }
 
     private fun LoadRequest.getLifecycle(): Lifecycle? {

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -129,7 +129,7 @@ internal class RequestService {
         val networkCachePolicy = if (isOnline) request.networkCachePolicy else CachePolicy.DISABLED
 
         // Disable allowRgb565 if there are transformations or the requested config is ALPHA_8.
-        // ALPHA_8 is a mask config where each pixel is 1 byte. It wouldn't make sense to use RGB_565 as an optimization.
+        // ALPHA_8 is a mask config where each pixel is 1 byte so it wouldn't make sense to use RGB_565 as an optimization in that case.
         val allowRgb565 = request.allowRgb565 && request.transformations.isEmpty() && bitmapConfig != Bitmap.Config.ALPHA_8
 
         return Options(

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -242,7 +242,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      *
      * If false, any use of [Bitmap.Config.HARDWARE] will be treated as [Bitmap.Config.ARGB_8888].
      *
-     * This is useful for shared element transitions, which do not support hardware Bitmaps.
+     * This is useful for shared element transitions, which do not support hardware bitmaps.
      */
     fun allowHardware(enable: Boolean): T = self {
         this.allowHardware = enable

--- a/coil-base/src/main/java/coil/transform/Transformation.kt
+++ b/coil-base/src/main/java/coil/transform/Transformation.kt
@@ -2,8 +2,6 @@ package coil.transform
 
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.O
 import coil.bitmappool.BitmapPool
 import coil.decode.DecodeResult
 import coil.fetch.DrawableResult
@@ -20,15 +18,6 @@ import coil.size.Size
  */
 interface Transformation {
 
-    companion object {
-        /** A whitelist of valid bitmap configs for the input and output bitmaps of [transform]. */
-        internal val VALID_CONFIGS = if (SDK_INT >= O) {
-            arrayOf(Bitmap.Config.ARGB_8888, Bitmap.Config.RGBA_F16)
-        } else {
-            arrayOf(Bitmap.Config.ARGB_8888)
-        }
-    }
-
     /**
      * Return a unique key for this transformation.
      *
@@ -44,7 +33,7 @@ interface Transformation {
      * so that they can be reused.
      *
      * @param pool A [BitmapPool] which can be used to request [Bitmap] instances.
-     * @param input The input [Bitmap] to transform. Its config will always be one of [VALID_CONFIGS].
+     * @param input The input [Bitmap] to transform. Its config will always be [Bitmap.Config.ARGB_8888] or [Bitmap.Config.RGBA_F16].
      * @param size The size of the image request.
      *
      * @see BitmapPool.get

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -196,7 +196,7 @@ class RealImageLoaderBasicTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - normalized bitmap config must be equal`() {
+    fun `isCachedDrawableValid - bitmap config must be equal`() {
         val request = createGetRequest()
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
@@ -242,8 +242,8 @@ class RealImageLoaderBasicTest {
         assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.RGB_565))
         assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.ALPHA_8))
 
-        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.HARDWARE))
         assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.RGBA_F16))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.HARDWARE))
         assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.ARGB_8888))
         assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.RGB_565))
         assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.ALPHA_8))

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -196,7 +196,7 @@ class RealImageLoaderBasicTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - cached drawable with equal or greater config is valid`() {
+    fun `isCachedDrawableValid - normalized bitmap config must be equal`() {
         val request = createGetRequest()
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
@@ -210,7 +210,7 @@ class RealImageLoaderBasicTest {
             )
         }
 
-        assertTrue(isBitmapConfigValid(Bitmap.Config.RGBA_F16))
+        assertFalse(isBitmapConfigValid(Bitmap.Config.RGBA_F16))
         assertTrue(isBitmapConfigValid(Bitmap.Config.HARDWARE))
         assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888))
         assertFalse(isBitmapConfigValid(Bitmap.Config.RGB_565))
@@ -218,19 +218,35 @@ class RealImageLoaderBasicTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - allowRgb565=true allows using RGB_565 bitmap with ARGB_8888 request`() {
-        val request = createGetRequest {
-            allowRgb565(true)
+    fun `isCachedDrawableValid - allowRgb565=true allows matching any config if cached bitmap is RGB_565`() {
+        fun isBitmapConfigValid(
+            cachedConfig: Bitmap.Config,
+            requestedConfig: Bitmap.Config
+        ): Boolean {
+            val request = createGetRequest {
+                allowRgb565(true)
+                bitmapConfig(requestedConfig)
+            }
+            return imageLoader.isCachedDrawableValid(
+                cached = createBitmap(config = cachedConfig).toDrawable(context),
+                isSampled = true,
+                size = PixelSize(100, 100),
+                scale = Scale.FILL,
+                request = request
+            )
         }
-        val cached = createBitmap(config = Bitmap.Config.HARDWARE).toDrawable(context)
-        val isValid = imageLoader.isCachedDrawableValid(
-            cached = cached,
-            isSampled = true,
-            size = PixelSize(100, 100),
-            scale = Scale.FILL,
-            request = request
-        )
-        assertTrue(isValid)
+
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.HARDWARE))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.RGBA_F16))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.ARGB_8888))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.RGB_565))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565, Bitmap.Config.ALPHA_8))
+
+        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.HARDWARE))
+        assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.RGBA_F16))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.ARGB_8888))
+        assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.RGB_565))
+        assertFalse(isBitmapConfigValid(Bitmap.Config.ARGB_8888, Bitmap.Config.ALPHA_8))
     }
 
     @Test
@@ -252,6 +268,7 @@ class RealImageLoaderBasicTest {
 
         assertFalse(isBitmapConfigValid(Bitmap.Config.HARDWARE))
         assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888))
+        assertFalse(isBitmapConfigValid(Bitmap.Config.RGB_565))
     }
 
     @Test


### PR DESCRIPTION
Tweak the bitmap config logic in `RealImageLoader.isCachedDrawableValid` so the memory cache is more restrictive on matching bitmap configs.

Essentially, the cached config now has to match the requested config. Previously, the memory cache would match bitmaps if the cached config was greater (of higher quality) than the requested config.

This PR also relaxes the logic around `allowRgb565` so that it will match any config if the cached drawable is `RGB_565`.