### PR TITLE
Ensure View is attached before checking if it is hardware accelerated.

### DIFF
--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -154,7 +154,8 @@ internal class RequestService {
         if (!request.allowHardware) return false
 
         // Prevent hardware bitmaps for non-hardware accelerated targets.
-        if (request.target.run { this is ViewTarget<*> && !view.isHardwareAccelerated }) return false
+        val target = request.target
+        if (target is ViewTarget<*> && target.view.run { isAttachedToWindow && !isHardwareAccelerated }) return false
 
         return true
     }


### PR DESCRIPTION
`isHardwareAccelerated` returns false if the view is not attached even if the view will be hardware accelerated when attached. It's better to be more permissive than restrictive in this case.

Fixes #280.