### PR TITLE
Decrease severity of deprecation warnings.

### DIFF
--- a/coil-base/src/main/java/coil/ComponentRegistry.kt
+++ b/coil-base/src/main/java/coil/ComponentRegistry.kt
@@ -30,8 +30,7 @@ class ComponentRegistry private constructor(
         /** Create a new [ComponentRegistry] instance. */
         @Deprecated(
             message = "Use ComponentRegistry.Builder to create new instances.",
-            replaceWith = ReplaceWith("ComponentRegistry.Builder().apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("ComponentRegistry.Builder().apply(builder).build()")
         )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}
@@ -40,8 +39,7 @@ class ComponentRegistry private constructor(
         /** Create a new [ComponentRegistry] instance. */
         @Deprecated(
             message = "Use ComponentRegistry.Builder to create new instances.",
-            replaceWith = ReplaceWith("ComponentRegistry.Builder(registry).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("ComponentRegistry.Builder(registry).apply(builder).build()")
         )
         inline operator fun invoke(
             registry: ComponentRegistry,

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -29,8 +29,7 @@ interface ImageLoader {
         /** Create a new [ImageLoader] instance. */
         @Deprecated(
             message = "Use ImageLoader.Builder to create new instances.",
-            replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()")
         )
         inline operator fun invoke(
             context: Context,

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -20,8 +20,7 @@ class Parameters private constructor(
         /** Create a new [Parameters] instance. */
         @Deprecated(
             message = "Use Parameters.Builder to create new instances.",
-            replaceWith = ReplaceWith("Parameters.Builder().apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("Parameters.Builder().apply(builder).build()")
         )
         inline operator fun invoke(
             builder: Builder.() -> Unit = {}

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -163,8 +163,7 @@ class LoadRequest internal constructor(
         /** Create a new [LoadRequest] instance. */
         @Deprecated(
             message = "Use LoadRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("LoadRequest.Builder(context, defaults).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, defaults).apply(builder).build()")
         )
         inline operator fun invoke(
             context: Context,
@@ -175,8 +174,7 @@ class LoadRequest internal constructor(
         /** Create a new [LoadRequest] instance. */
         @Deprecated(
             message = "Use LoadRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("LoadRequest.Builder(context, request).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("LoadRequest.Builder(context, request).apply(builder).build()")
         )
         inline operator fun invoke(
             context: Context,
@@ -259,8 +257,7 @@ class GetRequest internal constructor(
         /** Create a new [GetRequest] instance. */
         @Deprecated(
             message = "Use GetRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()")
         )
         inline operator fun invoke(
             defaults: DefaultRequestOptions,
@@ -270,8 +267,7 @@ class GetRequest internal constructor(
         /** Create a new [GetRequest] instance. */
         @Deprecated(
             message = "Use GetRequest.Builder to create new instances.",
-            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()"),
-            level = DeprecationLevel.HIDDEN
+            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()")
         )
         inline operator fun invoke(
             request: GetRequest,


### PR DESCRIPTION
Decreases the severity of the deprecation warnings introduced [here](https://github.com/coil-kt/coil/pull/267) to `DeprecationLevel.WARNING`. This is to match the level of the deprecations introduced [here](https://github.com/coil-kt/coil/pull/293/files).

The APIs were previously marked as `DeprecationLevel.HIDDEN` to allow consumers to still use the DSL syntax, however Lint still markes extension functions with the same signature as deprecated (seems like a bug). Converting the APIs back to `DeprecationLevel.WARNING` will smooth the migration to `0.10.0`.