### PR TITLE
Use JDK 11 on CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Set Up Java
-            - uses: actions/setup-java@v1
+              uses: actions/setup-java@v1
               with:
                   java-version: 11
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Set Up Java
             - uses: actions/setup-java@v1
               with:
-                java-version: 11
+                  java-version: 11
 
             # Validate the Gradle wrapper JAR files.
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
 
+            - name: Set Up Java
+            - uses: actions/setup-java@v1
+              with:
+                java-version: 11
+
             # Validate the Gradle wrapper JAR files.
             - uses: gradle/wrapper-validation-action@v1
 

--- a/coil-base/src/test/resources/robolectric.properties
+++ b/coil-base/src/test/resources/robolectric.properties
@@ -1,2 +1,0 @@
-# Using Robolectric with SDK 29 requires Java 9, however sdkmanager is incompatible with Java 9.
-sdk=28


### PR DESCRIPTION
Now that sdkmanager works with JDK 9+, we can use a newer JDK. JDK 11 is the next LTS version after Java 8.

This also allows us to run the Robolectric tests against API 29.