### PR TITLE
Migrate from @Experimental to @RequiresOptIn.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ allprojects {
 
     tasks.withType<KotlinCompile> {
         kotlinOptions {
-            freeCompilerArgs = listOf("-progressive", "-Xuse-experimental=kotlin.Experimental")
+            freeCompilerArgs = listOf("-progressive", "-Xopt-in=kotlin.RequiresOptIn")
             jvmTarget = "1.8"
         }
     }

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -8,7 +8,7 @@ import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.RealImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.api.load
 import coil.util.CoilUtils
 import coil.util.requestManager
@@ -22,7 +22,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoil::class)
+@OptIn(ExperimentalCoilApi::class)
 class RequestDisposableTest {
 
     private lateinit var context: Context

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-@UseExperimental(ExperimentalCoil::class)
+@OptIn(ExperimentalCoil::class)
 class RequestDisposableTest {
 
     private lateinit var context: Context

--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -1,9 +1,9 @@
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil
 
 import android.graphics.drawable.Drawable
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.request.RequestBuilder
 import coil.size.Precision
 import coil.transition.Transition

--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -1,4 +1,4 @@
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil
 

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -1,5 +1,5 @@
 @file:Suppress("MemberVisibilityCanBePrivate", "unused")
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil
 
@@ -9,7 +9,7 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import coil.annotation.BuilderMarker
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.drawable.CrossfadeDrawable
 import coil.memory.BitmapReferenceCounter
@@ -186,7 +186,7 @@ class ImageLoaderBuilder(context: Context) {
     /**
      * Set the default [Transition] for each request.
      */
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     fun transition(transition: Transition?) = apply {
         this.defaults = this.defaults.copy(transition = transition)
     }

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -1,5 +1,5 @@
 @file:Suppress("MemberVisibilityCanBePrivate", "unused")
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused")
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil
 
@@ -12,7 +12,7 @@ import android.util.Log
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleObserver
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.decode.BitmapFactoryDecoder
 import coil.decode.DataSource

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused")
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil
 

--- a/coil-base/src/main/java/coil/annotation/ExperimentalCoil.kt
+++ b/coil-base/src/main/java/coil/annotation/ExperimentalCoil.kt
@@ -6,5 +6,8 @@ package coil.annotation
  */
 @MustBeDocumented
 @Retention(AnnotationRetention.BINARY)
-@Experimental(Experimental.Level.WARNING)
+@RequiresOptIn(
+    message = "This API is experimental and may contain breaking changes in the future as its design is still incubating.",
+    level = RequiresOptIn.Level.WARNING
+)
 annotation class ExperimentalCoil

--- a/coil-base/src/main/java/coil/annotation/ExperimentalCoilApi.kt
+++ b/coil-base/src/main/java/coil/annotation/ExperimentalCoilApi.kt
@@ -10,4 +10,4 @@ package coil.annotation
     message = "This API is experimental and may contain breaking changes in the future as its design is still incubating.",
     level = RequiresOptIn.Level.WARNING
 )
-annotation class ExperimentalCoil
+annotation class ExperimentalCoilApi

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil.memory
 
@@ -8,7 +8,7 @@ import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.annotation.MainThread
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.base.R
 import coil.request.Request
 import coil.target.PoolableViewTarget

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -1,4 +1,4 @@
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil.memory
 

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "NOTHING_TO_INLINE", "unused")
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil.request
 

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -1,5 +1,5 @@
 @file:Suppress("FunctionName", "NOTHING_TO_INLINE", "unused")
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil.request
 
@@ -12,7 +12,7 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.Lifecycle
 import coil.DefaultRequestOptions
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.size.Precision

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused")
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil.request
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -1,5 +1,5 @@
 @file:Suppress("unused")
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil.request
 
@@ -20,7 +20,7 @@ import coil.DefaultRequestOptions
 import coil.ImageLoader
 import coil.ImageLoaderBuilder
 import coil.annotation.BuilderMarker
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.drawable.CrossfadeDrawable
@@ -496,7 +496,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
     /**
      * See: [ImageLoaderBuilder.transition]
      */
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     fun transition(transition: Transition?) = apply {
         this.transition = transition
     }

--- a/coil-base/src/main/java/coil/request/RequestDisposable.kt
+++ b/coil-base/src/main/java/coil/request/RequestDisposable.kt
@@ -2,7 +2,7 @@ package coil.request
 
 import android.view.View
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.target.ViewTarget
 import coil.util.requestManager
 import kotlinx.coroutines.Job
@@ -26,7 +26,7 @@ interface RequestDisposable {
     /**
      * Suspends until any in progress work completes.
      */
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     suspend fun await()
 }
 
@@ -44,7 +44,7 @@ internal class BaseTargetRequestDisposable(private val job: Job) : RequestDispos
         }
     }
 
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     override suspend fun await() {
         if (!isDisposed) {
             job.join()
@@ -73,7 +73,7 @@ internal class ViewTargetRequestDisposable(
         }
     }
 
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     override suspend fun await() {
         if (!isDisposed) {
             target.view.requestManager.currentRequestJob?.join()

--- a/coil-base/src/main/java/coil/target/ImageViewTarget.kt
+++ b/coil-base/src/main/java/coil/target/ImageViewTarget.kt
@@ -1,4 +1,4 @@
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil.target
 

--- a/coil-base/src/main/java/coil/target/ImageViewTarget.kt
+++ b/coil-base/src/main/java/coil/target/ImageViewTarget.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil.target
 
@@ -7,7 +7,7 @@ import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.transition.TransitionTarget
 
 /** A [Target] that handles setting images on an [ImageView]. */

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -3,7 +3,7 @@ package coil.transition
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.drawable.CrossfadeDrawable
 import coil.size.Scale
 import coil.transition.TransitionResult.Error
@@ -15,7 +15,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
 /** A [Transition] that crossfades from the current drawable to a new one. */
-@ExperimentalCoil
+@ExperimentalCoilApi
 class CrossfadeTransition @JvmOverloads constructor(
     val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION
 ) : Transition {

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -2,7 +2,7 @@ package coil.transition
 
 import android.graphics.Bitmap
 import androidx.annotation.MainThread
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.target.Target
 
 /**
@@ -11,7 +11,7 @@ import coil.target.Target
  * NOTE: A [Target] must implement [TransitionTarget] to support applying [Transition]s.
  * If the [Target] does not implement [TransitionTarget], any [Transition]s will be ignored.
  */
-@ExperimentalCoil
+@ExperimentalCoilApi
 interface Transition {
 
     /**

--- a/coil-base/src/main/java/coil/transition/TransitionResult.kt
+++ b/coil-base/src/main/java/coil/transition/TransitionResult.kt
@@ -1,13 +1,13 @@
 package coil.transition
 
 import android.graphics.drawable.Drawable
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.target.Target
 
 /**
  * Represents the result of an image request.
  */
-@ExperimentalCoil
+@ExperimentalCoilApi
 sealed class TransitionResult {
 
     /**

--- a/coil-base/src/main/java/coil/transition/TransitionTarget.kt
+++ b/coil-base/src/main/java/coil/transition/TransitionTarget.kt
@@ -2,14 +2,14 @@ package coil.transition
 
 import android.graphics.drawable.Drawable
 import android.view.View
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.target.Target
 import coil.target.ViewTarget
 
 /**
  * A [Target] that supports applying [Transition]s.
  */
-@ExperimentalCoil
+@ExperimentalCoilApi
 interface TransitionTarget<T : View> : ViewTarget<T> {
 
     /**

--- a/coil-base/src/main/java/coil/util/CoilUtils.kt
+++ b/coil-base/src/main/java/coil/util/CoilUtils.kt
@@ -2,7 +2,7 @@ package coil.util
 
 import android.content.Context
 import android.view.View
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import okhttp3.Cache
 
 /** Public utility methods for Coil. */
@@ -17,7 +17,7 @@ object CoilUtils {
     }
 
     /** Cancel any in progress requests attached to [view] and clear any associated resources. */
-    @ExperimentalCoil
+    @ExperimentalCoilApi
     @JvmStatic
     fun clear(view: View) {
         view.requestManager.clearCurrentRequest()

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -7,7 +7,7 @@ import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.graphics.drawable.BitmapDrawable
 import androidx.test.core.app.ApplicationProvider
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.api.newLoadBuilder
 import coil.bitmappool.BitmapPool
 import coil.decode.Options
@@ -50,7 +50,7 @@ import kotlin.test.assertTrue
  * Basic tests for [RealImageLoader] that don't touch Android's graphics pipeline ([BitmapFactory], [ImageDecoder], etc.).
  */
 @RunWith(RobolectricTestRunner::class)
-@OptIn(ExperimentalCoil::class)
+@OptIn(ExperimentalCoilApi::class)
 class RealImageLoaderBasicTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -50,7 +50,7 @@ import kotlin.test.assertTrue
  * Basic tests for [RealImageLoader] that don't touch Android's graphics pipeline ([BitmapFactory], [ImageDecoder], etc.).
  */
 @RunWith(RobolectricTestRunner::class)
-@UseExperimental(ExperimentalCoil::class)
+@OptIn(ExperimentalCoil::class)
 class RealImageLoaderBasicTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/fetch/HttpFetcherTest.kt
+++ b/coil-base/src/test/java/coil/fetch/HttpFetcherTest.kt
@@ -26,7 +26,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@UseExperimental(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class HttpFetcherTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -31,7 +31,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@UseExperimental(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
 class TargetDelegateTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.FakeBitmapPool
 import coil.target.FakeTarget
 import coil.target.ImageViewTarget
@@ -31,7 +31,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@OptIn(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalCoroutinesApi::class)
 class TargetDelegateTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -5,7 +5,7 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.drawable.CrossfadeDrawable
 import coil.util.createTestMainDispatcher
 import coil.util.error
@@ -24,7 +24,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@OptIn(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoilApi::class, ExperimentalCoroutinesApi::class)
 class CrossfadeTransitionTest {
 
     private lateinit var context: Context

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -24,7 +24,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
-@UseExperimental(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoil::class, ExperimentalCoroutinesApi::class)
 class CrossfadeTransitionTest {
 
     private lateinit var context: Context

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -1,6 +1,6 @@
 @file:JvmName("ImageViews")
 @file:Suppress("unused")
-@file:UseExperimental(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoil::class)
 
 package coil.api
 

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -1,6 +1,6 @@
 @file:JvmName("ImageViews")
 @file:Suppress("unused")
-@file:OptIn(ExperimentalCoil::class)
+@file:OptIn(ExperimentalCoilApi::class)
 
 package coil.api
 
@@ -11,7 +11,7 @@ import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import coil.Coil
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoil
+import coil.annotation.ExperimentalCoilApi
 import coil.request.LoadRequestBuilder
 import coil.request.RequestDisposable
 import coil.util.CoilUtils


### PR DESCRIPTION
Also renames `ExperimentalCoil` -> `ExperimentalCoilApi` to match the naming convention in the standard library:

- `ExperimentalXYZ` for an entire feature that is still experimental. E.g. `ExperimentalTime`
- `ExperimentalXYZApi` for individual functions/classes that are experimental within a stable feature.