### PR TITLE
Support setting default cache policies in ImageLoader.Builder.

### DIFF
--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -4,6 +4,7 @@ package coil
 
 import android.graphics.drawable.Drawable
 import coil.annotation.ExperimentalCoilApi
+import coil.request.CachePolicy
 import coil.request.RequestBuilder
 import coil.size.Precision
 import coil.transition.Transition
@@ -23,5 +24,8 @@ data class DefaultRequestOptions(
     val allowRgb565: Boolean = false,
     val placeholder: Drawable? = null,
     val error: Drawable? = null,
-    val fallback: Drawable? = null
+    val fallback: Drawable? = null,
+    val memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    val diskCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    val networkCachePolicy: CachePolicy = CachePolicy.ENABLED
 )

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -14,6 +14,7 @@ import coil.bitmappool.BitmapPool
 import coil.drawable.CrossfadeDrawable
 import coil.memory.BitmapReferenceCounter
 import coil.memory.MemoryCache
+import coil.request.CachePolicy
 import coil.request.Request
 import coil.size.Precision
 import coil.transition.CrossfadeTransition
@@ -241,6 +242,29 @@ class ImageLoaderBuilder(context: Context) {
      */
     fun fallback(drawable: Drawable?) = apply {
         this.defaults = this.defaults.copy(error = drawable)
+    }
+
+    /**
+     * Set the default memory cache policy.
+     */
+    fun memoryCachePolicy(policy: CachePolicy) = apply {
+        this.defaults = this.defaults.copy(memoryCachePolicy = policy)
+    }
+
+    /**
+     * Set the default disk cache policy.
+     */
+    fun diskCachePolicy(policy: CachePolicy) = apply {
+        this.defaults = this.defaults.copy(diskCachePolicy = policy)
+    }
+
+    /**
+     * Set the default network cache policy.
+     *
+     * NOTE: Disabling writes has no effect.
+     */
+    fun networkCachePolicy(policy: CachePolicy) = apply {
+        this.defaults = this.defaults.copy(networkCachePolicy = policy)
     }
 
     /**

--- a/coil-base/src/main/java/coil/decode/DataSource.kt
+++ b/coil-base/src/main/java/coil/decode/DataSource.kt
@@ -11,7 +11,7 @@ import coil.fetch.SourceResult
  * @see DrawableResult.dataSource
  */
 enum class DataSource {
-    NETWORK,
+    MEMORY,
     DISK,
-    MEMORY
+    NETWORK
 }

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -23,8 +23,9 @@ import okhttp3.Headers
  *  not have an alpha channel, components should only use RGB_565 if the image is guaranteed to not use alpha.
  * @param headers The header fields to use for any network requests.
  * @param parameters A map of custom parameters. These are used to pass custom data to a component.
- * @param networkCachePolicy Determines if this request is allowed to read from the network.
+ * @param memoryCachePolicy Determines if this request is allowed to read/write from/to memory.
  * @param diskCachePolicy Determines if this request is allowed to read/write from/to disk.
+ * @param networkCachePolicy Determines if this request is allowed to read from the network.
  */
 data class Options(
     val config: Bitmap.Config,
@@ -34,6 +35,7 @@ data class Options(
     val allowRgb565: Boolean,
     val headers: Headers,
     val parameters: Parameters,
-    val networkCachePolicy: CachePolicy,
-    val diskCachePolicy: CachePolicy
+    val memoryCachePolicy: CachePolicy,
+    val diskCachePolicy: CachePolicy,
+    val networkCachePolicy: CachePolicy
 )

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -140,6 +140,7 @@ internal class RequestService {
             allowRgb565 = allowRgb565,
             headers = request.headers,
             parameters = request.parameters,
+            memoryCachePolicy = request.memoryCachePolicy,
             diskCachePolicy = request.diskCachePolicy,
             networkCachePolicy = networkCachePolicy
         )

--- a/coil-base/src/main/java/coil/request/CachePolicy.kt
+++ b/coil-base/src/main/java/coil/request/CachePolicy.kt
@@ -5,9 +5,9 @@ package coil.request
 /**
  * Represents the read/write policy for a cache source.
  *
- * @see Request.networkCachePolicy
- * @see Request.diskCachePolicy
  * @see Request.memoryCachePolicy
+ * @see Request.diskCachePolicy
+ * @see Request.networkCachePolicy
  */
 enum class CachePolicy(
     val readEnabled: Boolean,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -53,9 +53,9 @@ sealed class Request {
     abstract val headers: Headers
     abstract val parameters: Parameters
 
-    abstract val networkCachePolicy: CachePolicy
-    abstract val diskCachePolicy: CachePolicy
     abstract val memoryCachePolicy: CachePolicy
+    abstract val diskCachePolicy: CachePolicy
+    abstract val networkCachePolicy: CachePolicy
 
     abstract val allowHardware: Boolean
     abstract val allowRgb565: Boolean
@@ -138,9 +138,9 @@ class LoadRequest internal constructor(
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
     override val parameters: Parameters,
-    override val networkCachePolicy: CachePolicy,
-    override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
+    override val diskCachePolicy: CachePolicy,
+    override val networkCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
     override val allowRgb565: Boolean,
     @DrawableRes internal val placeholderResId: Int,
@@ -238,9 +238,9 @@ class GetRequest internal constructor(
     override val colorSpace: ColorSpace?,
     override val headers: Headers,
     override val parameters: Parameters,
-    override val networkCachePolicy: CachePolicy,
-    override val diskCachePolicy: CachePolicy,
     override val memoryCachePolicy: CachePolicy,
+    override val diskCachePolicy: CachePolicy,
+    override val networkCachePolicy: CachePolicy,
     override val allowHardware: Boolean,
     override val allowRgb565: Boolean
 ) : Request() {

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -64,9 +64,9 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     protected var headers: Headers.Builder?
     protected var parameters: Parameters.Builder?
 
-    protected var networkCachePolicy: CachePolicy
-    protected var diskCachePolicy: CachePolicy
     protected var memoryCachePolicy: CachePolicy
+    protected var diskCachePolicy: CachePolicy
+    protected var networkCachePolicy: CachePolicy
 
     protected var allowHardware: Boolean
     protected var allowRgb565: Boolean
@@ -90,9 +90,9 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         headers = null
         parameters = null
 
-        networkCachePolicy = CachePolicy.ENABLED
-        diskCachePolicy = CachePolicy.ENABLED
-        memoryCachePolicy = CachePolicy.ENABLED
+        memoryCachePolicy = defaults.memoryCachePolicy
+        diskCachePolicy = defaults.diskCachePolicy
+        networkCachePolicy = defaults.networkCachePolicy
 
         allowHardware = defaults.allowHardware
         allowRgb565 = defaults.allowRgb565
@@ -300,12 +300,10 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     }
 
     /**
-     * Enable/disable reading from the network.
-     *
-     * NOTE: Disabling writes has no effect.
+     * Enable/disable reading/writing from/to the memory cache.
      */
-    fun networkCachePolicy(policy: CachePolicy): T = self {
-        this.networkCachePolicy = policy
+    fun memoryCachePolicy(policy: CachePolicy): T = self {
+        this.memoryCachePolicy = policy
     }
 
     /**
@@ -316,10 +314,12 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     }
 
     /**
-     * Enable/disable reading/writing from/to the memory cache.
+     * Enable/disable reading from the network.
+     *
+     * NOTE: Disabling writes has no effect.
      */
-    fun memoryCachePolicy(policy: CachePolicy): T = self {
-        this.memoryCachePolicy = policy
+    fun networkCachePolicy(policy: CachePolicy): T = self {
+        this.networkCachePolicy = policy
     }
 
     /**
@@ -572,9 +572,9 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
             colorSpace,
             headers?.build().orEmpty(),
             parameters?.build().orEmpty(),
-            networkCachePolicy,
-            diskCachePolicy,
             memoryCachePolicy,
+            diskCachePolicy,
+            networkCachePolicy,
             allowHardware,
             allowRgb565,
             placeholderResId,
@@ -620,9 +620,9 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
             colorSpace,
             headers?.build().orEmpty(),
             parameters?.build().orEmpty(),
-            networkCachePolicy,
-            diskCachePolicy,
             memoryCachePolicy,
+            diskCachePolicy,
+            networkCachePolicy,
             allowHardware,
             allowRgb565
         )

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -44,8 +44,9 @@ fun createOptions(
     allowRgb565: Boolean = false,
     headers: Headers = Headers.Builder().build(),
     parameters: Parameters = Parameters.Builder().build(),
-    networkCachePolicy: CachePolicy = CachePolicy.ENABLED,
-    diskCachePolicy: CachePolicy = CachePolicy.ENABLED
+    memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    diskCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    networkCachePolicy: CachePolicy = CachePolicy.ENABLED
 ): Options {
     return Options(
         config,
@@ -55,8 +56,9 @@ fun createOptions(
         allowRgb565,
         headers,
         parameters,
-        networkCachePolicy,
-        diskCachePolicy
+        memoryCachePolicy,
+        diskCachePolicy,
+        networkCachePolicy
     )
 }
 


### PR DESCRIPTION
This also reverses the order of cache policies so the values are in the order they're checked. **This will be mentioned at the top of the patch notes since it could cause issues if people have hardcoded the ordinal values.**