### PR TITLE
Introduce EventListener.

### DIFF
--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -15,7 +15,8 @@ import coil.size.SizeResolver
 import coil.transform.Transformation
 
 /**
- * Listener for metrics events. Implement this class to track the progress of an image request.
+ * An [ImageLoader]-scoped listener for tracking the progress of an image request.
+ * This class is useful for analytics, performance, or other metrics tracking.
  *
  * @see ImageLoaderBuilder.eventListenerFactory
  */

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -5,6 +5,7 @@ import androidx.annotation.WorkerThread
 import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.decode.Decoder
+import coil.decode.Options
 import coil.fetch.Fetcher
 import coil.map.Mapper
 import coil.map.MeasuredMapper
@@ -60,33 +61,37 @@ interface EventListener : Request.Listener {
      * Called before [Fetcher.fetch].
      *
      * @param fetcher The [Fetcher] that will be used to handle the request.
+     * @param options The [Options] that will be passed to [Fetcher.fetch].
      */
     @WorkerThread
-    fun fetchStart(request: Request, fetcher: Fetcher<*>) {}
+    fun fetchStart(request: Request, fetcher: Fetcher<*>, options: Options) {}
 
     /**
      * Called after [Fetcher.fetch].
      *
      * @param fetcher The [Fetcher] that was used to handle the request.
+     * @param options The [Options] that were passed to [Fetcher.fetch].
      */
     @WorkerThread
-    fun fetchEnd(request: Request, fetcher: Fetcher<*>) {}
+    fun fetchEnd(request: Request, fetcher: Fetcher<*>, options: Options) {}
 
     /**
      * Called before [Decoder.decode].
      *
      * @param decoder The [Decoder] that will be used to handle the request.
+     * @param options The [Options] that will be passed to [Decoder.decode].
      */
     @WorkerThread
-    fun decodeStart(request: Request, decoder: Decoder) {}
+    fun decodeStart(request: Request, decoder: Decoder, options: Options) {}
 
     /**
      * Called after [Decoder.decode].
      *
      * @param decoder The [Decoder] that was used to handle the request.
+     * @param options The [Options] that were passed to [Decoder.decode].
      */
     @WorkerThread
-    fun decodeEnd(request: Request, decoder: Decoder) {}
+    fun decodeEnd(request: Request, decoder: Decoder, options: Options) {}
 
     /**
      * Called before any [Transformation]s are applied.

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -16,9 +16,9 @@ import coil.transform.Transformation
 
 /**
  * An [ImageLoader]-scoped listener for tracking the progress of an image request.
- * This class is useful for analytics, performance, or other metrics tracking.
+ * This class is useful for measuring analytics, performance, or other metrics tracking.
  *
- * @see ImageLoaderBuilder.eventListenerFactory
+ * @see ImageLoaderBuilder.eventListener
  */
 @ExperimentalCoilApi
 interface EventListener : Request.Listener {

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -1,0 +1,141 @@
+package coil
+
+import androidx.annotation.MainThread
+import androidx.annotation.WorkerThread
+import coil.annotation.ExperimentalCoilApi
+import coil.decode.DataSource
+import coil.decode.Decoder
+import coil.fetch.Fetcher
+import coil.map.Mapper
+import coil.map.MeasuredMapper
+import coil.request.Request
+import coil.size.Size
+import coil.size.SizeResolver
+import coil.transform.Transformation
+
+/**
+ * Listener for metrics events. Implement this class to track the progress of an image request.
+ *
+ * @see ImageLoaderBuilder.eventListenerFactory
+ */
+@ExperimentalCoilApi
+interface EventListener : Request.Listener {
+
+    companion object {
+        @JvmField
+        val EMPTY = object : EventListener {}
+    }
+
+    /**
+     * Called when the request is started.
+     */
+    @MainThread
+    override fun onStart(request: Request) {}
+
+    /**
+     * Called before any [Mapper]s or [MeasuredMapper]s are called to convert the request's data.
+     */
+    @MainThread
+    fun mapStart(request: Request) {}
+
+    /**
+     * Called after the request's data has been converted.
+     */
+    @MainThread
+    fun mapEnd(request: Request, mappedData: Any) {}
+
+    /**
+     * Called before [SizeResolver.size] to await the request's size.
+     */
+    @MainThread
+    fun resolveSizeStart(request: Request) {}
+
+    /**
+     * Called after the request's size has been resolved.
+     */
+    @MainThread
+    fun resolveSizeEnd(request: Request, size: Size) {}
+
+    /**
+     * Called before [Fetcher.fetch].
+     *
+     * @param fetcher The [Fetcher] that will be used to handle the request.
+     */
+    @WorkerThread
+    fun fetchStart(request: Request, fetcher: Fetcher<*>) {}
+
+    /**
+     * Called after [Fetcher.fetch].
+     *
+     * @param fetcher The [Fetcher] that was used to handle the request.
+     */
+    @WorkerThread
+    fun fetchEnd(request: Request, fetcher: Fetcher<*>) {}
+
+    /**
+     * Called before [Decoder.decode].
+     *
+     * @param decoder The [Decoder] that will be used to handle the request.
+     */
+    @WorkerThread
+    fun decodeStart(request: Request, decoder: Decoder) {}
+
+    /**
+     * Called after [Decoder.decode].
+     *
+     * @param decoder The [Decoder] that was used to handle the request.
+     */
+    @WorkerThread
+    fun decodeEnd(request: Request, decoder: Decoder) {}
+
+    /**
+     * Called before any [Transformation]s are applied.
+     */
+    @WorkerThread
+    fun transformStart(request: Request) {}
+
+    /**
+     * Called after any [Transformation]s are applied.
+     */
+    @WorkerThread
+    fun transformEnd(request: Request) {}
+
+    /**
+     * Called when the request is successful.
+     */
+    @MainThread
+    override fun onSuccess(request: Request, source: DataSource) {}
+
+    /**
+     * Called when the request is cancelled.
+     */
+    @MainThread
+    override fun onCancel(request: Request) {}
+
+    /**
+     * Called when the request fails.
+     */
+    @MainThread
+    override fun onError(request: Request, throwable: Throwable) {}
+
+    /** A factory that creates new [EventListener] instances. */
+    interface Factory {
+
+        companion object {
+            @JvmField
+            val EMPTY = Factory(EventListener.EMPTY)
+
+            /** Create an [EventListener.Factory] that returns the same [listener]. */
+            @JvmStatic
+            @JvmName("create")
+            operator fun invoke(listener: EventListener): Factory {
+                return object : Factory {
+                    override fun newListener(request: Request) = listener
+                }
+            }
+        }
+
+        /** Return a new [EventListener]. */
+        fun newListener(request: Request): EventListener
+    }
+}

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -189,7 +189,7 @@ class ImageLoaderBuilder(context: Context) {
      * Set a single [EventListener] that will receive all callbacks for requests launched by this image loader.
      */
     @ExperimentalCoilApi
-    fun eventListener(listener: EventListener) = eventListenerFactory(EventListener.Factory(listener))
+    fun eventListener(listener: EventListener) = eventListener(EventListener.Factory(listener))
 
     /**
      * Set the [EventListener.Factory] to create per-request [EventListener]s.
@@ -197,7 +197,7 @@ class ImageLoaderBuilder(context: Context) {
      * @see eventListener
      */
     @ExperimentalCoilApi
-    fun eventListenerFactory(factory: EventListener.Factory) = apply {
+    fun eventListener(factory: EventListener.Factory) = apply {
         this.eventListenerFactory = factory
     }
 

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -38,6 +38,7 @@ class ImageLoaderBuilder(context: Context) {
     private val applicationContext = context.applicationContext
 
     private var callFactory: Call.Factory? = null
+    private var eventListenerFactory: EventListener.Factory? = null
     private var registry: ComponentRegistry? = null
     private var logger: Logger? = null
     private var defaults = DefaultRequestOptions()
@@ -98,6 +99,7 @@ class ImageLoaderBuilder(context: Context) {
     /**
      * Build and set the [ComponentRegistry].
      */
+    @JvmSynthetic
     inline fun componentRegistry(
         builder: ComponentRegistry.Builder.() -> Unit
     ) = componentRegistry(ComponentRegistry.Builder().apply(builder).build())
@@ -181,6 +183,22 @@ class ImageLoaderBuilder(context: Context) {
      */
     fun trackWeakReferences(enable: Boolean) = apply {
         this.trackWeakReferences = enable
+    }
+
+    /**
+     * Set a single [EventListener] that will receive all callbacks for requests launched by this image loader.
+     */
+    @ExperimentalCoilApi
+    fun eventListener(listener: EventListener) = eventListenerFactory(EventListener.Factory(listener))
+
+    /**
+     * Set the [EventListener.Factory] to create per-request [EventListener]s.
+     *
+     * @see eventListener
+     */
+    @ExperimentalCoilApi
+    fun eventListenerFactory(factory: EventListener.Factory) = apply {
+        this.eventListenerFactory = factory
     }
 
     /**
@@ -314,6 +332,7 @@ class ImageLoaderBuilder(context: Context) {
             memoryCache = memoryCache,
             weakMemoryCache = weakMemoryCache,
             callFactory = callFactory ?: buildDefaultCallFactory(),
+            eventListenerFactory = eventListenerFactory ?: EventListener.Factory.EMPTY,
             registry = registry ?: ComponentRegistry(),
             logger = logger
         )

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -96,6 +96,7 @@ internal class RealImageLoader(
     private val memoryCache: MemoryCache,
     private val weakMemoryCache: WeakMemoryCache,
     callFactory: Call.Factory,
+    private val eventListenerFactory: EventListener.Factory,
     registry: ComponentRegistry,
     private val logger: Logger?
 ) : ImageLoader, ComponentCallbacks {
@@ -139,9 +140,7 @@ internal class RealImageLoader(
 
     override fun load(request: LoadRequest): RequestDisposable {
         // Start loading the data.
-        val job = loaderScope.launch(exceptionHandler) {
-            execute(request.data, request)
-        }
+        val job = loaderScope.launch(exceptionHandler) { execute(request) }
 
         return if (request.target is ViewTarget<*>) {
             val requestId = request.target.view.requestManager.setCurrentRequestJob(job)
@@ -151,14 +150,14 @@ internal class RealImageLoader(
         }
     }
 
-    override suspend fun get(request: GetRequest): Drawable = execute(request.data, request)
+    override suspend fun get(request: GetRequest) = execute(request)
 
-    private suspend fun execute(
-        data: Any?,
-        request: Request
-    ): Drawable = withContext(Dispatchers.Main.immediate) outerJob@{
+    private suspend fun execute(request: Request) = withContext(Dispatchers.Main.immediate) outerJob@{
         // Ensure this image loader isn't shutdown.
         assertNotShutdown()
+
+        // Create a new event listener.
+        val eventListener = eventListenerFactory.newListener(request)
 
         // Compute lifecycle info on the main thread.
         val (lifecycle, mainDispatcher) = requestService.lifecycleInfo(request)
@@ -168,10 +167,11 @@ internal class RealImageLoader(
 
         val deferred = async<Drawable>(mainDispatcher, CoroutineStart.LAZY) innerJob@{
             // Fail before starting if data is null.
-            data ?: throw NullRequestDataException()
+            val data = request.data ?: throw NullRequestDataException()
 
             // Notify the listener that the request has started.
-            request.listener?.onStart(data)
+            eventListener.onStart(request)
+            request.listener?.onStart(request)
 
             // Invalidate the bitmap if it was provided as input.
             when (data) {
@@ -187,10 +187,12 @@ internal class RealImageLoader(
 
             // Prepare to resolve the size lazily.
             val sizeResolver = requestService.sizeResolver(request, context)
-            val lazySizeResolver = LazySizeResolver(this, sizeResolver, targetDelegate, request)
+            val lazySizeResolver = LazySizeResolver(this, sizeResolver, targetDelegate, request, eventListener)
 
             // Perform any data mapping.
+            eventListener.mapStart(request)
             val mappedData = mapData(data, lazySizeResolver)
+            eventListener.mapEnd(request, mappedData)
 
             // Compute the cache key.
             val fetcher = registry.requireFetcher(mappedData)
@@ -216,12 +218,13 @@ internal class RealImageLoader(
             if (cachedDrawable != null && isCachedDrawableValid(cachedDrawable, cachedValue.isSampled, size, scale, request)) {
                 logger?.log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
                 targetDelegate.success(cachedDrawable, true, request.transition)
-                request.listener?.onSuccess(data, DataSource.MEMORY)
+                eventListener.onSuccess(request, DataSource.MEMORY)
+                request.listener?.onSuccess(request, DataSource.MEMORY)
                 return@innerJob cachedDrawable
             }
 
             // Fetch and decode the image.
-            val (drawable, isSampled, source) = loadData(data, request, fetcher, mappedData, size, scale)
+            val (drawable, isSampled, source) = loadData(data, request, fetcher, mappedData, size, scale, eventListener)
 
             // Cache the result.
             if (request.memoryCachePolicy.writeEnabled) {
@@ -231,7 +234,8 @@ internal class RealImageLoader(
             // Set the final result on the target.
             logger?.log(TAG, Log.INFO) { "${source.emoji} Successful (${source.name}) - $data" }
             targetDelegate.success(drawable, false, request.transition)
-            request.listener?.onSuccess(data, source)
+            eventListener.onSuccess(request, source)
+            request.listener?.onSuccess(request, source)
 
             return@innerJob drawable
         }
@@ -246,13 +250,15 @@ internal class RealImageLoader(
                 throwable ?: return@launch
 
                 if (throwable is CancellationException) {
-                    logger?.log(TAG, Log.INFO) { "${Emoji.CONSTRUCTION} Cancelled - $data" }
-                    request.listener?.onCancel(data)
+                    logger?.log(TAG, Log.INFO) { "${Emoji.CONSTRUCTION} Cancelled - ${request.data}" }
+                    eventListener.onCancel(request)
+                    request.listener?.onCancel(request)
                 } else {
-                    logger?.log(TAG, Log.INFO) { "${Emoji.SIREN} Failed - $data - $throwable" }
+                    logger?.log(TAG, Log.INFO) { "${Emoji.SIREN} Failed - ${request.data} - $throwable" }
                     val drawable = if (throwable is NullRequestDataException) request.fallback else request.error
                     targetDelegate.error(drawable, request.transition)
-                    request.listener?.onError(data, throwable)
+                    eventListener.onError(request, throwable)
+                    request.listener?.onError(request, throwable)
                 }
             }
         }
@@ -365,11 +371,16 @@ internal class RealImageLoader(
         fetcher: Fetcher<Any>,
         mappedData: Any,
         size: Size,
-        scale: Scale
+        scale: Scale,
+        eventListener: EventListener
     ): DrawableResult = withContext(request.dispatcher) {
-        // Convert the data into a Drawable.
         val options = requestService.options(request, size, scale, networkObserver.isOnline())
-        val baseResult = when (val fetchResult = fetcher.fetch(bitmapPool, mappedData, size, options)) {
+
+        eventListener.fetchStart(request, fetcher)
+        val fetchResult = fetcher.fetch(bitmapPool, mappedData, size, options)
+        eventListener.fetchEnd(request, fetcher)
+
+        val baseResult = when (fetchResult) {
             is SourceResult -> {
                 val decodeResult = try {
                     // Check if we're cancelled.
@@ -385,7 +396,10 @@ internal class RealImageLoader(
                     }
 
                     // Decode the stream.
-                    decoder.decode(bitmapPool, fetchResult.source, size, options)
+                    eventListener.decodeStart(request, decoder)
+                    val decodeResult = decoder.decode(bitmapPool, fetchResult.source, size, options)
+                    eventListener.decodeEnd(request, decoder)
+                    decodeResult
                 } catch (rethrown: Exception) {
                     // NOTE: We only close the stream automatically if there is an uncaught exception.
                     // This allows custom decoders to continue to read the source after returning a Drawable.
@@ -407,7 +421,9 @@ internal class RealImageLoader(
         ensureActive()
 
         // Apply any transformations and prepare to draw.
+        eventListener.transformStart(request)
         val finalResult = applyTransformations(this, baseResult, request.transformations, size, options)
+        eventListener.transformEnd(request)
         (finalResult.drawable as? BitmapDrawable)?.bitmap?.prepareToDraw()
 
         return@withContext finalResult
@@ -475,7 +491,8 @@ internal class RealImageLoader(
         private val scope: CoroutineScope,
         private val sizeResolver: SizeResolver,
         private val targetDelegate: TargetDelegate,
-        private val request: Request
+        private val request: Request,
+        private val eventListener: EventListener
     ) {
 
         private var size: Size? = null
@@ -487,9 +504,12 @@ internal class RealImageLoader(
             // Call the target's onStart before resolving the size.
             targetDelegate.start(cached, cached ?: request.placeholder)
 
-            return@run sizeResolver.size()
-                .also { size = it }
-                .also { ensureActive() }
+            eventListener.resolveSizeStart(request)
+            val size = sizeResolver.size().also { size = it }
+            eventListener.resolveSizeEnd(request, size)
+
+            ensureActive()
+            return@run size
         }
     }
 }

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -376,9 +376,9 @@ internal class RealImageLoader(
     ): DrawableResult = withContext(request.dispatcher) {
         val options = requestService.options(request, size, scale, networkObserver.isOnline())
 
-        eventListener.fetchStart(request, fetcher)
+        eventListener.fetchStart(request, fetcher, options)
         val fetchResult = fetcher.fetch(bitmapPool, mappedData, size, options)
-        eventListener.fetchEnd(request, fetcher)
+        eventListener.fetchEnd(request, fetcher, options)
 
         val baseResult = when (fetchResult) {
             is SourceResult -> {
@@ -396,9 +396,9 @@ internal class RealImageLoader(
                     }
 
                     // Decode the stream.
-                    eventListener.decodeStart(request, decoder)
+                    eventListener.decodeStart(request, decoder, options)
                     val decodeResult = decoder.decode(bitmapPool, fetchResult.source, size, options)
-                    eventListener.decodeEnd(request, decoder)
+                    eventListener.decodeEnd(request, decoder, options)
                     decodeResult
                 } catch (rethrown: Exception) {
                     // NOTE: We only close the stream automatically if there is an uncaught exception.

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -73,25 +73,25 @@ sealed class Request {
          * Called when the request is dispatched and starts loading the image.
          */
         @MainThread
-        fun onStart(data: Any) {}
+        fun onStart(request: Request) {}
 
         /**
          * Called when the request successfully loads the image.
          */
         @MainThread
-        fun onSuccess(data: Any, source: DataSource) {}
+        fun onSuccess(request: Request, source: DataSource) {}
 
         /**
          * Called when the request is cancelled.
          */
         @MainThread
-        fun onCancel(data: Any?) {}
+        fun onCancel(request: Request) {}
 
         /**
          * Called when the request fails to load the image.
          */
         @MainThread
-        fun onError(data: Any?, throwable: Throwable) {}
+        fun onError(request: Request, throwable: Throwable) {}
     }
 }
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -129,15 +129,15 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      * Convenience function to create and set the [Request.Listener].
      */
     inline fun listener(
-        crossinline onStart: (data: Any) -> Unit = {},
-        crossinline onCancel: (data: Any?) -> Unit = {},
-        crossinline onError: (data: Any?, throwable: Throwable) -> Unit = { _, _ -> },
-        crossinline onSuccess: (data: Any, source: DataSource) -> Unit = { _, _ -> }
+        crossinline onStart: (request: Request) -> Unit = {},
+        crossinline onCancel: (request: Request) -> Unit = {},
+        crossinline onError: (request: Request, throwable: Throwable) -> Unit = { _, _ -> },
+        crossinline onSuccess: (request: Request, source: DataSource) -> Unit = { _, _ -> }
     ): T = listener(object : Request.Listener {
-        override fun onStart(data: Any) = onStart(data)
-        override fun onCancel(data: Any?) = onCancel(data)
-        override fun onError(data: Any?, throwable: Throwable) = onError(data, throwable)
-        override fun onSuccess(data: Any, source: DataSource) = onSuccess(data, source)
+        override fun onStart(request: Request) = onStart(request)
+        override fun onCancel(request: Request) = onCancel(request)
+        override fun onError(request: Request, throwable: Throwable) = onError(request, throwable)
+        override fun onSuccess(request: Request, source: DataSource) = onSuccess(request, source)
     })
 
     /**

--- a/coil-base/src/main/java/coil/size/SizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/SizeResolver.kt
@@ -11,7 +11,7 @@ import coil.request.RequestBuilder
 interface SizeResolver {
 
     companion object {
-        /** Construct a [SizeResolver] instance with a fixed [size]. */
+        /** Create a [SizeResolver] with a fixed [size]. */
         @JvmStatic
         @JvmName("create")
         operator fun invoke(size: Size): SizeResolver {

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -11,7 +11,7 @@ interface ViewSizeResolver<T : View> : SizeResolver {
 
     companion object {
         /**
-         * Construct a [ViewSizeResolver] instance using the default [View] measurement implementation.
+         * Create a [ViewSizeResolver] using the default [View] measurement implementation.
          *
          * @param view The [View] to measure.
          * @param subtractPadding If true, the [view]'s padding will be subtracted from its size.

--- a/coil-base/src/main/java/coil/util/DebugLogger.kt
+++ b/coil-base/src/main/java/coil/util/DebugLogger.kt
@@ -10,7 +10,7 @@ import java.io.StringWriter
 /**
  * A [Logger] implementation that writes to Android's [Log].
  *
- * NOTE: You **should not** enable this in release builds. Adding this to your [ImageLoader] this reduces performance.
+ * NOTE: You **should not** enable this in release builds. Adding this to your [ImageLoader] reduces performance.
  * Additionally, this will log URLs which can contain [PII](https://en.wikipedia.org/wiki/Personal_data).
  */
 class DebugLogger : Logger {

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -77,6 +77,7 @@ class RealImageLoaderBasicTest {
             memoryCache,
             weakMemoryCache,
             OkHttpClient(),
+            EventListener.Factory.EMPTY,
             ComponentRegistry(),
             null
         )
@@ -542,7 +543,8 @@ class RealImageLoaderBasicTest {
                 override suspend fun size() = block()
             },
             targetDelegate = EmptyTargetDelegate,
-            request = createLoadRequest(context)
+            request = createLoadRequest(context),
+            eventListener = EventListener.EMPTY
         )
     }
 }

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -36,12 +36,6 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
                 }
                 add(SvgDecoder(this@Application))
             }
-            .apply {
-                // Enable logging to the standard Android log if this is a debug build.
-                if (BuildConfig.DEBUG) {
-                    logger(DebugLogger())
-                }
-            }
             .okHttpClient {
                 // Create a disk cache with "unlimited" size. Don't do this in production.
                 // To create the an optimized Coil disk cache, use CoilUtils.createDefaultCache(context).
@@ -57,6 +51,12 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
                     .forceTls12() // The Unsplash API requires TLS 1.2, which isn't enabled by default before Lollipop.
                     .addNetworkInterceptor(cacheControlInterceptor)
                     .build()
+            }
+            .apply {
+                // Enable logging to the standard Android log if this is a debug build.
+                if (BuildConfig.DEBUG) {
+                    logger(DebugLogger())
+                }
             }
             .build()
     }


### PR DESCRIPTION
Introduce an ImageLoader-scoped listener named `EventListener`. This is useful for analytics, performance, or other metrics tracking.

Fixes #310.

BREAKING CHANGE: Pass the full request object to `Request.Listener` instead of just its data.