### PR TITLE
Deprecate Coil and ImageLoader extension functions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     ci:
         name: Build + Test
         runs-on: macOS-latest
+        timeout-minutes: 30
         steps:
             - uses: actions/checkout@v2
 

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -118,10 +118,10 @@ public abstract interface class coil/ImageLoader {
 	public static fun builder (Landroid/content/Context;)Lcoil/ImageLoaderBuilder;
 	public abstract fun clearMemory ()V
 	public static fun create (Landroid/content/Context;)Lcoil/ImageLoader;
+	public abstract fun execute (Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun execute (Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun get (Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDefaults ()Lcoil/DefaultRequestOptions;
-	public abstract fun launch (Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun launch (Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun load (Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun shutdown ()V
 }

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -61,7 +61,7 @@ public final class coil/DefaultRequestOptions {
 
 public abstract interface class coil/EventListener : coil/request/Request$Listener {
 	public static final field Companion Lcoil/EventListener$Companion;
-	public static final field EMPTY Lcoil/EventListener;
+	public static final field NONE Lcoil/EventListener;
 	public abstract fun decodeEnd (Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
 	public abstract fun decodeStart (Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
 	public abstract fun fetchEnd (Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;)V
@@ -120,6 +120,8 @@ public abstract interface class coil/ImageLoader {
 	public static fun create (Landroid/content/Context;)Lcoil/ImageLoader;
 	public abstract fun get (Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getDefaults ()Lcoil/DefaultRequestOptions;
+	public abstract fun launch (Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun launch (Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun load (Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun shutdown ()V
 }
@@ -129,6 +131,11 @@ public final class coil/ImageLoader$Companion {
 	public final fun create (Landroid/content/Context;)Lcoil/ImageLoader;
 	public final fun invoke (Landroid/content/Context;Lkotlin/jvm/functions/Function1;)Lcoil/ImageLoader;
 	public static synthetic fun invoke$default (Lcoil/ImageLoader$Companion;Landroid/content/Context;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/ImageLoader;
+}
+
+public final class coil/ImageLoader$DefaultImpls {
+	public static fun get (Lcoil/ImageLoader;Lcoil/request/GetRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun load (Lcoil/ImageLoader;Lcoil/request/LoadRequest;)Lcoil/request/RequestDisposable;
 }
 
 public final class coil/ImageLoaderBuilder {
@@ -436,11 +443,11 @@ public final class coil/request/CachePolicy : java/lang/Enum {
 
 public final class coil/request/GetRequest : coil/request/Request {
 	public static final field Companion Lcoil/request/GetRequest$Companion;
-	public static final fun builder (Lcoil/DefaultRequestOptions;)Lcoil/request/GetRequestBuilder;
+	public static final fun builder ()Lcoil/request/GetRequestBuilder;
 	public static final fun builder (Lcoil/request/GetRequest;)Lcoil/request/GetRequestBuilder;
 	public fun getAliasKeys ()Ljava/util/List;
-	public fun getAllowHardware ()Z
-	public fun getAllowRgb565 ()Z
+	public fun getAllowHardware ()Ljava/lang/Boolean;
+	public fun getAllowRgb565 ()Ljava/lang/Boolean;
 	public fun getBitmapConfig ()Landroid/graphics/Bitmap$Config;
 	public fun getColorSpace ()Landroid/graphics/ColorSpace;
 	public fun getData ()Ljava/lang/Object;
@@ -449,6 +456,7 @@ public final class coil/request/GetRequest : coil/request/Request {
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getError ()Landroid/graphics/drawable/Drawable;
 	public fun getFallback ()Landroid/graphics/drawable/Drawable;
+	public fun getFetcher ()Lcoil/fetch/Fetcher;
 	public fun getHeaders ()Lokhttp3/Headers;
 	public fun getKey ()Ljava/lang/String;
 	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -467,7 +475,7 @@ public final class coil/request/GetRequest : coil/request/Request {
 }
 
 public final class coil/request/GetRequest$Companion {
-	public final fun builder (Lcoil/DefaultRequestOptions;)Lcoil/request/GetRequestBuilder;
+	public final fun builder ()Lcoil/request/GetRequestBuilder;
 	public final fun builder (Lcoil/request/GetRequest;)Lcoil/request/GetRequestBuilder;
 	public final fun invoke (Lcoil/DefaultRequestOptions;Lkotlin/jvm/functions/Function1;)Lcoil/request/GetRequest;
 	public final fun invoke (Lcoil/request/GetRequest;Lkotlin/jvm/functions/Function1;)Lcoil/request/GetRequest;
@@ -476,19 +484,19 @@ public final class coil/request/GetRequest$Companion {
 }
 
 public final class coil/request/GetRequestBuilder : coil/request/RequestBuilder {
-	public fun <init> (Lcoil/DefaultRequestOptions;)V
+	public fun <init> ()V
 	public fun <init> (Lcoil/request/GetRequest;)V
 	public final fun build ()Lcoil/request/GetRequest;
-	public final fun data (Ljava/lang/Object;)Lcoil/request/GetRequestBuilder;
 }
 
 public final class coil/request/LoadRequest : coil/request/Request {
 	public static final field Companion Lcoil/request/LoadRequest$Companion;
-	public static final fun builder (Landroid/content/Context;Lcoil/DefaultRequestOptions;)Lcoil/request/LoadRequestBuilder;
-	public static final fun builder (Landroid/content/Context;Lcoil/request/LoadRequest;)Lcoil/request/LoadRequestBuilder;
+	public static final fun builder (Landroid/content/Context;)Lcoil/request/LoadRequestBuilder;
+	public static final fun builder (Lcoil/request/LoadRequest;)Lcoil/request/LoadRequestBuilder;
+	public static final fun builder (Lcoil/request/LoadRequest;Landroid/content/Context;)Lcoil/request/LoadRequestBuilder;
 	public fun getAliasKeys ()Ljava/util/List;
-	public fun getAllowHardware ()Z
-	public fun getAllowRgb565 ()Z
+	public fun getAllowHardware ()Ljava/lang/Boolean;
+	public fun getAllowRgb565 ()Ljava/lang/Boolean;
 	public fun getBitmapConfig ()Landroid/graphics/Bitmap$Config;
 	public fun getColorSpace ()Landroid/graphics/ColorSpace;
 	public final fun getContext ()Landroid/content/Context;
@@ -498,6 +506,7 @@ public final class coil/request/LoadRequest : coil/request/Request {
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getError ()Landroid/graphics/drawable/Drawable;
 	public fun getFallback ()Landroid/graphics/drawable/Drawable;
+	public fun getFetcher ()Lcoil/fetch/Fetcher;
 	public fun getHeaders ()Lokhttp3/Headers;
 	public fun getKey ()Ljava/lang/String;
 	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -518,8 +527,10 @@ public final class coil/request/LoadRequest : coil/request/Request {
 }
 
 public final class coil/request/LoadRequest$Companion {
-	public final fun builder (Landroid/content/Context;Lcoil/DefaultRequestOptions;)Lcoil/request/LoadRequestBuilder;
-	public final fun builder (Landroid/content/Context;Lcoil/request/LoadRequest;)Lcoil/request/LoadRequestBuilder;
+	public final fun builder (Landroid/content/Context;)Lcoil/request/LoadRequestBuilder;
+	public final fun builder (Lcoil/request/LoadRequest;)Lcoil/request/LoadRequestBuilder;
+	public final fun builder (Lcoil/request/LoadRequest;Landroid/content/Context;)Lcoil/request/LoadRequestBuilder;
+	public static synthetic fun builder$default (Lcoil/request/LoadRequest$Companion;Lcoil/request/LoadRequest;Landroid/content/Context;ILjava/lang/Object;)Lcoil/request/LoadRequestBuilder;
 	public final fun invoke (Landroid/content/Context;Lcoil/DefaultRequestOptions;Lkotlin/jvm/functions/Function1;)Lcoil/request/LoadRequest;
 	public final fun invoke (Landroid/content/Context;Lcoil/request/LoadRequest;Lkotlin/jvm/functions/Function1;)Lcoil/request/LoadRequest;
 	public static synthetic fun invoke$default (Lcoil/request/LoadRequest$Companion;Landroid/content/Context;Lcoil/DefaultRequestOptions;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/LoadRequest;
@@ -527,12 +538,13 @@ public final class coil/request/LoadRequest$Companion {
 }
 
 public final class coil/request/LoadRequestBuilder : coil/request/RequestBuilder {
-	public fun <init> (Landroid/content/Context;Lcoil/DefaultRequestOptions;)V
-	public fun <init> (Landroid/content/Context;Lcoil/request/LoadRequest;)V
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Lcoil/request/LoadRequest;)V
+	public fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;)V
+	public synthetic fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lcoil/request/LoadRequest;
 	public final fun crossfade (I)Lcoil/request/LoadRequestBuilder;
 	public final fun crossfade (Z)Lcoil/request/LoadRequestBuilder;
-	public final fun data (Ljava/lang/Object;)Lcoil/request/LoadRequestBuilder;
 	public final fun error (I)Lcoil/request/LoadRequestBuilder;
 	public final fun error (Landroid/graphics/drawable/Drawable;)Lcoil/request/LoadRequestBuilder;
 	public final fun fallback (I)Lcoil/request/LoadRequestBuilder;
@@ -599,8 +611,8 @@ public final class coil/request/Parameters$Entry {
 
 public abstract class coil/request/Request {
 	public abstract fun getAliasKeys ()Ljava/util/List;
-	public abstract fun getAllowHardware ()Z
-	public abstract fun getAllowRgb565 ()Z
+	public abstract fun getAllowHardware ()Ljava/lang/Boolean;
+	public abstract fun getAllowRgb565 ()Ljava/lang/Boolean;
 	public abstract fun getBitmapConfig ()Landroid/graphics/Bitmap$Config;
 	public abstract fun getColorSpace ()Landroid/graphics/ColorSpace;
 	public abstract fun getData ()Ljava/lang/Object;
@@ -609,6 +621,7 @@ public abstract class coil/request/Request {
 	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public abstract fun getError ()Landroid/graphics/drawable/Drawable;
 	public abstract fun getFallback ()Landroid/graphics/drawable/Drawable;
+	public abstract fun getFetcher ()Lcoil/fetch/Fetcher;
 	public abstract fun getHeaders ()Lokhttp3/Headers;
 	public abstract fun getKey ()Ljava/lang/String;
 	public abstract fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -640,7 +653,26 @@ public final class coil/request/Request$Listener$DefaultImpls {
 }
 
 public abstract class coil/request/RequestBuilder {
-	public synthetic fun <init> (Lcoil/DefaultRequestOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	protected field aliasKeys Ljava/util/List;
+	protected field allowHardware Ljava/lang/Boolean;
+	protected field allowRgb565 Ljava/lang/Boolean;
+	protected field bitmapConfig Landroid/graphics/Bitmap$Config;
+	protected field colorSpace Landroid/graphics/ColorSpace;
+	protected field data Ljava/lang/Object;
+	protected field decoder Lcoil/decode/Decoder;
+	protected field diskCachePolicy Lcoil/request/CachePolicy;
+	protected field dispatcher Lkotlinx/coroutines/CoroutineDispatcher;
+	protected field fetcher Lcoil/fetch/Fetcher;
+	protected field headers Lokhttp3/Headers$Builder;
+	protected field key Ljava/lang/String;
+	protected field listener Lcoil/request/Request$Listener;
+	protected field memoryCachePolicy Lcoil/request/CachePolicy;
+	protected field networkCachePolicy Lcoil/request/CachePolicy;
+	protected field parameters Lcoil/request/Parameters$Builder;
+	protected field precision Lcoil/size/Precision;
+	protected field scale Lcoil/size/Scale;
+	protected field sizeResolver Lcoil/size/SizeResolver;
+	protected field transformations Ljava/util/List;
 	public synthetic fun <init> (Lcoil/request/Request;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public final fun aliasKeys (Ljava/util/List;)Lcoil/request/RequestBuilder;
@@ -649,28 +681,11 @@ public abstract class coil/request/RequestBuilder {
 	public final fun allowRgb565 (Z)Lcoil/request/RequestBuilder;
 	public final fun bitmapConfig (Landroid/graphics/Bitmap$Config;)Lcoil/request/RequestBuilder;
 	public final fun colorSpace (Landroid/graphics/ColorSpace;)Lcoil/request/RequestBuilder;
+	public final fun data (Ljava/lang/Object;)Lcoil/request/RequestBuilder;
 	public final fun decoder (Lcoil/decode/Decoder;)Lcoil/request/RequestBuilder;
 	public final fun diskCachePolicy (Lcoil/request/CachePolicy;)Lcoil/request/RequestBuilder;
 	public final fun dispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)Lcoil/request/RequestBuilder;
-	protected final fun getAliasKeys ()Ljava/util/List;
-	protected final fun getAllowHardware ()Z
-	protected final fun getAllowRgb565 ()Z
-	protected final fun getBitmapConfig ()Landroid/graphics/Bitmap$Config;
-	protected final fun getColorSpace ()Landroid/graphics/ColorSpace;
-	protected final fun getData ()Ljava/lang/Object;
-	protected final fun getDecoder ()Lcoil/decode/Decoder;
-	protected final fun getDiskCachePolicy ()Lcoil/request/CachePolicy;
-	protected final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
-	protected final fun getHeaders ()Lokhttp3/Headers$Builder;
-	protected final fun getKey ()Ljava/lang/String;
-	protected final fun getListener ()Lcoil/request/Request$Listener;
-	protected final fun getMemoryCachePolicy ()Lcoil/request/CachePolicy;
-	protected final fun getNetworkCachePolicy ()Lcoil/request/CachePolicy;
-	protected final fun getParameters ()Lcoil/request/Parameters$Builder;
-	protected final fun getPrecision ()Lcoil/size/Precision;
-	protected final fun getScale ()Lcoil/size/Scale;
-	protected final fun getSizeResolver ()Lcoil/size/SizeResolver;
-	protected final fun getTransformations ()Ljava/util/List;
+	public final fun fetcher (Lcoil/fetch/Fetcher;)Lcoil/request/RequestBuilder;
 	public final fun headers (Lokhttp3/Headers;)Lcoil/request/RequestBuilder;
 	public final fun key (Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public final fun listener (Lcoil/request/Request$Listener;)Lcoil/request/RequestBuilder;
@@ -683,29 +698,10 @@ public abstract class coil/request/RequestBuilder {
 	public final fun removeHeader (Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public final fun removeParameter (Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public final fun scale (Lcoil/size/Scale;)Lcoil/request/RequestBuilder;
-	protected final fun setAliasKeys (Ljava/util/List;)V
-	protected final fun setAllowHardware (Z)V
-	protected final fun setAllowRgb565 (Z)V
-	protected final fun setBitmapConfig (Landroid/graphics/Bitmap$Config;)V
-	protected final fun setColorSpace (Landroid/graphics/ColorSpace;)V
-	protected final fun setData (Ljava/lang/Object;)V
-	protected final fun setDecoder (Lcoil/decode/Decoder;)V
-	protected final fun setDiskCachePolicy (Lcoil/request/CachePolicy;)V
-	protected final fun setDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setHeader (Ljava/lang/String;Ljava/lang/String;)Lcoil/request/RequestBuilder;
-	protected final fun setHeaders (Lokhttp3/Headers$Builder;)V
-	protected final fun setKey (Ljava/lang/String;)V
-	protected final fun setListener (Lcoil/request/Request$Listener;)V
-	protected final fun setMemoryCachePolicy (Lcoil/request/CachePolicy;)V
-	protected final fun setNetworkCachePolicy (Lcoil/request/CachePolicy;)V
 	public final fun setParameter (Ljava/lang/String;Ljava/lang/Object;)Lcoil/request/RequestBuilder;
 	public final fun setParameter (Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public static synthetic fun setParameter$default (Lcoil/request/RequestBuilder;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcoil/request/RequestBuilder;
-	protected final fun setParameters (Lcoil/request/Parameters$Builder;)V
-	protected final fun setPrecision (Lcoil/size/Precision;)V
-	protected final fun setScale (Lcoil/size/Scale;)V
-	protected final fun setSizeResolver (Lcoil/size/SizeResolver;)V
-	protected final fun setTransformations (Ljava/util/List;)V
 	public final fun size (I)Lcoil/request/RequestBuilder;
 	public final fun size (II)Lcoil/request/RequestBuilder;
 	public final fun size (Lcoil/size/Size;)Lcoil/request/RequestBuilder;
@@ -892,7 +888,12 @@ public final class coil/transition/CrossfadeTransition : coil/transition/Transit
 }
 
 public abstract interface class coil/transition/Transition {
+	public static final field Companion Lcoil/transition/Transition$Companion;
+	public static final field NONE Lcoil/transition/Transition;
 	public abstract fun transition (Lcoil/transition/TransitionTarget;Lcoil/transition/TransitionResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class coil/transition/Transition$Companion {
 }
 
 public abstract class coil/transition/TransitionResult {

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -541,6 +541,7 @@ public final class coil/request/LoadRequest$Companion {
 public final class coil/request/LoadRequestBuilder : coil/request/RequestBuilder {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Lcoil/DefaultRequestOptions;)V
+	public fun <init> (Landroid/content/Context;Lcoil/request/LoadRequest;)V
 	public fun <init> (Lcoil/request/LoadRequest;)V
 	public fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;)V
 	public synthetic fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -485,6 +485,7 @@ public final class coil/request/GetRequest$Companion {
 
 public final class coil/request/GetRequestBuilder : coil/request/RequestBuilder {
 	public fun <init> ()V
+	public fun <init> (Lcoil/DefaultRequestOptions;)V
 	public fun <init> (Lcoil/request/GetRequest;)V
 	public final fun build ()Lcoil/request/GetRequest;
 }
@@ -539,6 +540,7 @@ public final class coil/request/LoadRequest$Companion {
 
 public final class coil/request/LoadRequestBuilder : coil/request/RequestBuilder {
 	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Lcoil/DefaultRequestOptions;)V
 	public fun <init> (Lcoil/request/LoadRequest;)V
 	public fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;)V
 	public synthetic fun <init> (Lcoil/request/LoadRequest;Landroid/content/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -104,7 +104,7 @@ public final class coil/EventListener$DefaultImpls {
 
 public abstract interface class coil/EventListener$Factory {
 	public static final field Companion Lcoil/EventListener$Factory$Companion;
-	public static final field EMPTY Lcoil/EventListener$Factory;
+	public static final field NONE Lcoil/EventListener$Factory;
 	public static fun create (Lcoil/EventListener;)Lcoil/EventListener$Factory;
 	public abstract fun newListener (Lcoil/request/Request;)Lcoil/EventListener;
 }

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -456,7 +456,7 @@ public final class coil/request/GetRequest : coil/request/Request {
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getError ()Landroid/graphics/drawable/Drawable;
 	public fun getFallback ()Landroid/graphics/drawable/Drawable;
-	public fun getFetcher ()Lcoil/fetch/Fetcher;
+	public fun getFetcher ()Lkotlin/Pair;
 	public fun getHeaders ()Lokhttp3/Headers;
 	public fun getKey ()Ljava/lang/String;
 	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -506,7 +506,7 @@ public final class coil/request/LoadRequest : coil/request/Request {
 	public fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getError ()Landroid/graphics/drawable/Drawable;
 	public fun getFallback ()Landroid/graphics/drawable/Drawable;
-	public fun getFetcher ()Lcoil/fetch/Fetcher;
+	public fun getFetcher ()Lkotlin/Pair;
 	public fun getHeaders ()Lokhttp3/Headers;
 	public fun getKey ()Ljava/lang/String;
 	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -621,7 +621,7 @@ public abstract class coil/request/Request {
 	public abstract fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public abstract fun getError ()Landroid/graphics/drawable/Drawable;
 	public abstract fun getFallback ()Landroid/graphics/drawable/Drawable;
-	public abstract fun getFetcher ()Lcoil/fetch/Fetcher;
+	public abstract fun getFetcher ()Lkotlin/Pair;
 	public abstract fun getHeaders ()Lokhttp3/Headers;
 	public abstract fun getKey ()Ljava/lang/String;
 	public abstract fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
@@ -662,7 +662,7 @@ public abstract class coil/request/RequestBuilder {
 	protected field decoder Lcoil/decode/Decoder;
 	protected field diskCachePolicy Lcoil/request/CachePolicy;
 	protected field dispatcher Lkotlinx/coroutines/CoroutineDispatcher;
-	protected field fetcher Lcoil/fetch/Fetcher;
+	protected field fetcher Lkotlin/Pair;
 	protected field headers Lokhttp3/Headers$Builder;
 	protected field key Ljava/lang/String;
 	protected field listener Lcoil/request/Request$Listener;
@@ -685,7 +685,7 @@ public abstract class coil/request/RequestBuilder {
 	public final fun decoder (Lcoil/decode/Decoder;)Lcoil/request/RequestBuilder;
 	public final fun diskCachePolicy (Lcoil/request/CachePolicy;)Lcoil/request/RequestBuilder;
 	public final fun dispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)Lcoil/request/RequestBuilder;
-	public final fun fetcher (Lcoil/fetch/Fetcher;)Lcoil/request/RequestBuilder;
+	public final fun fetcher (Ljava/lang/Class;Lcoil/fetch/Fetcher;)Lcoil/request/RequestBuilder;
 	public final fun headers (Lokhttp3/Headers;)Lcoil/request/RequestBuilder;
 	public final fun key (Ljava/lang/String;)Lcoil/request/RequestBuilder;
 	public final fun listener (Lcoil/request/Request$Listener;)Lcoil/request/RequestBuilder;

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -149,7 +149,7 @@ class EventListenerTest {
             )
             .apply(builder)
             .build()
-        launch(request)
+        execute(request)
     }
 
     private class MethodChecker(private val callExpected: Boolean) {

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -10,6 +10,7 @@ import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.decode.Options
 import coil.fetch.Fetcher
+import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
 import coil.request.Request
 import coil.size.Size
@@ -138,7 +139,7 @@ class EventListenerTest {
     private suspend fun ImageLoader.testLoad(
         builder: LoadRequestBuilder.() -> Unit
     ) = suspendCancellableCoroutine<Unit> { continuation ->
-        load(context)
+        val request = LoadRequest.Builder(context)
             .size(100, 100)
             .target(ImageView(context))
             .listener(
@@ -147,7 +148,8 @@ class EventListenerTest {
                 onCancel = { continuation.resumeWithException(CancellationException()) }
             )
             .apply(builder)
-            .launch()
+            .build()
+        launch(request)
     }
 
     private class MethodChecker(private val callExpected: Boolean) {

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -14,7 +14,6 @@ import coil.request.LoadRequestBuilder
 import coil.request.Request
 import coil.size.Size
 import coil.transform.CircleCropTransformation
-import coil.util.createLoadRequest
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -139,17 +138,16 @@ class EventListenerTest {
     private suspend fun ImageLoader.testLoad(
         builder: LoadRequestBuilder.() -> Unit
     ) = suspendCancellableCoroutine<Unit> { continuation ->
-        val request = createLoadRequest(context) {
-            size(100, 100)
-            target(ImageView(context))
-            listener(
+        load(context)
+            .size(100, 100)
+            .target(ImageView(context))
+            .listener(
                 onSuccess = { _, _ -> continuation.resume(Unit) },
                 onError = { _, throwable -> continuation.resumeWithException(throwable) },
                 onCancel = { continuation.resumeWithException(CancellationException()) }
             )
-            builder()
-        }
-        load(request)
+            .apply(builder)
+            .launch()
     }
 
     private class MethodChecker(private val callExpected: Boolean) {

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -11,10 +11,6 @@ import android.widget.ImageView
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
-import coil.api.get
-import coil.api.getAny
-import coil.api.load
-import coil.api.loadAny
 import coil.base.test.R
 import coil.bitmappool.BitmapPool
 import coil.decode.BitmapFactoryDecoder
@@ -25,6 +21,8 @@ import coil.decode.Options
 import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.fetch.DrawableResult
 import coil.request.CachePolicy
+import coil.request.GetRequest
+import coil.request.LoadRequest
 import coil.request.NullRequestDataException
 import coil.size.PixelSize
 import coil.size.Size
@@ -230,14 +228,16 @@ class RealImageLoaderIntegrationTest {
 
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
-                imageLoader.load(context, url) {
-                    memoryCachePolicy(CachePolicy.DISABLED)
-                    listener(
+                val request = LoadRequest.Builder(context)
+                    .data(url)
+                    .memoryCachePolicy(CachePolicy.DISABLED)
+                    .listener(
                         onSuccess = { _, _ -> continuation.resume(Unit) },
                         onError = { _, throwable -> continuation.resumeWithException(throwable) },
                         onCancel = { continuation.resumeWithException(CancellationException()) }
                     )
-                }
+                    .build()
+                imageLoader.launch(request)
             }
         }
 
@@ -277,9 +277,11 @@ class RealImageLoaderIntegrationTest {
         assertTrue(cacheFolder.listFiles().isNullOrEmpty())
 
         runBlocking {
-            imageLoader.get(url) {
-                memoryCachePolicy(CachePolicy.DISABLED)
-            }
+            val request = GetRequest.Builder()
+                .data(url)
+                .memoryCachePolicy(CachePolicy.DISABLED)
+                .build()
+            imageLoader.launch(request)
         }
 
         val cacheFile = cacheFolder.listFiles().orEmpty().find { it.name.contains(Cache.key(url)) && it.length() == IMAGE_SIZE }
@@ -299,10 +301,10 @@ class RealImageLoaderIntegrationTest {
                     isSampled = false,
                     dataSource = DataSource.MEMORY
                 ),
-                request = createGetRequest(context) { transformations(CircleCropTransformation()) },
+                request = createGetRequest { transformations(CircleCropTransformation()) },
                 size = size,
                 options = createOptions(),
-                eventListener = EventListener.EMPTY
+                eventListener = EventListener.NONE
             )
         }
 
@@ -323,10 +325,10 @@ class RealImageLoaderIntegrationTest {
                     isSampled = false,
                     dataSource = DataSource.MEMORY
                 ),
-                request = createGetRequest(context) { transformations(emptyList()) },
+                request = createGetRequest { transformations(emptyList()) },
                 size = size,
                 options = createOptions(),
-                eventListener = EventListener.EMPTY
+                eventListener = EventListener.NONE
             )
         }
 
@@ -342,11 +344,12 @@ class RealImageLoaderIntegrationTest {
             suspendCancellableCoroutine<Unit> { continuation ->
                 var hasCalledTargetOnError = false
 
-                imageLoader.loadAny(context, null) {
-                    size(100, 100)
-                    error(error)
-                    fallback(fallback)
-                    target(
+                val request = LoadRequest.Builder(context)
+                    .data(null)
+                    .size(100, 100)
+                    .error(error)
+                    .fallback(fallback)
+                    .target(
                         onStart = { throw IllegalStateException() },
                         onError = { drawable ->
                             check(drawable === fallback)
@@ -354,7 +357,7 @@ class RealImageLoaderIntegrationTest {
                         },
                         onSuccess = { throw IllegalStateException() }
                     )
-                    listener(
+                    .listener(
                         onStart = { throw IllegalStateException() },
                         onSuccess = { _, _ -> throw IllegalStateException() },
                         onCancel = { throw IllegalStateException() },
@@ -366,7 +369,8 @@ class RealImageLoaderIntegrationTest {
                             }
                         }
                     )
-                }
+                    .build()
+                imageLoader.launch(request)
             }
         }
     }
@@ -379,15 +383,17 @@ class RealImageLoaderIntegrationTest {
 
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
-                imageLoader.loadAny(context, data) {
-                    target(imageView)
-                    size(100, 100)
-                    listener(
+                val request = LoadRequest.Builder(context)
+                    .data(data)
+                    .target(imageView)
+                    .size(100, 100)
+                    .listener(
                         onSuccess = { _, _ -> continuation.resume(Unit) },
                         onError = { _, throwable -> continuation.resumeWithException(throwable) },
                         onCancel = { continuation.resumeWithException(CancellationException()) }
                     )
-                }
+                    .build()
+                imageLoader.launch(request)
             }
         }
 
@@ -398,9 +404,11 @@ class RealImageLoaderIntegrationTest {
 
     private fun testGet(data: Any, expectedSize: PixelSize = PixelSize(100, 125)) {
         val drawable = runBlocking {
-            imageLoader.getAny(data) {
-                size(100, 100)
-            }
+            val request = GetRequest.Builder()
+                .data(data)
+                .size(100, 100)
+                .build()
+            imageLoader.launch(request)
         }
 
         assertTrue(drawable is BitmapDrawable)

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -299,7 +299,7 @@ class RealImageLoaderIntegrationTest {
                     isSampled = false,
                     dataSource = DataSource.MEMORY
                 ),
-                request = createGetRequest { transformations(CircleCropTransformation()) },
+                request = createGetRequest(context) { transformations(CircleCropTransformation()) },
                 size = size,
                 options = createOptions(),
                 eventListener = EventListener.EMPTY
@@ -323,7 +323,7 @@ class RealImageLoaderIntegrationTest {
                     isSampled = false,
                     dataSource = DataSource.MEMORY
                 ),
-                request = createGetRequest { transformations(emptyList()) },
+                request = createGetRequest(context) { transformations(emptyList()) },
                 size = size,
                 options = createOptions(),
                 eventListener = EventListener.EMPTY

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -237,7 +237,7 @@ class RealImageLoaderIntegrationTest {
                         onCancel = { continuation.resumeWithException(CancellationException()) }
                     )
                     .build()
-                imageLoader.launch(request)
+                imageLoader.execute(request)
             }
         }
 
@@ -281,7 +281,7 @@ class RealImageLoaderIntegrationTest {
                 .data(url)
                 .memoryCachePolicy(CachePolicy.DISABLED)
                 .build()
-            imageLoader.launch(request)
+            imageLoader.execute(request)
         }
 
         val cacheFile = cacheFolder.listFiles().orEmpty().find { it.name.contains(Cache.key(url)) && it.length() == IMAGE_SIZE }
@@ -370,7 +370,7 @@ class RealImageLoaderIntegrationTest {
                         }
                     )
                     .build()
-                imageLoader.launch(request)
+                imageLoader.execute(request)
             }
         }
     }
@@ -393,7 +393,7 @@ class RealImageLoaderIntegrationTest {
                         onCancel = { continuation.resumeWithException(CancellationException()) }
                     )
                     .build()
-                imageLoader.launch(request)
+                imageLoader.execute(request)
             }
         }
 
@@ -408,7 +408,7 @@ class RealImageLoaderIntegrationTest {
                 .data(data)
                 .size(100, 100)
                 .build()
-            imageLoader.launch(request)
+            imageLoader.execute(request)
         }
 
         assertTrue(drawable is BitmapDrawable)

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -46,7 +46,7 @@ class RequestDisposableTest {
             .target { /* Do nothing. */ }
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         assertTrue(disposable is BaseTargetRequestDisposable)
         assertFalse(disposable.isDisposed)
@@ -63,7 +63,7 @@ class RequestDisposableTest {
             .target { result = it }
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         assertTrue(disposable is BaseTargetRequestDisposable)
         assertNull(result)
@@ -83,7 +83,7 @@ class RequestDisposableTest {
             .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         assertTrue(disposable is ViewTargetRequestDisposable)
         assertFalse(disposable.isDisposed)
@@ -101,7 +101,7 @@ class RequestDisposableTest {
             .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         assertTrue(disposable is ViewTargetRequestDisposable)
         assertNull(imageView.drawable)
@@ -121,7 +121,7 @@ class RequestDisposableTest {
             .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         runBlocking(Dispatchers.Main.immediate) {
             assertTrue(disposable is ViewTargetRequestDisposable)
@@ -153,7 +153,7 @@ class RequestDisposableTest {
                 .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
                 .listener(onError = { _, throwable -> throw throwable })
                 .build()
-            return imageLoader.launch(request)
+            return imageLoader.execute(request)
         }
 
         val disposable1 = launchNewRequest()
@@ -178,7 +178,7 @@ class RequestDisposableTest {
             .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
             .listener(onError = { _, throwable -> throw throwable })
             .build()
-        val disposable = imageLoader.launch(request)
+        val disposable = imageLoader.execute(request)
 
         assertFalse(disposable.isDisposed)
         CoilUtils.clear(imageView)

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -9,7 +9,6 @@ import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.RealImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.api.load
 import coil.util.CoilUtils
 import coil.util.requestManager
 import kotlinx.coroutines.Dispatchers
@@ -42,10 +41,12 @@ class RequestDisposableTest {
     @Test
     fun baseTargetRequestDisposable_dispose() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
-        val disposable = imageLoader.load(context, data) {
-            target { /* Do nothing. */ }
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target { /* Do nothing. */ }
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         assertTrue(disposable is BaseTargetRequestDisposable)
         assertFalse(disposable.isDisposed)
@@ -57,10 +58,12 @@ class RequestDisposableTest {
     fun baseTargetRequestDisposable_await() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
         var result: Drawable? = null
-        val disposable = imageLoader.load(context, data) {
-            target { result = it }
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target { result = it }
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         assertTrue(disposable is BaseTargetRequestDisposable)
         assertNull(result)
@@ -74,11 +77,13 @@ class RequestDisposableTest {
     fun viewTargetRequestDisposable_dispose() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
         val imageView = ImageView(context)
-        val disposable = imageLoader.load(context, data) {
-            target(imageView)
-            size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target(imageView)
+            .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         assertTrue(disposable is ViewTargetRequestDisposable)
         assertFalse(disposable.isDisposed)
@@ -90,11 +95,13 @@ class RequestDisposableTest {
     fun viewTargetRequestDisposable_await() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
         val imageView = ImageView(context)
-        val disposable = imageLoader.load(context, data) {
-            target(imageView)
-            size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target(imageView)
+            .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         assertTrue(disposable is ViewTargetRequestDisposable)
         assertNull(imageView.drawable)
@@ -108,11 +115,13 @@ class RequestDisposableTest {
     fun viewTargetRequestDisposable_restart() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
         val imageView = ImageView(context)
-        val disposable = imageLoader.load(context, data) {
-            target(imageView)
-            size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target(imageView)
+            .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         runBlocking(Dispatchers.Main.immediate) {
             assertTrue(disposable is ViewTargetRequestDisposable)
@@ -138,11 +147,13 @@ class RequestDisposableTest {
         val imageView = ImageView(context)
 
         fun launchNewRequest(): RequestDisposable {
-            return imageLoader.load(context, data) {
-                target(imageView)
-                size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
-                listener(onError = { _, throwable -> throw throwable })
-            }
+            val request = LoadRequest.Builder(context)
+                .data(data)
+                .target(imageView)
+                .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
+                .listener(onError = { _, throwable -> throw throwable })
+                .build()
+            return imageLoader.launch(request)
         }
 
         val disposable1 = launchNewRequest()
@@ -161,11 +172,13 @@ class RequestDisposableTest {
     fun viewTargetRequestDisposable_clear() {
         val data = "$SCHEME_CONTENT://coil/normal.jpg".toUri()
         val imageView = ImageView(context)
-        val disposable = imageLoader.load(context, data) {
-            target(imageView)
-            size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
-            listener(onError = { _, throwable -> throw throwable })
-        }
+        val request = LoadRequest.Builder(context)
+            .data(data)
+            .target(imageView)
+            .size(100) // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.
+            .listener(onError = { _, throwable -> throw throwable })
+            .build()
+        val disposable = imageLoader.launch(request)
 
         assertFalse(disposable.isDisposed)
         CoilUtils.clear(imageView)

--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -5,20 +5,20 @@ package coil
 import android.graphics.drawable.Drawable
 import coil.annotation.ExperimentalCoilApi
 import coil.request.CachePolicy
-import coil.request.RequestBuilder
+import coil.request.Request
 import coil.size.Precision
 import coil.transition.Transition
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 /**
- * A set of default request options, which are used to initialize a [RequestBuilder].
+ * A request options which are used as default values for unset [Request] options.
  *
  * @see ImageLoader.defaults
  */
 data class DefaultRequestOptions(
     val dispatcher: CoroutineDispatcher = Dispatchers.IO,
-    val transition: Transition? = null,
+    val transition: Transition = Transition.NONE,
     val precision: Precision = Precision.AUTOMATIC,
     val allowHardware: Boolean = true,
     val allowRgb565: Boolean = false,

--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 /**
- * A request options which are used as default values for unset [Request] options.
+ * A set of default options that are used to fill in unset [Request] values.
  *
  * @see ImageLoader.defaults
  */

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -27,8 +27,7 @@ import coil.transition.TransitionTarget
 interface EventListener : Request.Listener {
 
     companion object {
-        @JvmField
-        val NONE = object : EventListener {}
+        @JvmField val NONE = object : EventListener {}
     }
 
     /**
@@ -160,8 +159,7 @@ interface EventListener : Request.Listener {
     interface Factory {
 
         companion object {
-            @JvmField
-            val EMPTY = Factory(NONE)
+            @JvmField val EMPTY = Factory(NONE)
 
             /** Create an [EventListener.Factory] that returns the same [listener]. */
             @JvmStatic

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -28,7 +28,7 @@ interface EventListener : Request.Listener {
 
     companion object {
         @JvmField
-        val EMPTY = object : EventListener {}
+        val NONE = object : EventListener {}
     }
 
     /**
@@ -161,7 +161,7 @@ interface EventListener : Request.Listener {
 
         companion object {
             @JvmField
-            val EMPTY = Factory(EventListener.EMPTY)
+            val EMPTY = Factory(NONE)
 
             /** Create an [EventListener.Factory] that returns the same [listener]. */
             @JvmStatic

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -159,7 +159,7 @@ interface EventListener : Request.Listener {
     interface Factory {
 
         companion object {
-            @JvmField val EMPTY = Factory(NONE)
+            @JvmField val NONE = Factory(EventListener.NONE)
 
             /** Create an [EventListener.Factory] that returns the same [listener]. */
             @JvmStatic

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -14,7 +14,7 @@ import coil.request.RequestDisposable
 import coil.target.Target
 
 /**
- * Loads images using [launch] and [launch].
+ * A service class that fetches and decodes image data.
  */
 interface ImageLoader {
 
@@ -91,7 +91,7 @@ interface ImageLoader {
 
     /** @see launch */
     @Deprecated(
-        message = "Migrate to launch().",
+        message = "Migrate to launch(request).",
         replaceWith = ReplaceWith("launch(request)"),
         level = DeprecationLevel.ERROR
     )
@@ -99,7 +99,7 @@ interface ImageLoader {
 
     /** @see launch */
     @Deprecated(
-        message = "Migrate to launch().",
+        message = "Migrate to launch(request).",
         replaceWith = ReplaceWith("launch(request)"),
         level = DeprecationLevel.ERROR
     )

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -12,7 +12,11 @@ import coil.request.RequestDisposable
 import coil.target.Target
 
 /**
- * A service class that fetches and decodes image data.
+ * A service class that loads images by executing [Request]s. Image loaders handle caching, source fetching,
+ * image decoding, request management, bitmap pooling, memory management, and more.
+ *
+ * Image loaders are designed to be shareable and work best when you create a single instance and
+ * share it throughout your app.
  */
 interface ImageLoader {
 
@@ -39,30 +43,28 @@ interface ImageLoader {
     }
 
     /**
-     * The default options for any [Request]s created by this image loader.
+     * The default options that are used to fill in unset [Request] values.
      */
     val defaults: DefaultRequestOptions
 
     /**
-     * Launch an asynchronous operation that executes the [request] and sets the result on its [Target].
-     *
-     * If the request's target is null, this method preloads the image.
+     * Launch an asynchronous operation that executes the [LoadRequest] and sets the result on its [Target].
      *
      * @param request The request to execute.
      * @return A [RequestDisposable] which can be used to cancel or check the status of the request.
      */
-    fun launch(request: LoadRequest): RequestDisposable
+    fun execute(request: LoadRequest): RequestDisposable
 
     /**
-     * Executes the [request] and suspend until the operation is complete. Return the loaded [Drawable].
+     * Suspends and executes the [GetRequest]. Returns the loaded [Drawable] when complete.
      *
      * @param request The request to execute.
      * @return The [Drawable] result.
      */
-    suspend fun launch(request: GetRequest): Drawable
+    suspend fun execute(request: GetRequest): Drawable
 
     /**
-     * Completely clear this image loader's memory cache and bitmap pool.
+     * Clear this image loader's memory cache and bitmap pool.
      */
     @MainThread
     fun clearMemory()
@@ -77,19 +79,19 @@ interface ImageLoader {
     @MainThread
     fun shutdown()
 
-    /** @see launch */
+    /** @see execute */
     @Deprecated(
-        message = "Migrate to launch(request).",
-        replaceWith = ReplaceWith("launch(request)"),
+        message = "Migrate to execute(request).",
+        replaceWith = ReplaceWith("this.execute(request)"),
         level = DeprecationLevel.ERROR
     )
-    fun load(request: LoadRequest): RequestDisposable = launch(request)
+    fun load(request: LoadRequest): RequestDisposable = execute(request)
 
-    /** @see launch */
+    /** @see execute */
     @Deprecated(
-        message = "Migrate to launch(request).",
-        replaceWith = ReplaceWith("launch(request)"),
+        message = "Migrate to execute(request).",
+        replaceWith = ReplaceWith("this.execute(request)"),
         level = DeprecationLevel.ERROR
     )
-    suspend fun get(request: GetRequest): Drawable = launch(request)
+    suspend fun get(request: GetRequest): Drawable = execute(request)
 }

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -6,9 +6,7 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import androidx.annotation.MainThread
 import coil.request.GetRequest
-import coil.request.GetRequestBuilder
 import coil.request.LoadRequest
-import coil.request.LoadRequestBuilder
 import coil.request.Request
 import coil.request.RequestDisposable
 import coil.target.Target
@@ -46,17 +44,7 @@ interface ImageLoader {
     val defaults: DefaultRequestOptions
 
     /**
-     * Create a new [LoadRequestBuilder].
-     */
-    fun load(context: Context) = LoadRequestBuilder(context, this)
-
-    /**
-     * Create a new [GetRequestBuilder].
-     */
-    fun get() = GetRequestBuilder(this)
-
-    /**
-     * Start an asynchronous operation to load the [request]'s data into its [Target].
+     * Launch an asynchronous operation that executes the [request] and sets the result on its [Target].
      *
      * If the request's target is null, this method preloads the image.
      *
@@ -66,7 +54,7 @@ interface ImageLoader {
     fun launch(request: LoadRequest): RequestDisposable
 
     /**
-     * Load the [request]'s data and suspend until the operation is complete. Return the loaded [Drawable].
+     * Executes the [request] and suspend until the operation is complete. Return the loaded [Drawable].
      *
      * @param request The request to execute.
      * @return The [Drawable] result.
@@ -84,7 +72,7 @@ interface ImageLoader {
      *
      * All associated resources will be freed and any new requests will fail before starting.
      *
-     * In progress load requests will be cancelled. In progress get requests will continue until complete.
+     * In progress [LoadRequest]s will be cancelled. In progress [GetRequest]s will continue until complete.
      */
     @MainThread
     fun shutdown()

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -88,4 +88,20 @@ interface ImageLoader {
      */
     @MainThread
     fun shutdown()
+
+    /** @see launch */
+    @Deprecated(
+        message = "Migrate to launch().",
+        replaceWith = ReplaceWith("launch(request)"),
+        level = DeprecationLevel.ERROR
+    )
+    fun load(request: LoadRequest): RequestDisposable = launch(request)
+
+    /** @see launch */
+    @Deprecated(
+        message = "Migrate to launch().",
+        replaceWith = ReplaceWith("launch(request)"),
+        level = DeprecationLevel.ERROR
+    )
+    suspend fun get(request: GetRequest): Drawable = launch(request)
 }

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -12,7 +12,7 @@ import coil.request.RequestDisposable
 import coil.target.Target
 
 /**
- * A service class that loads images by executing [Request]s. Image loaders handle caching, source fetching,
+ * A service class that loads images by executing [Request]s. Image loaders handle caching, data fetching,
  * image decoding, request management, bitmap pooling, memory management, and more.
  *
  * Image loaders are designed to be shareable and work best when you create a single instance and

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -6,28 +6,30 @@ import android.content.Context
 import android.graphics.drawable.Drawable
 import androidx.annotation.MainThread
 import coil.request.GetRequest
+import coil.request.GetRequestBuilder
 import coil.request.LoadRequest
+import coil.request.LoadRequestBuilder
 import coil.request.Request
 import coil.request.RequestDisposable
 import coil.target.Target
 
 /**
- * Loads images using [load] and [get].
+ * Loads images using [launch] and [launch].
  */
 interface ImageLoader {
 
     companion object {
-        /** Alias to create an [ImageLoaderBuilder]. */
+        /** Alias for [ImageLoaderBuilder]. */
         @JvmStatic
         @JvmName("builder")
         inline fun Builder(context: Context) = ImageLoaderBuilder(context)
 
-        /** Alias to create a new [ImageLoader] without configuration. */
+        /** Create a new [ImageLoader] without configuration. */
         @JvmStatic
         @JvmName("create")
         inline operator fun invoke(context: Context) = ImageLoaderBuilder(context).build()
 
-        /** Create a new [ImageLoader] instance. */
+        /** Create a new [ImageLoader]. */
         @Deprecated(
             message = "Use ImageLoader.Builder to create new instances.",
             replaceWith = ReplaceWith("ImageLoader.Builder(context).apply(builder).build()")
@@ -44,6 +46,16 @@ interface ImageLoader {
     val defaults: DefaultRequestOptions
 
     /**
+     * Create a new [LoadRequestBuilder].
+     */
+    fun load(context: Context) = LoadRequestBuilder(context, this)
+
+    /**
+     * Create a new [GetRequestBuilder].
+     */
+    fun get() = GetRequestBuilder(this)
+
+    /**
      * Start an asynchronous operation to load the [request]'s data into its [Target].
      *
      * If the request's target is null, this method preloads the image.
@@ -51,7 +63,7 @@ interface ImageLoader {
      * @param request The request to execute.
      * @return A [RequestDisposable] which can be used to cancel or check the status of the request.
      */
-    fun load(request: LoadRequest): RequestDisposable
+    fun launch(request: LoadRequest): RequestDisposable
 
     /**
      * Load the [request]'s data and suspend until the operation is complete. Return the loaded [Drawable].
@@ -59,7 +71,7 @@ interface ImageLoader {
      * @param request The request to execute.
      * @return The [Drawable] result.
      */
-    suspend fun get(request: GetRequest): Drawable
+    suspend fun launch(request: GetRequest): Drawable
 
     /**
      * Completely clear this image loader's memory cache and bitmap pool.
@@ -72,7 +84,7 @@ interface ImageLoader {
      *
      * All associated resources will be freed and any new requests will fail before starting.
      *
-     * In progress [load] requests will be cancelled. In progress [get] requests will continue until complete.
+     * In progress load requests will be cancelled. In progress get requests will continue until complete.
      */
     @MainThread
     fun shutdown()

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -215,7 +215,7 @@ class ImageLoaderBuilder(context: Context) {
      * @see `crossfade(Boolean)`
      */
     fun crossfade(durationMillis: Int) = apply {
-        val factory = if (durationMillis > 0) CrossfadeTransition(durationMillis) else null
+        val factory = if (durationMillis > 0) CrossfadeTransition(durationMillis) else Transition.NONE
         this.defaults = this.defaults.copy(transition = factory)
     }
 
@@ -223,7 +223,7 @@ class ImageLoaderBuilder(context: Context) {
      * Set the default [Transition] for each request.
      */
     @ExperimentalCoilApi
-    fun transition(transition: Transition?) = apply {
+    fun transition(transition: Transition) = apply {
         this.defaults = this.defaults.copy(transition = transition)
     }
 

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -332,7 +332,7 @@ class ImageLoaderBuilder(context: Context) {
             memoryCache = memoryCache,
             weakMemoryCache = weakMemoryCache,
             callFactory = callFactory ?: buildDefaultCallFactory(),
-            eventListenerFactory = eventListenerFactory ?: EventListener.Factory.EMPTY,
+            eventListenerFactory = eventListenerFactory ?: EventListener.Factory.NONE,
             registry = registry ?: ComponentRegistry(),
             logger = logger
         )

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -136,7 +136,7 @@ internal class RealImageLoader(
         context.registerComponentCallbacks(this)
     }
 
-    override fun load(request: LoadRequest): RequestDisposable {
+    override fun launch(request: LoadRequest): RequestDisposable {
         // Start loading the data.
         val job = loaderScope.launch(exceptionHandler) { execute(request) }
 
@@ -148,7 +148,7 @@ internal class RealImageLoader(
         }
     }
 
-    override suspend fun get(request: GetRequest) = execute(request)
+    override suspend fun launch(request: GetRequest) = execute(request)
 
     private suspend fun execute(request: Request) = withContext(Dispatchers.Main.immediate) outerJob@{
         // Ensure this image loader isn't shutdown.

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -141,7 +141,7 @@ internal class RealImageLoader(
 
     override fun execute(request: LoadRequest): RequestDisposable {
         // Start loading the data.
-        val job = loaderScope.launch(exceptionHandler) { execute(request) }
+        val job = loaderScope.launch(exceptionHandler) { executeRequest(request) }
 
         return if (request.target is ViewTarget<*>) {
             val requestId = request.target.view.requestManager.setCurrentRequestJob(job)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -138,7 +138,7 @@ internal class RealImageLoader(
         context.registerComponentCallbacks(this)
     }
 
-    override fun launch(request: LoadRequest): RequestDisposable {
+    override fun execute(request: LoadRequest): RequestDisposable {
         // Start loading the data.
         val job = loaderScope.launch(exceptionHandler) { execute(request) }
 
@@ -150,9 +150,9 @@ internal class RealImageLoader(
         }
     }
 
-    override suspend fun launch(request: GetRequest) = execute(request)
+    override suspend fun execute(request: GetRequest): Drawable = executeRequest(request)
 
-    private suspend fun execute(request: Request) = withContext(Dispatchers.Main.immediate) outerJob@{
+    private suspend fun executeRequest(request: Request): Drawable = withContext(Dispatchers.Main.immediate) outerJob@{
         // Ensure this image loader isn't shutdown.
         assertNotShutdown()
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -74,6 +74,7 @@ import coil.util.putValue
 import coil.util.requestManager
 import coil.util.takeIf
 import coil.util.toDrawable
+import coil.util.validateFetcher
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -195,8 +196,7 @@ internal class RealImageLoader(
             eventListener.mapEnd(request, mappedData)
 
             // Compute the cache key.
-            @Suppress("UNCHECKED_CAST")
-            val fetcher = request.fetcher as Fetcher<Any>? ?: registry.requireFetcher(mappedData)
+            val fetcher = request.validateFetcher(mappedData) ?: registry.requireFetcher(mappedData)
             val cacheKey = request.key ?: computeCacheKey(fetcher, mappedData, request.parameters, request.transformations, lazySizeResolver)
 
             // Check the memory cache.

--- a/coil-base/src/main/java/coil/api/ImageLoaders.kt
+++ b/coil-base/src/main/java/coil/api/ImageLoaders.kt
@@ -33,7 +33,7 @@ import java.io.File
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(uri).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -41,19 +41,19 @@ inline fun ImageLoader.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(uri).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     uri: String,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(uri).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region URL (HttpUrl)
@@ -61,7 +61,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(url).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(url).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -69,19 +69,19 @@ inline fun ImageLoader.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(url).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(url).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(url).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(url).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     url: HttpUrl,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(url).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(url).apply(builder).build())
 
 // endregion
 // region Uri
@@ -89,7 +89,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(uri).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -97,19 +97,19 @@ inline fun ImageLoader.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(uri).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     uri: Uri,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(uri).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region File
@@ -117,7 +117,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(file).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(file).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -125,19 +125,19 @@ inline fun ImageLoader.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(file).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(file).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(file).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(file).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     file: File,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(file).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(file).apply(builder).build())
 
 // endregion
 // region Resource
@@ -145,7 +145,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -153,19 +153,19 @@ inline fun ImageLoader.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(drawableRes).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(drawableRes).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     @DrawableRes drawableRes: Int,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(drawableRes).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(drawableRes).apply(builder).build())
 
 // endregion
 // region Drawable
@@ -173,7 +173,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -181,19 +181,19 @@ inline fun ImageLoader.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(drawable).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(drawable).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(drawable).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     drawable: Drawable,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(drawable).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(drawable).apply(builder).build())
 
 // endregion
 // region Bitmap
@@ -201,7 +201,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -209,19 +209,19 @@ inline fun ImageLoader.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(bitmap).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(bitmap).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.get(
     bitmap: Bitmap,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(bitmap).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(bitmap).apply(builder).build())
 
 // endregion
 // region Any
@@ -229,7 +229,7 @@ suspend inline fun ImageLoader.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(LoadRequest.Builder(context).data(data).apply(builder).build())",
+        expression = "this.execute(LoadRequest.Builder(context).data(data).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -237,19 +237,19 @@ inline fun ImageLoader.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = launch(LoadRequest.Builder(context).data(data).apply(builder).build())
+): RequestDisposable = execute(LoadRequest.Builder(context).data(data).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.launch(GetRequest.Builder().data(data).apply(builder).build())",
+        expression = "this.execute(GetRequest.Builder().data(data).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun ImageLoader.getAny(
     data: Any,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = launch(GetRequest.Builder().data(data).apply(builder).build())
+): Drawable = execute(GetRequest.Builder().data(data).apply(builder).build())
 
 // endregion
 // region Request Creation

--- a/coil-base/src/main/java/coil/api/ImageLoaders.kt
+++ b/coil-base/src/main/java/coil/api/ImageLoaders.kt
@@ -28,120 +28,192 @@ import java.io.File
 
 // region URL (String)
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(uri).apply(builder).build())
+): RequestDisposable = load(context).data(uri).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     uri: String,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(uri).apply(builder).build())
+): Drawable = get().data(uri).apply(builder).launch()
 
 // endregion
 // region URL (HttpUrl)
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(url).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(url).apply(builder).build())
+): RequestDisposable = load(context).data(url).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(url).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     url: HttpUrl,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(url).apply(builder).build())
+): Drawable = get().data(url).apply(builder).launch()
 
 // endregion
 // region Uri
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(uri).apply(builder).build())
+): RequestDisposable = load(context).data(uri).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     uri: Uri,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(uri).apply(builder).build())
+): Drawable = get().data(uri).apply(builder).launch()
 
 // endregion
 // region File
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(file).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(file).apply(builder).build())
+): RequestDisposable = load(context).data(file).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(file).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     file: File,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(file).apply(builder).build())
+): Drawable = get().data(file).apply(builder).launch()
 
 // endregion
 // region Resource
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(drawableRes).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(drawableRes).apply(builder).build())
+): RequestDisposable = load(context).data(drawableRes).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(drawableRes).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     @DrawableRes drawableRes: Int,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(drawableRes).apply(builder).build())
+): Drawable = get().data(drawableRes).apply(builder).launch()
 
 // endregion
 // region Drawable
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(drawable).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(drawable).apply(builder).build())
+): RequestDisposable = load(context).data(drawable).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(drawable).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     drawable: Drawable,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(drawable).apply(builder).build())
+): Drawable = get().data(drawable).apply(builder).launch()
 
 // endregion
 // region Bitmap
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(bitmap).apply(builder).launch()")
+)
 inline fun ImageLoader.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(bitmap).apply(builder).build())
+): RequestDisposable = load(context).data(bitmap).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(bitmap).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.get(
     bitmap: Bitmap,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(bitmap).apply(builder).build())
+): Drawable = get().data(bitmap).apply(builder).launch()
 
 // endregion
 // region Any
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(data).apply(builder).launch()")
+)
 inline fun ImageLoader.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(LoadRequestBuilder(context, defaults).data(data).apply(builder).build())
+): RequestDisposable = load(context).data(data).apply(builder).launch()
 
+@Deprecated(
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(data).apply(builder).launch()")
+)
 suspend inline fun ImageLoader.getAny(
     data: Any,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get(GetRequestBuilder(defaults).data(data).apply(builder).build())
+): Drawable = get().data(data).apply(builder).launch()
 
 // endregion
 // region Request Creation
 
-inline fun ImageLoader.newLoadBuilder(context: Context) = LoadRequestBuilder(context, defaults)
+@Deprecated(
+    message = "Replace with class member function.",
+    replaceWith = ReplaceWith("load(context)")
+)
+inline fun ImageLoader.newLoadBuilder(context: Context) = load(context)
 
-inline fun ImageLoader.newGetBuilder() = GetRequestBuilder(defaults)
+@Deprecated(
+    message = "Replace with class member function.",
+    replaceWith = ReplaceWith("get()")
+)
+inline fun ImageLoader.newGetBuilder() = get()
 
 // endregion

--- a/coil-base/src/main/java/coil/api/ImageLoaders.kt
+++ b/coil-base/src/main/java/coil/api/ImageLoaders.kt
@@ -9,7 +9,9 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.annotation.DrawableRes
 import coil.ImageLoader
+import coil.request.GetRequest
 import coil.request.GetRequestBuilder
+import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
 import coil.request.RequestDisposable
 import okhttp3.HttpUrl
@@ -30,190 +32,238 @@ import java.io.File
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(uri).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     uri: String,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(uri).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region URL (HttpUrl)
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(url).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(url).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(url).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(url).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(url).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(url).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     url: HttpUrl,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(url).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(url).apply(builder).build())
 
 // endregion
 // region Uri
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(uri).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     uri: Uri,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(uri).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region File
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(file).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(file).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(file).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(file).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(file).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(file).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     file: File,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(file).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(file).apply(builder).build())
 
 // endregion
 // region Resource
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(drawableRes).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(drawableRes).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(drawableRes).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(drawableRes).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     @DrawableRes drawableRes: Int,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(drawableRes).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(drawableRes).apply(builder).build())
 
 // endregion
 // region Drawable
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(drawable).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(drawable).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(drawable).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(drawable).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     drawable: Drawable,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(drawable).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(drawable).apply(builder).build())
 
 // endregion
 // region Bitmap
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(bitmap).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(bitmap).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(bitmap).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(bitmap).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.get(
     bitmap: Bitmap,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(bitmap).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(bitmap).apply(builder).build())
 
 // endregion
 // region Any
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(data).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(LoadRequest.Builder(context).data(data).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun ImageLoader.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = load(context).data(data).apply(builder).launch()
+): RequestDisposable = launch(LoadRequest.Builder(context).data(data).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(data).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.launch(GetRequest.Builder().data(data).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun ImageLoader.getAny(
     data: Any,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = get().data(data).apply(builder).launch()
+): Drawable = launch(GetRequest.Builder().data(data).apply(builder).build())
 
 // endregion
 // region Request Creation
 
 @Deprecated(
-    message = "Replace with class member function.",
-    replaceWith = ReplaceWith("load(context)")
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("LoadRequest.Builder(context)")
 )
-inline fun ImageLoader.newLoadBuilder(context: Context) = load(context)
+inline fun ImageLoader.newLoadBuilder(context: Context) = LoadRequest.Builder(context)
 
 @Deprecated(
-    message = "Replace with class member function.",
-    replaceWith = ReplaceWith("get()")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("GetRequest.Builder()")
 )
-inline fun ImageLoader.newGetBuilder() = get()
+inline fun ImageLoader.newGetBuilder() = GetRequest.Builder()
 
 // endregion

--- a/coil-base/src/main/java/coil/decode/EmptyDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/EmptyDecoder.kt
@@ -1,9 +1,9 @@
 package coil.decode
 
-import android.graphics.drawable.ColorDrawable
 import coil.ComponentRegistry
 import coil.bitmappool.BitmapPool
 import coil.size.Size
+import coil.util.EMPTY_DRAWABLE
 import okio.BufferedSource
 import okio.blackholeSink
 
@@ -15,7 +15,7 @@ import okio.blackholeSink
 internal object EmptyDecoder : Decoder {
 
     private val result = DecodeResult(
-        drawable = ColorDrawable(),
+        drawable = EMPTY_DRAWABLE,
         isSampled = false
     )
     private val sink = blackholeSink()

--- a/coil-base/src/main/java/coil/memory/DelegateService.kt
+++ b/coil-base/src/main/java/coil/memory/DelegateService.kt
@@ -62,7 +62,6 @@ internal class DelegateService(
             is LoadRequest -> when (val target = request.target) {
                 is ViewTarget<*> -> {
                     requestDelegate = ViewTargetRequestDelegate(
-                        loader = imageLoader,
                         request = request,
                         target = targetDelegate,
                         lifecycle = lifecycle,

--- a/coil-base/src/main/java/coil/memory/DelegateService.kt
+++ b/coil-base/src/main/java/coil/memory/DelegateService.kt
@@ -62,6 +62,7 @@ internal class DelegateService(
             is LoadRequest -> when (val target = request.target) {
                 is ViewTarget<*> -> {
                     requestDelegate = ViewTargetRequestDelegate(
+                        imageLoader = imageLoader,
                         request = request,
                         target = targetDelegate,
                         lifecycle = lifecycle,

--- a/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
+++ b/coil-base/src/main/java/coil/memory/HardwareBitmapService.kt
@@ -97,8 +97,7 @@ private object LimitedFileDescriptorHardwareBitmapService : HardwareBitmapServic
  */
 private object HardwareBitmapBlacklist {
 
-    @JvmField
-    val IS_BLACKLISTED = when (SDK_INT) {
+    @JvmField val IS_BLACKLISTED = when (SDK_INT) {
         26 -> run {
             val model = Build.MODEL ?: return@run false
 

--- a/coil-base/src/main/java/coil/memory/RequestDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/RequestDelegate.kt
@@ -60,7 +60,7 @@ internal class ViewTargetRequestDelegate(
     /** Repeat this request with the same params. */
     @MainThread
     fun restart() {
-        imageLoader.launch(request)
+        imageLoader.execute(request)
     }
 
     override fun dispose() {

--- a/coil-base/src/main/java/coil/memory/RequestDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/RequestDelegate.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import coil.ImageLoader
 import coil.request.LoadRequest
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -49,7 +48,6 @@ internal class BaseRequestDelegate(
  * @see ViewTargetRequestManager
  */
 internal class ViewTargetRequestDelegate(
-    private val loader: ImageLoader,
     private val request: LoadRequest,
     private val target: TargetDelegate,
     private val lifecycle: Lifecycle,
@@ -60,7 +58,7 @@ internal class ViewTargetRequestDelegate(
     /** Repeat this request with the same params. */
     @MainThread
     fun restart() {
-        loader.load(request)
+        request.launch()
     }
 
     override fun dispose() {

--- a/coil-base/src/main/java/coil/memory/RequestDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/RequestDelegate.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import coil.ImageLoader
 import coil.request.LoadRequest
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
@@ -48,6 +49,7 @@ internal class BaseRequestDelegate(
  * @see ViewTargetRequestManager
  */
 internal class ViewTargetRequestDelegate(
+    private val imageLoader: ImageLoader,
     private val request: LoadRequest,
     private val target: TargetDelegate,
     private val lifecycle: Lifecycle,
@@ -58,7 +60,7 @@ internal class ViewTargetRequestDelegate(
     /** Repeat this request with the same params. */
     @MainThread
     fun restart() {
-        request.launch()
+        imageLoader.launch(request)
     }
 
     override fun dispose() {

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -4,6 +4,6 @@ import coil.ImageLoader
 import kotlin.coroutines.CoroutineContext
 
 /**
- * An exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [Request.data] is null.
+ * Exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [Request.data] is null.
  */
 class NullRequestDataException : RuntimeException("The request's data is null.")

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -5,7 +5,5 @@ import kotlin.coroutines.CoroutineContext
 
 /**
  * An exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [Request.data] is null.
- *
- * @see Request.fallback
  */
 class NullRequestDataException : RuntimeException("The request's data is null.")

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -4,7 +4,7 @@ import coil.ImageLoader
 import kotlin.coroutines.CoroutineContext
 
 /**
- * An exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [LoadRequest.data] is null.
+ * An exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [Request.data] is null.
  *
  * @see Request.fallback
  */

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -4,6 +4,6 @@ import coil.ImageLoader
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [Request.data] is null.
+ * Exception thrown by [ImageLoader.execute] (inside the [CoroutineContext]) when [Request.data] is null.
  */
 class NullRequestDataException : RuntimeException("The request's data is null.")

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -1,9 +1,10 @@
 package coil.request
 
 import coil.ImageLoader
+import kotlin.coroutines.CoroutineContext
 
 /**
- * Exception for when null [Request.data] is passed to [ImageLoader.load].
+ * An exception thrown by [ImageLoader.launch] (inside the [CoroutineContext]) when [LoadRequest.data] is null.
  *
  * @see Request.fallback
  */

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -15,8 +15,7 @@ class Parameters private constructor(
     constructor() : this(sortedMapOf())
 
     companion object {
-        @JvmField
-        val EMPTY = Parameters()
+        @JvmField val EMPTY = Parameters()
 
         /** Create a new [Parameters] instance. */
         @Deprecated(

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -50,7 +50,7 @@ sealed class Request {
     abstract val scale: Scale?
     abstract val precision: Precision?
 
-    abstract val fetcher: Fetcher<*>?
+    abstract val fetcher: Pair<Class<*>, Fetcher<*>>?
     abstract val decoder: Decoder?
 
     abstract val allowHardware: Boolean?
@@ -139,7 +139,7 @@ class LoadRequest internal constructor(
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,
     override val precision: Precision?,
-    override val fetcher: Fetcher<*>?,
+    override val fetcher: Pair<Class<*>, Fetcher<*>>?,
     override val decoder: Decoder?,
     override val allowHardware: Boolean?,
     override val allowRgb565: Boolean?,
@@ -249,7 +249,7 @@ class GetRequest internal constructor(
     override val sizeResolver: SizeResolver?,
     override val scale: Scale?,
     override val precision: Precision?,
-    override val fetcher: Fetcher<*>?,
+    override val fetcher: Pair<Class<*>, Fetcher<*>>?,
     override val decoder: Decoder?,
     override val allowHardware: Boolean?,
     override val allowRgb565: Boolean?,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.annotation.MainThread
 import androidx.lifecycle.Lifecycle
+import coil.DefaultRequestOptions
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
@@ -172,6 +173,29 @@ class LoadRequest internal constructor(
             request: LoadRequest,
             context: Context = request.context
         ) = LoadRequestBuilder(request, context)
+
+        /** Create a new [LoadRequest]. */
+        @Deprecated(
+            message = "Use LoadRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("LoadRequest.Builder(context).apply(builder).build()")
+        )
+        @Suppress("UNUSED_PARAMETER")
+        inline operator fun invoke(
+            context: Context,
+            defaults: DefaultRequestOptions,
+            builder: LoadRequestBuilder.() -> Unit = {}
+        ): LoadRequest = LoadRequestBuilder(context).apply(builder).build()
+
+        /** Create a new [LoadRequest]. */
+        @Deprecated(
+            message = "Use LoadRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("LoadRequest.Builder(request, context).apply(builder).build()")
+        )
+        inline operator fun invoke(
+            context: Context,
+            request: LoadRequest,
+            builder: LoadRequestBuilder.() -> Unit = {}
+        ): LoadRequest = LoadRequestBuilder(request, context).apply(builder).build()
     }
 
     override val placeholder: Drawable?
@@ -246,6 +270,27 @@ class GetRequest internal constructor(
         @JvmStatic
         @JvmName("builder")
         inline fun Builder(request: GetRequest) = GetRequestBuilder(request)
+
+        /** Create a new [GetRequest]. */
+        @Deprecated(
+            message = "Use GetRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("GetRequest.Builder(defaults).apply(builder).build()")
+        )
+        @Suppress("UNUSED_PARAMETER")
+        inline operator fun invoke(
+            defaults: DefaultRequestOptions,
+            builder: GetRequestBuilder.() -> Unit = {}
+        ): GetRequest = GetRequestBuilder().apply(builder).build()
+
+        /** Create a new [GetRequest]. */
+        @Deprecated(
+            message = "Use GetRequest.Builder to create new instances.",
+            replaceWith = ReplaceWith("GetRequest.Builder(request).apply(builder).build()")
+        )
+        inline operator fun invoke(
+            request: GetRequest,
+            builder: GetRequestBuilder.() -> Unit = {}
+        ): GetRequest = GetRequestBuilder(request).apply(builder).build()
     }
 
     override val target: Target? = null

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -120,11 +120,11 @@ sealed class Request {
  *     .data("https://www.example.com/image.jpg")
  *     .target(imageView)
  *     .build()
- * val disposable = imageLoader.launch(request)
+ * val disposable = imageLoader.execute(request)
  * ```
  *
  * @see LoadRequestBuilder
- * @see ImageLoader.launch
+ * @see ImageLoader.execute
  */
 class LoadRequest internal constructor(
     val context: Context,
@@ -231,7 +231,7 @@ class LoadRequest internal constructor(
  *     .data("https://www.example.com/image.jpg")
  *     .size(256, 256)
  *     .build()
- * val drawable = imageLoader.launch(request)
+ * val drawable = imageLoader.execute(request)
  * ```
  *
  * @see GetRequestBuilder

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -241,7 +241,7 @@ class LoadRequest internal constructor(
  */
 class GetRequest internal constructor(
     override val imageLoader: ImageLoader,
-    override val data: Any,
+    override val data: Any?,
     override val key: String?,
     override val aliasKeys: List<String>,
     override val listener: Listener?,

--- a/coil-base/src/main/java/coil/request/Request.kt
+++ b/coil-base/src/main/java/coil/request/Request.kt
@@ -33,6 +33,7 @@ import okhttp3.Headers
 sealed class Request {
 
     abstract val imageLoader: ImageLoader
+
     abstract val data: Any?
     abstract val key: String?
     abstract val aliasKeys: List<String>
@@ -97,7 +98,7 @@ sealed class Request {
 /**
  * A value object that represents a *load* image request.
  *
- * Instances can be created and executed ad hoc:
+ * Instances can be built and executed ad hoc:
  * ```
  * val disposable = imageLoader.load(context)
  *     .data("https://www.example.com/image.jpg")
@@ -106,14 +107,14 @@ sealed class Request {
  *     .launch()
  * ```
  *
- * Or instances can be created separately from the call that executes them:
+ * Or instances can be built and executed later:
  * ```
- * val request = LoadRequest.Builder(context, imageLoader)
+ * val request = imageLoader.load(context)
  *     .data("https://www.example.com/image.jpg")
  *     .crossfade(true)
  *     .target(imageView)
  *     .build()
- * val disposable = imageLoader.load(request)
+ * val disposable = request.launch()
  * ```
  *
  * @see LoadRequestBuilder
@@ -218,7 +219,7 @@ class LoadRequest internal constructor(
 /**
  * A value object that represents a *get* image request.
  *
- * Instances can be created and executed ad hoc:
+ * Instances can be built and executed ad hoc:
  * ```
  * val drawable = imageLoader.get()
  *     .data("https://www.example.com/image.jpg")
@@ -226,13 +227,13 @@ class LoadRequest internal constructor(
  *     .launch()
  * ```
  *
- * Or instances can be created separately from the call that executes them:
+ * Or instances can be built and executed later:
  * ```
- * val request = GetRequest.Builder(imageLoader)
+ * val request = imageLoader.get()
  *     .data("https://www.example.com/image.jpg")
  *     .size(1080, 1920)
  *     .build()
- * val drawable = imageLoader.get(request)
+ * val drawable = request.launch()
  * ```
  *
  * @see GetRequestBuilder

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -467,7 +467,6 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
         message = "Migrate to LoadRequest.Builder(request, context).",
         replaceWith = ReplaceWith("LoadRequest.Builder(request, context)")
     )
-    @Suppress("UNUSED_PARAMETER")
     constructor(context: Context, request: LoadRequest) : this(request, context)
 
     /**

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import coil.ComponentRegistry
+import coil.DefaultRequestOptions
 import coil.ImageLoader
 import coil.ImageLoaderBuilder
 import coil.annotation.BuilderMarker
@@ -455,6 +456,13 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
         fallbackDrawable = request.fallbackDrawable
     }
 
+    @Deprecated(
+        message = "Migrate to LoadRequest.Builder(context).",
+        replaceWith = ReplaceWith("LoadRequest.Builder(context)")
+    )
+    @Suppress("UNUSED_PARAMETER")
+    constructor(context: Context, defaults: DefaultRequestOptions) : this(context)
+
     /**
      * Convenience function to set [imageView] as the [Target].
      */
@@ -615,6 +623,13 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
     constructor() : super()
 
     constructor(request: GetRequest) : super(request)
+
+    @Deprecated(
+        message = "Migrate to GetRequest.Builder().",
+        replaceWith = ReplaceWith("GetRequest.Builder()")
+    )
+    @Suppress("UNUSED_PARAMETER")
+    constructor(defaults: DefaultRequestOptions) : this()
 
     /**
      * Create a new [GetRequest] instance.

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -120,6 +120,13 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     }
 
     /**
+     * Set the data to load.
+     */
+    fun data(data: Any?) = apply {
+        this.data = data
+    }
+
+    /**
      * Convenience function to create and set the [Request.Listener].
      */
     inline fun listener(
@@ -428,13 +435,6 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
     }
 
     /**
-     * Set the data to load.
-     */
-    fun data(data: Any?) = apply {
-        this.data = data
-    }
-
-    /**
      * Convenience function to set [imageView] as the [Target].
      */
     fun target(imageView: ImageView) = apply {
@@ -605,19 +605,12 @@ class GetRequestBuilder : RequestBuilder<GetRequestBuilder> {
     ) : super(request, loader)
 
     /**
-     * Set the data to load.
-     */
-    fun data(data: Any) = apply {
-        this.data = data
-    }
-
-    /**
      * Create a new [GetRequest] instance.
      */
     fun build(): GetRequest {
         return GetRequest(
             imageLoader,
-            checkNotNull(data) { "data == null" },
+            data,
             key,
             aliasKeys,
             listener,

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -122,7 +122,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     /**
      * Set the data to load.
      */
-    fun data(data: Any?) = apply {
+    fun data(data: Any?): T = self {
         this.data = data
     }
 

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -49,32 +49,32 @@ import java.io.File
 @BuilderMarker
 sealed class RequestBuilder<T : RequestBuilder<T>> {
 
-    protected var data: Any?
-    protected var key: String?
-    protected var aliasKeys: List<String>
+    @JvmField protected var data: Any?
+    @JvmField protected var key: String?
+    @JvmField protected var aliasKeys: List<String>
 
-    protected var listener: Request.Listener?
-    protected var dispatcher: CoroutineDispatcher?
-    protected var transformations: List<Transformation>
-    protected var bitmapConfig: Bitmap.Config
-    protected var colorSpace: ColorSpace? = null
+    @JvmField protected var listener: Request.Listener?
+    @JvmField protected var dispatcher: CoroutineDispatcher?
+    @JvmField protected var transformations: List<Transformation>
+    @JvmField protected var bitmapConfig: Bitmap.Config
+    @JvmField protected var colorSpace: ColorSpace? = null
 
-    protected var sizeResolver: SizeResolver?
-    protected var scale: Scale?
-    protected var precision: Precision?
+    @JvmField protected var sizeResolver: SizeResolver?
+    @JvmField protected var scale: Scale?
+    @JvmField protected var precision: Precision?
 
-    protected var fetcher: Fetcher<*>?
-    protected var decoder: Decoder?
+    @JvmField protected var fetcher: Fetcher<*>?
+    @JvmField protected var decoder: Decoder?
 
-    protected var allowHardware: Boolean?
-    protected var allowRgb565: Boolean?
+    @JvmField protected var allowHardware: Boolean?
+    @JvmField protected var allowRgb565: Boolean?
 
-    protected var memoryCachePolicy: CachePolicy?
-    protected var diskCachePolicy: CachePolicy?
-    protected var networkCachePolicy: CachePolicy?
+    @JvmField protected var memoryCachePolicy: CachePolicy?
+    @JvmField protected var diskCachePolicy: CachePolicy?
+    @JvmField protected var networkCachePolicy: CachePolicy?
 
-    protected var headers: Headers.Builder?
-    protected var parameters: Parameters.Builder?
+    @JvmField protected var headers: Headers.Builder?
+    @JvmField protected var parameters: Parameters.Builder?
 
     constructor() {
         data = null

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -63,7 +63,7 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
     @JvmField protected var scale: Scale?
     @JvmField protected var precision: Precision?
 
-    @JvmField protected var fetcher: Fetcher<*>?
+    @JvmField protected var fetcher: Pair<Class<*>, Fetcher<*>>?
     @JvmField protected var decoder: Decoder?
 
     @JvmField protected var allowHardware: Boolean?
@@ -288,8 +288,14 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
      *
      * NOTE: This skips calling [Fetcher.handles] for [fetcher].
      */
-    fun fetcher(fetcher: Fetcher<*>): T = self {
-        this.fetcher = fetcher
+    inline fun <reified R : Any> fetcher(fetcher: Fetcher<R>) = fetcher(R::class.java, fetcher)
+
+    /**
+     * @see RequestBuilder.fetcher
+     */
+    @PublishedApi
+    internal fun <R : Any> fetcher(type: Class<R>, fetcher: Fetcher<R>): T = self {
+        this.fetcher = type to fetcher
     }
 
     /**

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -47,6 +47,7 @@ import okio.BufferedSource
 sealed class RequestBuilder<T : RequestBuilder<T>> {
 
     protected val imageLoader: ImageLoader
+
     protected var data: Any?
     protected var key: String?
     protected var aliasKeys: List<String>
@@ -84,18 +85,14 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         dispatcher = defaults.dispatcher
         transformations = emptyList()
         bitmapConfig = Utils.getDefaultBitmapConfig()
-        if (SDK_INT >= 26) {
-            colorSpace = null
-        }
-        headers = null
-        parameters = null
-
+        if (SDK_INT >= 26) colorSpace = null
+        allowHardware = defaults.allowHardware
+        allowRgb565 = defaults.allowRgb565
         memoryCachePolicy = defaults.memoryCachePolicy
         diskCachePolicy = defaults.diskCachePolicy
         networkCachePolicy = defaults.networkCachePolicy
-
-        allowHardware = defaults.allowHardware
-        allowRgb565 = defaults.allowRgb565
+        headers = null
+        parameters = null
     }
 
     constructor(request: Request, loader: ImageLoader) {
@@ -112,18 +109,14 @@ sealed class RequestBuilder<T : RequestBuilder<T>> {
         dispatcher = request.dispatcher
         transformations = request.transformations
         bitmapConfig = request.bitmapConfig
-        if (SDK_INT >= 26) {
-            colorSpace = request.colorSpace
-        }
-        headers = request.headers.newBuilder()
-        parameters = request.parameters.newBuilder()
-
+        if (SDK_INT >= 26) colorSpace = request.colorSpace
+        allowHardware = request.allowHardware
+        allowRgb565 = request.allowRgb565
         networkCachePolicy = request.networkCachePolicy
         diskCachePolicy = request.diskCachePolicy
         memoryCachePolicy = request.memoryCachePolicy
-
-        allowHardware = request.allowHardware
-        allowRgb565 = request.allowRgb565
+        headers = request.headers.newBuilder()
+        parameters = request.parameters.newBuilder()
     }
 
     /**

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -525,7 +525,7 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
      * See: [ImageLoaderBuilder.crossfade]
      */
     fun crossfade(durationMillis: Int) = apply {
-        this.transition = if (durationMillis > 0) CrossfadeTransition(durationMillis) else null
+        this.transition = if (durationMillis > 0) CrossfadeTransition(durationMillis) else Transition.NONE
     }
 
     /**

--- a/coil-base/src/main/java/coil/request/RequestBuilder.kt
+++ b/coil-base/src/main/java/coil/request/RequestBuilder.kt
@@ -463,6 +463,13 @@ class LoadRequestBuilder : RequestBuilder<LoadRequestBuilder> {
     @Suppress("UNUSED_PARAMETER")
     constructor(context: Context, defaults: DefaultRequestOptions) : this(context)
 
+    @Deprecated(
+        message = "Migrate to LoadRequest.Builder(request, context).",
+        replaceWith = ReplaceWith("LoadRequest.Builder(request, context)")
+    )
+    @Suppress("UNUSED_PARAMETER")
+    constructor(context: Context, request: LoadRequest) : this(request, context)
+
     /**
      * Convenience function to set [imageView] as the [Target].
      */

--- a/coil-base/src/main/java/coil/request/RequestDisposable.kt
+++ b/coil-base/src/main/java/coil/request/RequestDisposable.kt
@@ -1,7 +1,6 @@
 package coil.request
 
 import android.view.View
-import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.target.ViewTarget
 import coil.util.requestManager
@@ -9,7 +8,7 @@ import kotlinx.coroutines.Job
 import java.util.UUID
 
 /**
- * Represents the work of an [ImageLoader.load] request.
+ * Represents the work of a launched [LoadRequest].
  */
 interface RequestDisposable {
 

--- a/coil-base/src/main/java/coil/transition/EmptyTransition.kt
+++ b/coil-base/src/main/java/coil/transition/EmptyTransition.kt
@@ -1,0 +1,20 @@
+@file:OptIn(ExperimentalCoilApi::class)
+
+package coil.transition
+
+import coil.annotation.ExperimentalCoilApi
+import coil.transition.TransitionResult.Error
+import coil.transition.TransitionResult.Success
+
+/**
+ * A transition that applies the [TransitionResult] on the [TransitionTarget] without animating.
+ */
+internal object EmptyTransition : Transition {
+
+    override suspend fun transition(target: TransitionTarget<*>, result: TransitionResult) {
+        when (result) {
+            is Success -> target.onSuccess(result.drawable)
+            is Error -> target.onError(result.drawable)
+        }
+    }
+}

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -15,8 +15,7 @@ import coil.target.Target
 interface Transition {
 
     companion object {
-        @JvmField
-        val NONE: Transition = EmptyTransition
+        @JvmField val NONE: Transition = EmptyTransition
     }
 
     /**

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -14,6 +14,11 @@ import coil.target.Target
 @ExperimentalCoilApi
 interface Transition {
 
+    companion object {
+        @JvmField
+        val NONE: Transition = EmptyTransition
+    }
+
     /**
      * Start the transition animation and suspend until it completes or is cancelled.
      *

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -30,6 +30,7 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.DefaultRequestOptions
 import coil.base.R
 import coil.decode.DataSource
+import coil.fetch.Fetcher
 import coil.memory.MemoryCache
 import coil.memory.ViewTargetRequestManager
 import coil.request.LoadRequest
@@ -277,4 +278,16 @@ internal inline fun Request.errorOrDefault(defaults: () -> DefaultRequestOptions
 
 internal inline fun Request.fallbackOrDefault(defaults: () -> DefaultRequestOptions): Drawable? {
     return if (this is LoadRequest && fallbackDrawable != null) fallback else defaults().fallback
+}
+
+/** Ensure [Request.fetcher] is valid for [data]. */
+@Suppress("UNCHECKED_CAST")
+internal fun <T : Any> Request.validateFetcher(data: T): Fetcher<T>? {
+    val (type, fetcher) = fetcher ?: return null
+
+    check(type.isAssignableFrom(data::class.java)) {
+        "${fetcher.javaClass.name} cannot handle data with type ${data.javaClass.name}."
+    }
+
+    return fetcher as Fetcher<T>
 }

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -7,7 +7,9 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.VectorDrawable
 import android.net.Uri
@@ -25,6 +27,7 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.drawable.toDrawable
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import coil.DefaultRequestOptions
 import coil.base.R
 import coil.decode.DataSource
 import coil.memory.MemoryCache
@@ -251,17 +254,27 @@ internal fun Resources.getDrawableCompat(@DrawableRes resId: Int, theme: Resourc
 internal val Configuration.nightMode: Int
     get() = uiMode and Configuration.UI_MODE_NIGHT_MASK
 
+internal val EMPTY_DRAWABLE = ColorDrawable(Color.TRANSPARENT)
+
 private val EMPTY_HEADERS = Headers.Builder().build()
 
 internal fun Headers?.orEmpty() = this ?: EMPTY_HEADERS
 
 internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY
 
-internal fun Request.isDiskOnlyPreload(): Boolean {
-    return this is LoadRequest && target == null && !memoryCachePolicy.writeEnabled
-}
-
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()
 
 internal inline val Any.identityHashCode: Int
     get() = System.identityHashCode(this)
+
+internal fun Request.placeholderOrDefault(defaults: () -> DefaultRequestOptions): Drawable? {
+    return if (this is LoadRequest && placeholderDrawable != null) placeholder else defaults().placeholder
+}
+
+internal inline fun Request.errorOrDefault(defaults: () -> DefaultRequestOptions): Drawable? {
+    return if (this is LoadRequest && errorDrawable != null) error else defaults().error
+}
+
+internal inline fun Request.fallbackOrDefault(defaults: () -> DefaultRequestOptions): Drawable? {
+    return if (this is LoadRequest && fallbackDrawable != null) fallback else defaults().fallback
+}

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -17,6 +17,7 @@ import coil.memory.EmptyTargetDelegate
 import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
 import coil.memory.WeakMemoryCache
+import coil.request.LoadRequest
 import coil.request.Parameters
 import coil.size.OriginalSize
 import coil.size.PixelSize
@@ -89,7 +90,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - fill`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
@@ -140,7 +141,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - fit`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
@@ -191,7 +192,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - small not sampled cached drawable is valid`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             precision(Precision.INEXACT)
         }
         val cached = createBitmap().toDrawable(context)
@@ -207,7 +208,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - bitmap config must be equal`() {
-        val request = createGetRequest(context)
+        val request = createGetRequest()
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
             val cached = createBitmap(config = config).toDrawable(context)
@@ -233,7 +234,7 @@ class RealImageLoaderBasicTest {
             cachedConfig: Bitmap.Config,
             requestedConfig: Bitmap.Config
         ): Boolean {
-            val request = createGetRequest(context) {
+            val request = createGetRequest {
                 allowRgb565(true)
                 bitmapConfig(requestedConfig)
             }
@@ -261,7 +262,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - allowHardware=false prevents using cached hardware bitmap`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             allowHardware(false)
         }
 
@@ -428,7 +429,7 @@ class RealImageLoaderBasicTest {
 
         runBlocking {
             var error: Throwable? = null
-            imageLoader.load(context)
+            val request = LoadRequest.Builder(context)
                 .key(key)
                 .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                 .size(100, 100)
@@ -448,8 +449,8 @@ class RealImageLoaderBasicTest {
                 .listener(
                     onError = { _, throwable -> error = throwable }
                 )
-                .launch()
-                .await()
+                .build()
+            imageLoader.launch(request).await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }
@@ -464,7 +465,7 @@ class RealImageLoaderBasicTest {
 
         runBlocking {
             var error: Throwable? = null
-            imageLoader.load(context)
+            val request = LoadRequest.Builder(context)
                 .key(key)
                 .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                 .size(100, 100)
@@ -482,8 +483,8 @@ class RealImageLoaderBasicTest {
                 .listener(
                     onError = { _, throwable -> error = throwable }
                 )
-                .launch()
-                .await()
+                .build()
+            imageLoader.launch(request).await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }
@@ -543,7 +544,8 @@ class RealImageLoaderBasicTest {
             },
             targetDelegate = EmptyTargetDelegate,
             request = createLoadRequest(context),
-            eventListener = EventListener.EMPTY
+            defaults = DefaultRequestOptions(),
+            eventListener = EventListener.NONE
         )
     }
 }

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -77,7 +77,7 @@ class RealImageLoaderBasicTest {
             memoryCache,
             weakMemoryCache,
             OkHttpClient(),
-            EventListener.Factory.EMPTY,
+            EventListener.Factory.NONE,
             ComponentRegistry(),
             null
         )

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -450,7 +450,7 @@ class RealImageLoaderBasicTest {
                     onError = { _, throwable -> error = throwable }
                 )
                 .build()
-            imageLoader.launch(request).await()
+            imageLoader.execute(request).await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }
@@ -484,7 +484,7 @@ class RealImageLoaderBasicTest {
                     onError = { _, throwable -> error = throwable }
                 )
                 .build()
-            imageLoader.launch(request).await()
+            imageLoader.execute(request).await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -89,7 +89,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - fill`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             size(100, 100)
             precision(Precision.INEXACT)
         }
@@ -140,7 +140,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - fit`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             size(100, 100)
             precision(Precision.INEXACT)
         }
@@ -191,7 +191,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - small not sampled cached drawable is valid`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             precision(Precision.INEXACT)
         }
         val cached = createBitmap().toDrawable(context)
@@ -207,7 +207,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - bitmap config must be equal`() {
-        val request = createGetRequest()
+        val request = createGetRequest(context)
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
             val cached = createBitmap(config = config).toDrawable(context)
@@ -233,7 +233,7 @@ class RealImageLoaderBasicTest {
             cachedConfig: Bitmap.Config,
             requestedConfig: Bitmap.Config
         ): Boolean {
-            val request = createGetRequest {
+            val request = createGetRequest(context) {
                 allowRgb565(true)
                 bitmapConfig(requestedConfig)
             }
@@ -261,7 +261,7 @@ class RealImageLoaderBasicTest {
 
     @Test
     fun `isCachedDrawableValid - allowHardware=false prevents using cached hardware bitmap`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             allowHardware(false)
         }
 

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -8,7 +8,6 @@ import android.graphics.ImageDecoder
 import android.graphics.drawable.BitmapDrawable
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
-import coil.api.newLoadBuilder
 import coil.bitmappool.BitmapPool
 import coil.decode.Options
 import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
@@ -429,7 +428,7 @@ class RealImageLoaderBasicTest {
 
         runBlocking {
             var error: Throwable? = null
-            val request = imageLoader.newLoadBuilder(context)
+            imageLoader.load(context)
                 .key(key)
                 .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                 .size(100, 100)
@@ -449,8 +448,8 @@ class RealImageLoaderBasicTest {
                 .listener(
                     onError = { _, throwable -> error = throwable }
                 )
-                .build()
-            imageLoader.load(request).await()
+                .launch()
+                .await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }
@@ -465,7 +464,7 @@ class RealImageLoaderBasicTest {
 
         runBlocking {
             var error: Throwable? = null
-            val request = imageLoader.newLoadBuilder(context)
+            imageLoader.load(context)
                 .key(key)
                 .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                 .size(100, 100)
@@ -483,8 +482,8 @@ class RealImageLoaderBasicTest {
                 .listener(
                     onError = { _, throwable -> error = throwable }
                 )
-                .build()
-            imageLoader.load(request).await()
+                .launch()
+                .await()
 
             // Rethrow any errors that occurred while loading.
             error?.let { throw it }

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -62,7 +62,7 @@ class TargetDelegateTest {
     @Test
     fun `empty target does not invalidate`() {
         val request = createLoadRequest(context)
-        val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
+        val delegate = delegateService.createTargetDelegate(request, EventListener.NONE)
 
         runBlocking {
             val bitmap = createBitmap()
@@ -73,19 +73,19 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), false, null)
+            delegate.success(bitmap.toDrawable(context), false, Transition.NONE)
             assertFalse(counter.isInvalid(bitmap))
         }
     }
 
     @Test
     fun `get request invalidates the success bitmap`() {
-        val request = createGetRequest(context)
-        val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
+        val request = createGetRequest()
+        val delegate = delegateService.createTargetDelegate(request, EventListener.NONE)
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), false, null)
+            delegate.success(bitmap.toDrawable(context), false, Transition.NONE)
             assertTrue(counter.isInvalid(bitmap))
         }
     }
@@ -96,7 +96,7 @@ class TargetDelegateTest {
         val request = createLoadRequest(context) {
             target(target)
         }
-        val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
+        val delegate = delegateService.createTargetDelegate(request, EventListener.NONE)
 
         runBlocking {
             val bitmap = createBitmap()
@@ -108,14 +108,14 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), false, null)
+            delegate.success(bitmap.toDrawable(context), false, Transition.NONE)
             assertTrue(target.success)
             assertTrue(counter.isInvalid(bitmap))
         }
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.error(bitmap.toDrawable(context), null)
+            delegate.error(bitmap.toDrawable(context), Transition.NONE)
             assertTrue(target.error)
             assertFalse(counter.isInvalid(bitmap))
         }
@@ -126,7 +126,7 @@ class TargetDelegateTest {
         val request = createLoadRequest(context) {
             target(ImageViewTarget(ImageView(context)))
         }
-        val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
+        val delegate = delegateService.createTargetDelegate(request, EventListener.NONE)
 
         val initialBitmap = createBitmap()
         val initialDrawable = initialBitmap.toDrawable(context)
@@ -136,7 +136,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            delegate.success(bitmap.toDrawable(context), false, null)
+            delegate.success(bitmap.toDrawable(context), false, Transition.NONE)
             assertFalse(counter.isInvalid(bitmap))
             assertTrue(pool.bitmaps.contains(initialBitmap))
         }
@@ -147,7 +147,7 @@ class TargetDelegateTest {
         val request = createLoadRequest(context) {
             target(ImageViewTarget(ImageView(context)))
         }
-        val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
+        val delegate = delegateService.createTargetDelegate(request, EventListener.NONE)
 
         val initialBitmap = createBitmap()
         val initialDrawable = initialBitmap.toDrawable(context)

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -80,7 +80,7 @@ class TargetDelegateTest {
 
     @Test
     fun `get request invalidates the success bitmap`() {
-        val request = createGetRequest()
+        val request = createGetRequest(context)
         val delegate = delegateService.createTargetDelegate(request, EventListener.EMPTY)
 
         runBlocking {

--- a/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
@@ -26,7 +26,7 @@ class RequestBuilderTest {
             .crossfade(false)
             .build()
 
-        val request = LoadRequest.Builder(context, loader.defaults)
+        val request = LoadRequest.Builder(context, loader)
             .crossfade(false)
             .build()
 

--- a/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
@@ -26,7 +26,7 @@ class RequestBuilderTest {
             .crossfade(false)
             .build()
 
-        val request = LoadRequest.Builder(context, loader)
+        val request = LoadRequest.Builder(context)
             .crossfade(false)
             .build()
 

--- a/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestBuilderTest.kt
@@ -3,13 +3,16 @@ package coil.request
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
+import coil.transition.Transition
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.assertNull
+import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoilApi::class)
 class RequestBuilderTest {
 
     private lateinit var context: Context
@@ -21,7 +24,7 @@ class RequestBuilderTest {
 
     /** Regression test: https://github.com/coil-kt/coil/issues/221 */
     @Test
-    fun `crossfade false creates no transition`() {
+    fun `crossfade false creates none transition`() {
         val loader = ImageLoader.Builder(context)
             .crossfade(false)
             .build()
@@ -30,7 +33,7 @@ class RequestBuilderTest {
             .crossfade(false)
             .build()
 
-        assertNull(request.transition)
+        assertEquals(Transition.NONE, request.transition)
 
         loader.shutdown()
     }

--- a/coil-base/src/test/java/coil/request/RequestServiceTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestServiceTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
+import coil.DefaultRequestOptions
 import coil.memory.RequestService
 import coil.size.Precision
 import coil.target.ViewTarget
@@ -25,7 +26,7 @@ class RequestServiceTest {
     @Before
     fun before() {
         context = ApplicationProvider.getApplicationContext()
-        service = RequestService(null)
+        service = RequestService(DefaultRequestOptions(), null)
     }
 
     @Test
@@ -39,7 +40,7 @@ class RequestServiceTest {
 
     @Test
     fun `allowInexactSize - inexact precision`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             precision(Precision.INEXACT)
         }
         assertTrue(service.allowInexactSize(request))
@@ -80,7 +81,7 @@ class RequestServiceTest {
 
     @Test
     fun `allowInexactSize - GetRequest`() {
-        val request = createGetRequest(context) {
+        val request = createGetRequest {
             size(100)
         }
         assertFalse(service.allowInexactSize(request))

--- a/coil-base/src/test/java/coil/request/RequestServiceTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestServiceTest.kt
@@ -39,7 +39,7 @@ class RequestServiceTest {
 
     @Test
     fun `allowInexactSize - inexact precision`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             precision(Precision.INEXACT)
         }
         assertTrue(service.allowInexactSize(request))
@@ -80,7 +80,7 @@ class RequestServiceTest {
 
     @Test
     fun `allowInexactSize - GetRequest`() {
-        val request = createGetRequest {
+        val request = createGetRequest(context) {
             size(100)
         }
         assertFalse(service.allowInexactSize(request))

--- a/coil-default/api/coil-default.api
+++ b/coil-default/api/coil-default.api
@@ -14,13 +14,6 @@ public abstract interface class coil/ImageLoaderFactory {
 
 public final class coil/api/Coils {
 	public static final fun get (Lcoil/Coil;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Landroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Ljava/io/File;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun get (Lcoil/Coil;Landroid/content/Context;Lokhttp3/HttpUrl;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcoil/Coil;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcoil/Coil;Landroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcoil/Coil;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -28,22 +21,13 @@ public final class coil/api/Coils {
 	public static final fun get (Lcoil/Coil;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun get (Lcoil/Coil;Lokhttp3/HttpUrl;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Landroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Ljava/io/File;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lcoil/Coil;Landroid/content/Context;Lokhttp3/HttpUrl;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Landroid/graphics/drawable/Drawable;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Landroid/net/Uri;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Ljava/io/File;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lcoil/Coil;Lokhttp3/HttpUrl;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun getAny (Lcoil/Coil;Landroid/content/Context;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getAny (Lcoil/Coil;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun getAny$default (Lcoil/Coil;Landroid/content/Context;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun getAny$default (Lcoil/Coil;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun load (Lcoil/Coil;Landroid/content/Context;ILkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
 	public static final fun load (Lcoil/Coil;Landroid/content/Context;Landroid/graphics/Bitmap;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
@@ -65,13 +49,13 @@ public final class coil/api/Coils {
 
 public final class coil/api/ImageViews {
 	public static final fun clear (Landroid/widget/ImageView;)V
-	public static final fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
@@ -79,7 +63,7 @@ public final class coil/api/ImageViews {
 	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static final fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
 	public static synthetic fun loadAny$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
 }
 

--- a/coil-default/src/main/java/coil/Coil.kt
+++ b/coil-default/src/main/java/coil/Coil.kt
@@ -4,8 +4,6 @@ package coil
 
 import android.app.Application
 import android.content.Context
-import coil.request.GetRequestBuilder
-import coil.request.LoadRequestBuilder
 import coil.util.CoilContentProvider
 
 /**
@@ -15,22 +13,6 @@ object Coil {
 
     private var imageLoader: ImageLoader? = null
     private var imageLoaderFactory: ImageLoaderFactory? = null
-
-    /**
-     * Convenience function to get the default [ImageLoader] and create a new [LoadRequestBuilder].
-     *
-     * @see ImageLoader.load
-     */
-    @JvmStatic
-    fun load(context: Context): LoadRequestBuilder = imageLoader(context).load(context)
-
-    /**
-     * Convenience function to get the default [ImageLoader] and create a new [GetRequestBuilder].
-     *
-     * @see ImageLoader.get
-     */
-    @JvmStatic
-    fun get(context: Context): GetRequestBuilder = imageLoader(context).get()
 
     /** @see imageLoader */
     @Deprecated(

--- a/coil-default/src/main/java/coil/Coil.kt
+++ b/coil-default/src/main/java/coil/Coil.kt
@@ -4,6 +4,8 @@ package coil
 
 import android.app.Application
 import android.content.Context
+import coil.request.GetRequestBuilder
+import coil.request.LoadRequestBuilder
 import coil.util.CoilContentProvider
 
 /**
@@ -13,6 +15,14 @@ object Coil {
 
     private var imageLoader: ImageLoader? = null
     private var imageLoaderFactory: ImageLoaderFactory? = null
+
+    /** @see ImageLoader.load */
+    @JvmStatic
+    fun load(context: Context): LoadRequestBuilder = imageLoader(context).load(context)
+
+    /** @see ImageLoader.get */
+    @JvmStatic
+    fun get(context: Context): GetRequestBuilder = imageLoader(context).get()
 
     /** @see imageLoader */
     @Deprecated(

--- a/coil-default/src/main/java/coil/Coil.kt
+++ b/coil-default/src/main/java/coil/Coil.kt
@@ -17,7 +17,7 @@ object Coil {
     /** @see imageLoader */
     @Deprecated(
         message = "Migrate to imageLoader(context).",
-        replaceWith = ReplaceWith("imageLoader(context)")
+        replaceWith = ReplaceWith("this.imageLoader(context)")
     )
     @JvmStatic
     fun loader(): ImageLoader = imageLoader(CoilContentProvider.context)
@@ -59,7 +59,7 @@ object Coil {
     /** @see setImageLoader */
     @Deprecated(
         message = "Migrate to setImageLoader(loader).",
-        replaceWith = ReplaceWith("setImageLoader(loader)")
+        replaceWith = ReplaceWith("this.setImageLoader(loader)")
     )
     @JvmStatic
     fun setDefaultImageLoader(loader: ImageLoader) = setImageLoader(loader)
@@ -67,7 +67,7 @@ object Coil {
     /** @see setImageLoader */
     @Deprecated(
         message = "Migrate to setDefaultImageLoader(ImageLoaderFactory).",
-        replaceWith = ReplaceWith("setImageLoader(object : ImageLoaderFactory { override fun getImageLoader() = initializer() })")
+        replaceWith = ReplaceWith("this.setImageLoader(object : ImageLoaderFactory { override fun getImageLoader() = initializer() })")
     )
     @JvmStatic
     fun setDefaultImageLoader(initializer: () -> ImageLoader) {

--- a/coil-default/src/main/java/coil/Coil.kt
+++ b/coil-default/src/main/java/coil/Coil.kt
@@ -16,11 +16,19 @@ object Coil {
     private var imageLoader: ImageLoader? = null
     private var imageLoaderFactory: ImageLoaderFactory? = null
 
-    /** @see ImageLoader.load */
+    /**
+     * Convenience function to get the default [ImageLoader] and create a new [LoadRequestBuilder].
+     *
+     * @see ImageLoader.load
+     */
     @JvmStatic
     fun load(context: Context): LoadRequestBuilder = imageLoader(context).load(context)
 
-    /** @see ImageLoader.get */
+    /**
+     * Convenience function to get the default [ImageLoader] and create a new [GetRequestBuilder].
+     *
+     * @see ImageLoader.get
+     */
     @JvmStatic
     fun get(context: Context): GetRequestBuilder = imageLoader(context).get()
 

--- a/coil-default/src/main/java/coil/api/Coils.kt
+++ b/coil-default/src/main/java/coil/api/Coils.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Coils")
-@file:Suppress("unused")
+@file:Suppress("NOTHING_TO_INLINE", "unused")
 
 package coil.api
 
@@ -28,21 +28,19 @@ import java.io.File
 
 // region URL (String)
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, uri, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    uri: String,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(uri, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, uri).",
-    replaceWith = ReplaceWith("get(context, uri, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     uri: String,
@@ -52,21 +50,19 @@ suspend inline fun Coil.get(
 // endregion
 // region URL (HttpUrl)
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(url).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, url, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    url: HttpUrl,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(url, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, url).",
-    replaceWith = ReplaceWith("get(context, url, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(url).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     url: HttpUrl,
@@ -76,21 +72,19 @@ suspend inline fun Coil.get(
 // endregion
 // region Uri
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, uri, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    uri: Uri,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(uri, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, uri).",
-    replaceWith = ReplaceWith("get(context, uri, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     uri: Uri,
@@ -100,21 +94,19 @@ suspend inline fun Coil.get(
 // endregion
 // region File
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(file).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, file, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    file: File,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(file, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, file).",
-    replaceWith = ReplaceWith("get(context, file, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(file).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     file: File,
@@ -124,21 +116,19 @@ suspend inline fun Coil.get(
 // endregion
 // region Resource
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(drawableRes).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, drawableRes, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    @DrawableRes drawableRes: Int,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(drawableRes, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, drawableRes).",
-    replaceWith = ReplaceWith("get(context, drawableRes, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(drawableRes).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     @DrawableRes drawableRes: Int,
@@ -148,21 +138,19 @@ suspend inline fun Coil.get(
 // endregion
 // region Drawable
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(drawable).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, drawable, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    drawable: Drawable,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(drawable, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, drawable).",
-    replaceWith = ReplaceWith("get(context, drawable, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(drawable).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     drawable: Drawable,
@@ -172,21 +160,19 @@ suspend inline fun Coil.get(
 // endregion
 // region Bitmap
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(bitmap).apply(builder).launch()")
+)
 inline fun Coil.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).load(context, bitmap, builder)
 
-suspend inline fun Coil.get(
-    context: Context,
-    bitmap: Bitmap,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).get(bitmap, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.get(context, bitmap).",
-    replaceWith = ReplaceWith("get(context, bitmap, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(bitmap).apply(builder).launch()")
 )
 suspend inline fun Coil.get(
     bitmap: Bitmap,
@@ -196,21 +182,19 @@ suspend inline fun Coil.get(
 // endregion
 // region Any
 
+@Deprecated(
+    message = "Replace with the LoadRequest.Builder API.",
+    replaceWith = ReplaceWith("load(context).data(data).apply(builder).launch()")
+)
 inline fun Coil.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable = imageLoader(context).loadAny(context, data, builder)
 
-suspend inline fun Coil.getAny(
-    context: Context,
-    data: Any,
-    builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = imageLoader(context).getAny(data, builder)
-
 @Deprecated(
-    message = "Migrate to Coil.getAny(context, data).",
-    replaceWith = ReplaceWith("getAny(context, data, builder)")
+    message = "Replace with the GetRequest.Builder API.",
+    replaceWith = ReplaceWith("get().data(data).apply(builder).launch()")
 )
 suspend inline fun Coil.getAny(
     data: Any,

--- a/coil-default/src/main/java/coil/api/Coils.kt
+++ b/coil-default/src/main/java/coil/api/Coils.kt
@@ -33,7 +33,7 @@ import java.io.File
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(uri).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -41,19 +41,19 @@ inline fun Coil.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(uri).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     uri: String,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(uri).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region URL (HttpUrl)
@@ -61,7 +61,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(url).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(url).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -69,19 +69,19 @@ inline fun Coil.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(url).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(url).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(url).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(url).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     url: HttpUrl,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(url).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(url).apply(builder).build())
 
 // endregion
 // region Uri
@@ -89,7 +89,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(uri).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -97,19 +97,19 @@ inline fun Coil.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(uri).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     uri: Uri,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(uri).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region File
@@ -117,7 +117,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(file).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(file).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -125,19 +125,19 @@ inline fun Coil.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(file).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(file).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(file).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(file).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     file: File,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(file).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(file).apply(builder).build())
 
 // endregion
 // region Resource
@@ -145,7 +145,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -153,19 +153,19 @@ inline fun Coil.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(drawableRes).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(drawableRes).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     @DrawableRes drawableRes: Int,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(drawableRes).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(drawableRes).apply(builder).build())
 
 // endregion
 // region Drawable
@@ -173,7 +173,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -181,19 +181,19 @@ inline fun Coil.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(drawable).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(drawable).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(drawable).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     drawable: Drawable,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(drawable).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(drawable).apply(builder).build())
 
 // endregion
 // region Bitmap
@@ -201,7 +201,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -209,19 +209,19 @@ inline fun Coil.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(bitmap).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(bitmap).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.get(
     bitmap: Bitmap,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(bitmap).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(bitmap).apply(builder).build())
 
 // endregion
 // region Any
@@ -229,7 +229,7 @@ suspend inline fun Coil.get(
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(data).apply(builder).build())",
+        expression = "this.imageLoader(context).execute(LoadRequest.Builder(context).data(data).apply(builder).build())",
         imports = ["coil.request.LoadRequest"]
     )
 )
@@ -237,18 +237,18 @@ inline fun Coil.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(data).apply(builder).build())
+): RequestDisposable = imageLoader(context).execute(LoadRequest.Builder(context).data(data).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
     replaceWith = ReplaceWith(
-        expression = "this.loader().launch(GetRequest.Builder().data(data).apply(builder).build())",
+        expression = "this.loader().execute(GetRequest.Builder().data(data).apply(builder).build())",
         imports = ["coil.request.GetRequest"]
     )
 )
 suspend inline fun Coil.getAny(
     data: Any,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().launch(GetRequest.Builder().data(data).apply(builder).build())
+): Drawable = loader().execute(GetRequest.Builder().data(data).apply(builder).build())
 
 // endregion

--- a/coil-default/src/main/java/coil/api/Coils.kt
+++ b/coil-default/src/main/java/coil/api/Coils.kt
@@ -9,7 +9,9 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.annotation.DrawableRes
 import coil.Coil
+import coil.request.GetRequest
 import coil.request.GetRequestBuilder
+import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
 import coil.request.RequestDisposable
 import okhttp3.HttpUrl
@@ -30,175 +32,223 @@ import java.io.File
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     uri: String?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, uri, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     uri: String,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(uri, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region URL (HttpUrl)
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(url).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(url).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     url: HttpUrl?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, url, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(url).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(url).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(url).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     url: HttpUrl,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(url, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(url).apply(builder).build())
 
 // endregion
 // region Uri
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     uri: Uri?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, uri, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(uri).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(uri).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(uri).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     uri: Uri,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(uri, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(uri).apply(builder).build())
 
 // endregion
 // region File
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(file).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(file).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     file: File?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, file, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(file).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(file).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(file).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     file: File,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(file, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(file).apply(builder).build())
 
 // endregion
 // region Resource
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(drawableRes).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     @DrawableRes drawableRes: Int,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, drawableRes, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(drawableRes).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(drawableRes).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(drawableRes).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     @DrawableRes drawableRes: Int,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(drawableRes, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(drawableRes).apply(builder).build())
 
 // endregion
 // region Drawable
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(drawable).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     drawable: Drawable?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, drawable, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(drawable).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(drawable).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(drawable).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     drawable: Drawable,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(drawable, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(drawable).apply(builder).build())
 
 // endregion
 // region Bitmap
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(bitmap).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.load(
     context: Context,
     bitmap: Bitmap?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).load(context, bitmap, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(bitmap).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(bitmap).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(bitmap).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.get(
     bitmap: Bitmap,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().get(bitmap, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(bitmap).apply(builder).build())
 
 // endregion
 // region Any
 
 @Deprecated(
     message = "Replace with the LoadRequest.Builder API.",
-    replaceWith = ReplaceWith("load(context).data(data).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.imageLoader(context).launch(LoadRequest.Builder(context).data(data).apply(builder).build())",
+        imports = ["coil.request.LoadRequest"]
+    )
 )
 inline fun Coil.loadAny(
     context: Context,
     data: Any?,
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = imageLoader(context).loadAny(context, data, builder)
+): RequestDisposable = imageLoader(context).launch(LoadRequest.Builder(context).data(data).apply(builder).build())
 
 @Deprecated(
     message = "Replace with the GetRequest.Builder API.",
-    replaceWith = ReplaceWith("get().data(data).apply(builder).launch()")
+    replaceWith = ReplaceWith(
+        expression = "this.loader().launch(GetRequest.Builder().data(data).apply(builder).build())",
+        imports = ["coil.request.GetRequest"]
+    )
 )
 suspend inline fun Coil.getAny(
     data: Any,
     builder: GetRequestBuilder.() -> Unit = {}
-): Drawable = loader().getAny(data, builder)
+): Drawable = loader().launch(GetRequest.Builder().data(data).apply(builder).build())
 
 // endregion

--- a/coil-default/src/main/java/coil/api/Coils.kt
+++ b/coil-default/src/main/java/coil/api/Coils.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Coils")
-@file:Suppress("NOTHING_TO_INLINE", "unused")
+@file:Suppress("unused")
 
 package coil.api
 

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -103,7 +103,7 @@ inline fun ImageView.loadAny(
         .target(this)
         .apply(builder)
         .build()
-    return imageLoader.launch(request)
+    return imageLoader.execute(request)
 }
 
 /**

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -12,136 +12,86 @@ import androidx.annotation.DrawableRes
 import coil.Coil
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
+import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
 import coil.request.RequestDisposable
 import coil.util.CoilUtils
 import okhttp3.HttpUrl
 import java.io.File
 
-// This file defines a collection of type-safe load extension functions for ImageViews.
-//
-// Example:
-// ```
-// imageView.load("https://www.example.com/image.jpg") {
-//     networkCachePolicy(CachePolicy.DISABLED)
-//     transformations(CircleCropTransformation())
-// }
-// ```
-
-// region URL (String)
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     uri: String?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(uri)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(uri, imageLoader, builder)
 
-// endregion
-// region URL (HttpUrl)
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     url: HttpUrl?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(url)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(url, imageLoader, builder)
 
-// endregion
-// region Uri
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     uri: Uri?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(uri)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(uri, imageLoader, builder)
 
-// endregion
-// region File
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     file: File?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(file)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(file, imageLoader, builder)
 
-// endregion
-// region Resource
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     @DrawableRes drawableRes: Int,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(drawableRes)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(drawableRes, imageLoader, builder)
 
-// endregion
-// region Drawable
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     drawable: Drawable?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(drawable)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(drawable, imageLoader, builder)
 
-// endregion
-// region Bitmap
-
+/** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
     bitmap: Bitmap?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context)
-        .data(bitmap)
-        .target(this)
-        .apply(builder)
-        .launch()
-}
+): RequestDisposable = loadAny(bitmap, imageLoader, builder)
 
-// endregion
-// region Any
-
+/**
+ * Load the image referenced by [data] and set it on this [ImageView].
+ *
+ * This is the type-unsafe version of [ImageView.load].
+ *
+ * Example usage:
+ * ```
+ * imageView.load("https://www.example.com/image.jpg") {
+ *     crossfade(true)
+ *     transformations(CircleCropTransformation())
+ * }
+ * ```
+ *
+ * @param data The data to load.
+ * @param imageLoader The [ImageLoader] that will be used to create and launch the [LoadRequest].
+ * @param builder An optional lambda to configure the request before it is launched.
+ */
 @JvmSynthetic
 inline fun ImageView.loadAny(
     data: Any?,
@@ -155,14 +105,9 @@ inline fun ImageView.loadAny(
         .launch()
 }
 
-// endregion
-// region Other
-
 /**
- * Cancel any in progress requests and clear any resources associated with this [ImageView].
+ * Cancel any in progress requests and clear all resources associated with this [ImageView].
  */
 fun ImageView.clear() {
     CoilUtils.clear(this)
 }
-
-// endregion

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -30,113 +30,129 @@ import java.io.File
 
 // region URL (String)
 
+@JvmSynthetic
 inline fun ImageView.load(
     uri: String?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, uri) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(uri)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region URL (HttpUrl)
 
+@JvmSynthetic
 inline fun ImageView.load(
     url: HttpUrl?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, url) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(url)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region Uri
 
+@JvmSynthetic
 inline fun ImageView.load(
     uri: Uri?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, uri) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(uri)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region File
 
+@JvmSynthetic
 inline fun ImageView.load(
     file: File?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, file) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(file)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region Resource
 
+@JvmSynthetic
 inline fun ImageView.load(
     @DrawableRes drawableRes: Int,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, drawableRes) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(drawableRes)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region Drawable
 
+@JvmSynthetic
 inline fun ImageView.load(
     drawable: Drawable?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, drawable) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(drawable)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region Bitmap
 
+@JvmSynthetic
 inline fun ImageView.load(
     bitmap: Bitmap?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context, bitmap) {
-        target(this@load)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(bitmap)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion
 // region Any
 
+@JvmSynthetic
 inline fun ImageView.loadAny(
     data: Any?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.loadAny(context, data) {
-        target(this@loadAny)
-        builder()
-    }
+    return imageLoader.load(context)
+        .data(data)
+        .target(this)
+        .apply(builder)
+        .launch()
 }
 
 // endregion

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -54,10 +54,10 @@ inline fun ImageView.load(
 /** @see ImageView.loadAny */
 @JvmSynthetic
 inline fun ImageView.load(
-    @DrawableRes drawableRes: Int,
+    @DrawableRes drawableResId: Int,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable = loadAny(drawableRes, imageLoader, builder)
+): RequestDisposable = loadAny(drawableResId, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -98,11 +98,12 @@ inline fun ImageView.loadAny(
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
 ): RequestDisposable {
-    return imageLoader.load(context)
+    val request = LoadRequest.Builder(context)
         .data(data)
         .target(this)
         .apply(builder)
-        .launch()
+        .build()
+    return imageLoader.launch(request)
 }
 
 /**

--- a/coil-default/src/main/java/coil/api/ImageViews.kt
+++ b/coil-default/src/main/java/coil/api/ImageViews.kt
@@ -80,7 +80,7 @@ inline fun ImageView.load(
  *
  * This is the type-unsafe version of [ImageView.load].
  *
- * Example usage:
+ * Example:
  * ```
  * imageView.load("https://www.example.com/image.jpg") {
  *     crossfade(true)

--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -75,6 +75,6 @@ public final class coil/drawable/ScaleDrawable : android/graphics/drawable/Drawa
 
 public final class coil/extension/Gifs {
 	public static final fun repeatCount (Lcoil/request/Parameters;)Ljava/lang/Integer;
-	public static final fun repeatCount (Lcoil/request/RequestBuilder;I)V
+	public static final fun repeatCount (Lcoil/request/RequestBuilder;I)Lcoil/request/RequestBuilder;
 }
 

--- a/coil-gif/src/main/java/coil/extension/Gifs.kt
+++ b/coil-gif/src/main/java/coil/extension/Gifs.kt
@@ -18,9 +18,9 @@ import coil.request.RequestBuilder
  * @see MovieDrawable.setRepeatCount
  * @see AnimatedImageDrawable.setRepeatCount
  */
-fun RequestBuilder<*>.repeatCount(repeatCount: Int) {
+fun <T : RequestBuilder<T>> RequestBuilder<T>.repeatCount(repeatCount: Int): T {
     require(repeatCount >= MovieDrawable.REPEAT_INFINITE) { "Invalid repeatCount: $repeatCount" }
-    setParameter(REPEAT_COUNT_KEY, repeatCount)
+    return setParameter(REPEAT_COUNT_KEY, repeatCount)
 }
 
 /** Get the number of times to repeat the animation if the result is an animated [Drawable]. */

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ColorSpace
-import coil.ImageLoader
 import coil.decode.Options
 import coil.request.CachePolicy
 import coil.request.GetRequest
@@ -79,19 +78,12 @@ val Bitmap.size: PixelSize
     get() = PixelSize(width, height)
 
 inline fun createGetRequest(
-    context: Context,
     builder: GetRequestBuilder.() -> Unit = {}
-): GetRequest = createGetRequest(ImageLoader(context), builder)
-
-inline fun createGetRequest(
-    imageLoader: ImageLoader,
-    builder: GetRequestBuilder.() -> Unit = {}
-): GetRequest = GetRequestBuilder(imageLoader).data(Unit).apply(builder).build()
+): GetRequest = GetRequest.Builder().data(Unit).apply(builder).build()
 
 inline fun createLoadRequest(
     context: Context,
-    imageLoader: ImageLoader = ImageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): LoadRequest = LoadRequestBuilder(context, imageLoader).data(Unit).apply(builder).build()
+): LoadRequest = LoadRequest.Builder(context).data(Unit).apply(builder).build()
 
 inline fun error(): Nothing = throw IllegalStateException()

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ColorSpace
-import coil.DefaultRequestOptions
+import coil.ImageLoader
 import coil.decode.Options
 import coil.request.CachePolicy
 import coil.request.GetRequest
@@ -79,12 +79,15 @@ val Bitmap.size: PixelSize
     get() = PixelSize(width, height)
 
 inline fun createGetRequest(
+    context: Context,
+    imageLoader: ImageLoader = ImageLoader(context),
     builder: GetRequestBuilder.() -> Unit = {}
-): GetRequest = GetRequestBuilder(DefaultRequestOptions()).data(Unit).apply(builder).build()
+): GetRequest = GetRequestBuilder(imageLoader).data(Unit).apply(builder).build()
 
 inline fun createLoadRequest(
     context: Context,
+    imageLoader: ImageLoader = ImageLoader(context),
     builder: LoadRequestBuilder.() -> Unit = {}
-): LoadRequest = LoadRequestBuilder(context, DefaultRequestOptions()).data(Unit).apply(builder).build()
+): LoadRequest = LoadRequestBuilder(context, imageLoader).data(Unit).apply(builder).build()
 
 inline fun error(): Nothing = throw IllegalStateException()

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -80,7 +80,11 @@ val Bitmap.size: PixelSize
 
 inline fun createGetRequest(
     context: Context,
-    imageLoader: ImageLoader = ImageLoader(context),
+    builder: GetRequestBuilder.() -> Unit = {}
+): GetRequest = createGetRequest(ImageLoader(context), builder)
+
+inline fun createGetRequest(
+    imageLoader: ImageLoader,
     builder: GetRequestBuilder.() -> Unit = {}
 ): GetRequest = GetRequestBuilder(imageLoader).data(Unit).apply(builder).build()
 

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -13,7 +13,7 @@ public abstract class coil/fetch/VideoFrameFetcher : coil/fetch/Fetcher {
 	public fun <init> (Landroid/content/Context;)V
 	public fun fetch (Lcoil/bitmappool/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Ljava/lang/Object;)Z
-	public abstract fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
+	protected abstract fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
 }
 
 public final class coil/fetch/VideoFrameFetcher$Companion {
@@ -25,7 +25,6 @@ public final class coil/fetch/VideoFrameFileFetcher : coil/fetch/VideoFrameFetch
 	public synthetic fun handles (Ljava/lang/Object;)Z
 	public fun key (Ljava/io/File;)Ljava/lang/String;
 	public synthetic fun key (Ljava/lang/Object;)Ljava/lang/String;
-	public fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/io/File;)V
 	public synthetic fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
 }
 
@@ -35,7 +34,6 @@ public final class coil/fetch/VideoFrameUriFetcher : coil/fetch/VideoFrameFetche
 	public synthetic fun handles (Ljava/lang/Object;)Z
 	public fun key (Landroid/net/Uri;)Ljava/lang/String;
 	public synthetic fun key (Ljava/lang/Object;)Ljava/lang/String;
-	public fun setDataSource (Landroid/media/MediaMetadataRetriever;Landroid/net/Uri;)V
 	public synthetic fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
 }
 

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -1,9 +1,9 @@
 public final class coil/extension/Videos {
 	public static final fun videoFrameMicros (Lcoil/request/Parameters;)Ljava/lang/Long;
-	public static final fun videoFrameMicros (Lcoil/request/RequestBuilder;J)V
-	public static final fun videoFrameMillis (Lcoil/request/RequestBuilder;J)V
+	public static final fun videoFrameMicros (Lcoil/request/RequestBuilder;J)Lcoil/request/RequestBuilder;
+	public static final fun videoFrameMillis (Lcoil/request/RequestBuilder;J)Lcoil/request/RequestBuilder;
 	public static final fun videoFrameOption (Lcoil/request/Parameters;)Ljava/lang/Integer;
-	public static final fun videoFrameOption (Lcoil/request/RequestBuilder;I)V
+	public static final fun videoFrameOption (Lcoil/request/RequestBuilder;I)Lcoil/request/RequestBuilder;
 }
 
 public abstract class coil/fetch/VideoFrameFetcher : coil/fetch/Fetcher {

--- a/coil-video/src/main/java/coil/extension/Videos.kt
+++ b/coil-video/src/main/java/coil/extension/Videos.kt
@@ -21,7 +21,9 @@ import coil.request.RequestBuilder
  *
  * @see VideoFrameFetcher
  */
-fun RequestBuilder<*>.videoFrameMillis(frameMillis: Long) = videoFrameMicros(1000 * frameMillis)
+fun <T : RequestBuilder<T>> RequestBuilder<T>.videoFrameMillis(frameMillis: Long): T {
+    return videoFrameMicros(1000 * frameMillis)
+}
 
 /**
  * Set the time **in microseconds** of the frame to extract from a video.
@@ -30,9 +32,9 @@ fun RequestBuilder<*>.videoFrameMillis(frameMillis: Long) = videoFrameMicros(100
  *
  * @see VideoFrameFetcher
  */
-fun RequestBuilder<*>.videoFrameMicros(frameMicros: Long) {
+fun <T : RequestBuilder<T>> RequestBuilder<T>.videoFrameMicros(frameMicros: Long): T {
     require(frameMicros >= 0) { "frameMicros must be >= 0" }
-    setParameter(VIDEO_FRAME_MICROS_KEY, frameMicros)
+    return setParameter(VIDEO_FRAME_MICROS_KEY, frameMicros)
 }
 
 /**
@@ -45,12 +47,12 @@ fun RequestBuilder<*>.videoFrameMicros(frameMicros: Long) {
  * @see MediaMetadataRetriever
  * @see VideoFrameFetcher
  */
-fun RequestBuilder<*>.videoFrameOption(option: Int) {
+fun <T : RequestBuilder<T>> RequestBuilder<T>.videoFrameOption(option: Int): T {
     require(option == OPTION_PREVIOUS_SYNC ||
         option == OPTION_NEXT_SYNC ||
         option == OPTION_CLOSEST_SYNC ||
         option == OPTION_CLOSEST) { "Invalid video frame option: $option." }
-    setParameter(VIDEO_FRAME_OPTION_KEY, option)
+    return setParameter(VIDEO_FRAME_OPTION_KEY, option)
 }
 
 /**

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -75,7 +75,7 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
 
     companion object {
         // https://developer.android.com/guide/topics/media/media-formats#video-formats
-        internal val SUPPORTED_FILE_EXTENSIONS = arrayOf(".3gp", ".mkv", ".mp4", ".ts", ".webm")
+        @JvmField internal val SUPPORTED_FILE_EXTENSIONS = arrayOf(".3gp", ".mkv", ".mp4", ".ts", ".webm")
 
         internal const val ASSET_FILE_PATH_ROOT = "android_asset"
 
@@ -85,7 +85,7 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
 
     private val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
-    abstract fun MediaMetadataRetriever.setDataSource(data: T)
+    protected abstract fun MediaMetadataRetriever.setDataSource(data: T)
 
     override suspend fun fetch(
         pool: BitmapPool,

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,6 +14,13 @@ Yes! [Read here](java_compatibility.md).
 
 [Read here](../image_loaders/#caching).
 
+## How do I enable logging?
+
+Set `logger(DebugLogger())` when constructing your `ImageLoader`.
+
+!!! Note
+    `DebugLogger` should only be used in debug builds.
+
 ## How do I get development snapshots?
 
 Add the snapshots repository to your list of repositories:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -10,7 +10,8 @@ Coil has 5 artifacts published to `mavenCentral()`:
 * `io.coil-kt:coil-svg`: Includes a [decoder](../api/coil-base/coil.decode/-decoder) to support decoding SVGs. See [SVGs](svgs.md) for more details.
 * `io.coil-kt:coil-video`: Includes two [fetchers](../api/coil-base/coil.fetch/-fetcher) to support fetching and decoding frames from [any of Android's supported video formats](https://developer.android.com/guide/topics/media/media-formats#video-codecs). See [videos](videos.md) for more details.
 
-You should depend on `io.coil-kt:coil-base` and **not** `io.coil-kt:coil` if any of the following is true:
+You should depend on `io.coil-kt:coil-base` and **not** `io.coil-kt:coil` if either of the following is true:
+
 - You are writing a library that depends on Coil. This is to avoid opting your users into the singleton.
 - You want to use dependency injection to inject your [ImageLoader](image_loaders.md) instance(s).
 
@@ -65,17 +66,18 @@ val imageLoader = ImageLoader.Builder(context)
     .build()
 ```
 
-Coil performs best when you create a single `ImageLoader` and share it throughout your app. This is because each `ImageLoader` has its own memory cache and bitmap pool.
+Coil performs best when you create a single `ImageLoader` and share it throughout your app. This is because each `ImageLoader` has its own memory cache, bitmap pool, and network observer.
 
-### Requests
+## Requests
 
 There are two types of `Request`s:
+
 - `LoadRequest`: A request that supports `Target`s, `Transition`s, and more that is scoped to a [`Lifecycle`](https://developer.android.com/jetpack/androidx/releases/lifecycle).
 - `GetRequst`: A request that [suspends](https://kotlinlang.org/docs/reference/coroutines/basics.html) and returns a `Drawable`.
 
 New requests can be created using their respective builder.
 
-All requests should have their `data` set (url, uri, file, drawable resource, etc.). This is what the `ImageLoader` will use to figure where to fetch the image data from.
+All requests should set `data` (i.e. url, uri, file, drawable resource, etc.). This is what the `ImageLoader` will use to figure where to fetch the image data from.
 
 Additionally, you likely want to set a `target` when creating a `LoadRequest`. It's optional, but the `target` is what will receive the loaded placeholder/success/error drawables. If you don't set a `target`, the `ImageLoader` will execute the request as normal effectively preloading the image.
 

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -67,14 +67,14 @@ val fakeImageLoader = object : ImageLoader {
     
     override val defaults = DefaultRequestOptions()
 
-    override fun launch(request: LoadRequest): RequestDisposable {
+    override fun execute(request: LoadRequest): RequestDisposable {
         // Always call onStart before onSuccess.
         request.target?.onStart(drawable)
         request.target?.onSuccess(drawable)
         return disposable
     }
 
-    override suspend fun launch(request: GetRequest) = drawable
+    override suspend fun execute(request: GetRequest) = drawable
 
     override fun clearMemory() {}
 

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -49,6 +49,10 @@ However, if you'd prefer a singleton the `io.coil-kt:coil` artifact provides a d
 !!! Note
     Use the `io.coil-kt:coil-base` artifact if you are using dependency injection.
 
+## Shutdown
+
+When you're done with an `ImageLoader` you should call `ImageLoader.shutdown()`. This releases all resources and observers used by the image loader and stops any new requests from being executed. Failure to call `ImageLoader.shutdown()` can leak the observers used internally.
+
 ## Testing
 
 `ImageLoader` is an interface, which you can replace with a fake implementation.

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -1,6 +1,6 @@
 # Image Loaders
 
-Image Loaders are [service objects](https://publicobject.com/2019/06/10/value-objects-service-objects-and-glue/) that handle image requests with `load` and `get`. They handle caching, image decoding, request management, bitmap pooling, memory management, and more.
+Image Loaders are [service objects](https://publicobject.com/2019/06/10/value-objects-service-objects-and-glue/) that execute `Request`s. They handle caching, image decoding, request management, bitmap pooling, memory management, and more.
 
 New instances can be created like so:
 
@@ -12,7 +12,7 @@ Similar to [Requests](requests.md), `ImageLoader`s can be configured by using a 
 
 ```kotlin
 val imageLoader = ImageLoader.Builder(context)
-    .availableMemoryPercentage(0.5)
+    .availableMemoryPercentage(0.25)
     .bitmapPoolPercentage(0.5)
     .crossfade(true)
     .build()
@@ -20,13 +20,11 @@ val imageLoader = ImageLoader.Builder(context)
 
 Internally, this constructs a `RealImageLoader` using [ImageLoaderBuilder](../api/coil-base/coil/-image-loader-builder).
 
-If you're using the Coil singleton, you can then replace its `ImageLoader` instance with `Coil.setDefaultImageLoader`. The best place to set the default `ImageLoader` is in your `Application` class.
-
 ## Caching
 
-Each Image Loader keeps a memory cache of recently loaded `BitmapDrawable`s as well as a reusable pool of `Bitmap`s.
+Each `ImageLoader` keeps a memory cache of recently loaded `BitmapDrawable`s as well as a reusable pool of `Bitmap`s.
 
-Coil relies on `OkHttpClient` to handle disk caching. **By default, every `ImageLoader` is already set up for disk caching** and will set a max cache size of between 10-250MB depending on the remaining space on the user's device.
+`ImageLoader`s rely on `OkHttpClient` to handle disk caching. **By default, every `ImageLoader` is already set up for disk caching** and will set a max cache size of between 10-250MB depending on the remaining space on the user's device.
 
 However, if you set a custom `OkHttpClient`, you'll need to add the disk cache yourself. To get a `Cache` instance that's optimized for Coil, you can use [`CoilUtils.createDefaultCache`](../api/coil-base/coil.util/-coil-utils/create-default-cache/). Optionally, you can create your own `Cache` instance with a different size + location. Here's an example:
 
@@ -42,34 +40,11 @@ val imageLoader = ImageLoader.Builder(context)
 
 ## Singleton vs. Dependency Injection
 
-Ideally, you should construct and inject your `ImageLoader` instance(s) using dependency injection. This will scale well as your app grows and it is the best way to manage multiple `ImageLoader` instances.
+Coil performs best when you create a single `ImageLoader` and share it throughout your app. This is because each `ImageLoader` has its own memory cache and bitmap pool.
 
-However, for simple use cases the `io.coil-kt:coil` artifact provides a default `ImageLoader` instance that can be accessed with `Coil.imageLoader(context)`. Both `ImageView.load` and `Coil.load` use the default `ImageLoader` instance as a default parameter:
+If you use a dependency injector like [Dagger](https://github.com/google/dagger), then you should create a single `ImageLoader` instance and inject it throughout your app.
 
-```kotlin
-inline fun ImageView.load(
-    url: String?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
-    builder: LoadRequestBuilder.() -> Unit = {}
-): RequestDisposable {
-    return imageLoader.load(context, url) {
-        target(this@load)
-        builder()
-    }
-}
-```
-
-The `ImageView` extension function can be called with a specific `ImageLoader` like so:
-
-```kotlin
-imageView.load("https://www.example.com/image.jpg", imageLoader) {
-    crossfade(true)
-    placeholder(R.drawable.image)
-    transformations(CircleCropTransformation())
-}
-```
-
-The default `ImageLoader` is instantiated lazily and can be replaced with `Coil.setDefaultImageLoader`.
+However, if you'd prefer a singleton the `io.coil-kt:coil` artifact provides a default `ImageLoader` instance that can be accessed with `Coil.imageLoader(context)`. [Read here](../getting_started/#singleton) for how to initialize the singleton `ImageLoader` instance.
 
 !!! Note
     Use the `io.coil-kt:coil-base` artifact if you are using dependency injection.
@@ -92,14 +67,14 @@ val fakeImageLoader = object : ImageLoader {
     
     override val defaults = DefaultRequestOptions()
 
-    override fun load(request: LoadRequest): RequestDisposable {
+    override fun launch(request: LoadRequest): RequestDisposable {
         // Always call onStart before onSuccess.
         request.target?.onStart(drawable)
         request.target?.onSuccess(drawable)
         return disposable
     }
 
-    override suspend fun get(request: GetRequest) = drawable
+    override suspend fun launch(request: GetRequest) = drawable
 
     override fun clearMemory() {}
 

--- a/docs/image_pipeline.md
+++ b/docs/image_pipeline.md
@@ -40,10 +40,11 @@ class ItemMapper : Mapper<Item, HttpUrl> {
 After registering it when constructing our `ImageLoader` (see above), we can safely load an `Item`:
 
 ```kotlin
-imageLoader.load(context)
+val request = LoadRequest.Builder(context)
     .data(item)
     .target(imageView)
-    .launch()
+    .build()
+imageLoader.execute(request)
 ```
 
 If you want to know a `Target`'s size when mapping an object, you can extend from [Measured Mapper](../api/coil-base/coil.map/-measured-mapper).

--- a/docs/image_pipeline.md
+++ b/docs/image_pipeline.md
@@ -33,22 +33,23 @@ We could write a custom mapper to map it to an `HttpUrl`:
 
 ```kotlin
 class ItemMapper : Mapper<Item, HttpUrl> {
-    override fun map(data: Item): HttpUrl = HttpUrl.get(data.imageUrl)
+    override fun map(data: Item) = data.imageUrl.toHttpUrl()
 }
 ```
 
 After registering it when constructing our `ImageLoader` (see above), we can safely load an `Item`:
 
 ```kotlin
-imageView.loadAny(item)
+imageLoader.load(context)
+    .data(item)
+    .target(imageView)
+    .launch()
 ```
-
-`loadAny` is the type-unsafe version of `load` that accepts any data type.
 
 If you want to know a `Target`'s size when mapping an object, you can extend from [Measured Mapper](../api/coil-base/coil.map/-measured-mapper).
 
 !!! Note
-    Extending from `Measured Mapper` can prevent setting placeholders and or cached drawables synchronously, as they force Coil to wait for the target to be measured. Prefer extending `Mapper` if you do not need to know the `Target`'s size.
+    Extending from `Measured Mapper` can prevent setting placeholders and or cached drawables synchronously, as they force an `ImageLoader` to wait for the target to be measured. Prefer extending `Mapper` if you do not need to know the `Target`'s size.
 
 See [Mapper](../api/coil-base/coil.map/-mapper) and [Measured Mapper](../api/coil-base/coil.map/-measured-mapper) for more information.
 

--- a/docs/image_pipeline.md
+++ b/docs/image_pipeline.md
@@ -2,7 +2,7 @@
 
 Android supports many [image formats](https://developer.android.com/guide/topics/media/media-formats) out of the box, however there are also plenty of formats it does not (e.g. GIF, SVG, TIFF, etc.)
 
-Fortunately, [ImageLoaders](image_loaders.md) support pluggable components to add new data types, new fetching behavior, new image encodings, or otherwise overwrite the base image loading behavior. Coil's image pipeline consists of three main parts: [Mappers](../api/coil-base/coil.map/-mapper), [Fetchers](../api/coil-base/coil.fetch/-fetcher), and [Decoders](../api/coil-base/coil.decode/-decoder).
+Fortunately, [ImageLoader](image_loaders.md)s support pluggable components to add new data types, new fetching behavior, new image encodings, or otherwise overwrite the base image loading behavior. Coil's image pipeline consists of three main parts: [Mappers](../api/coil-base/coil.map/-mapper), [Fetchers](../api/coil-base/coil.fetch/-fetcher), and [Decoders](../api/coil-base/coil.decode/-decoder).
 
 Custom components must be added to the `ImageLoader` when constructing it through its [ComponentRegistry](../api/coil-base/coil/-component-registry):
 
@@ -10,7 +10,7 @@ Custom components must be added to the `ImageLoader` when constructing it throug
 val imageLoader = ImageLoader.Builder(context)
     .componentRegistry {
         add(ItemMapper())
-        add(ProtocolBufferFetcher())
+        add(CronetFetcher())
         add(GifDecoder())
     }
     .build()
@@ -29,15 +29,15 @@ data class Item(
 )
 ```
 
-We could write a custom mapper to map it to an `HttpUrl`:
+We could write a custom mapper to map it to its URL, which will be handled later in the pipeline:
 
 ```kotlin
-class ItemMapper : Mapper<Item, HttpUrl> {
-    override fun map(data: Item) = data.imageUrl.toHttpUrl()
+class ItemMapper : Mapper<Item, String> {
+    override fun map(data: Item) = data.imageUrl
 }
 ```
 
-After registering it when constructing our `ImageLoader` (see above), we can safely load an `Item`:
+After registering it when building our `ImageLoader` (see above), we can safely load an `Item`:
 
 ```kotlin
 val request = LoadRequest.Builder(context)
@@ -47,10 +47,10 @@ val request = LoadRequest.Builder(context)
 imageLoader.execute(request)
 ```
 
-If you want to know a `Target`'s size when mapping an object, you can extend from [Measured Mapper](../api/coil-base/coil.map/-measured-mapper).
+If you want to know a request's size when mapping an object, you can implement [MeasuredMapper](../api/coil-base/coil.map/-measured-mapper) instead of [Mapper](../api/coil-base/coil.map/-mapper).
 
 !!! Note
-    Extending from `Measured Mapper` can prevent setting placeholders and or cached drawables synchronously, as they force an `ImageLoader` to wait for the target to be measured. Prefer extending `Mapper` if you do not need to know the `Target`'s size.
+    `MeasuredMapper`s force the request to suspend until the size is measured. This can prevent setting placeholders and or cached drawables synchronously. Prefer extending `Mapper` if you do not need to know the request's size.
 
 See [Mapper](../api/coil-base/coil.map/-mapper) and [Measured Mapper](../api/coil-base/coil.map/-measured-mapper) for more information.
 

--- a/docs/java_compatibility.md
+++ b/docs/java_compatibility.md
@@ -7,7 +7,7 @@ Also, suspend functions cannot be implemented in Java. This means custom [Transf
 With these limitations in mind, here is the recommended way to execute `load` requests from Java:
 
 ```java
-LoadRequest request = ImageLoaders.newLoadBuilder(imageLoader, context)
+LoadRequest request = imageLoader.load(context)
         .data("https://www.example.com/image.jpg")
         .crossfade(true)
         .target(imageView)
@@ -36,7 +36,7 @@ object ImageLoaderCompat {
 Then call the `ImageLoaderCompat` function from Java:
 
 ```java
-GetRequest request = ImageLoaders.newGetBuilder(imageLoader)
+GetRequest request = imageLoader.get()
         .data("https://www.example.com/image.jpg")
         .size(1080, 1920)
         .build();

--- a/docs/java_compatibility.md
+++ b/docs/java_compatibility.md
@@ -34,7 +34,7 @@ object ImageLoaderCompat {
 Then call the `ImageLoaderCompat` function from Java:
 
 ```java
-GetRequest request = GetRequest.Builder()
+GetRequest request = GetRequest.builder()
     .data("https://www.example.com/image.jpg")
     .size(1080, 1920)
     .build();

--- a/docs/java_compatibility.md
+++ b/docs/java_compatibility.md
@@ -4,19 +4,21 @@ Coil's API is designed to be Kotlin-first. It leverages Kotlin language features
 
 Importantly, suspend functions cannot be implemented in Java. This means custom [Transformations](transformations.md), [Size Resolvers](../api/coil-base/coil.size/-size-resolver), [Fetchers](../image_pipeline/#fetchers), and [Decoders](../image_pipeline/#decoders) **must** be implemented in Kotlin.
 
-With these limitations in mind, Coil is still mostly Java compatible. The syntax to launch a `LoadRequest` is the same in Java and Kotlin:
+Despite these limitations, most of Coil's API is Java compatible. For instance, the syntax to launch a `LoadRequest` is almost the same in Java and Kotlin:
 
 ```java
-imageLoader.load(context)
+LoadRequest request = LoadRequest.builder(context)
     .data("https://www.example.com/image.jpg")
     .crossfade(true)
     .target(imageView)
-    .launch();
+    .build();
+imageLoader.execute(request)
 ```
 
-If you're using the `io.coil-kt:coil` artifact, you can use `Coil.load(context)`.
+!!! Note
+    `ImageView.load` extension functions cannot be used from Java. Use the `LoadRequest.Builder` API instead.
 
-`suspend` functions cannot be easily called from Java. Thus, to get an image synchronously you'll have to create a wrapper function for `get`:
+`suspend` functions cannot be easily called from Java. Thus, to get an image synchronously you'll have to create a wrapper function to execute `GetRequest`s:
 
 ```kotlin
 object ImageLoaderCompat {
@@ -25,14 +27,14 @@ object ImageLoaderCompat {
     fun getBlocking(
         imageLoader: ImageLoader,
         request: GetRequest
-    ): Drawable = runBlocking { imageLoader.launch(request) }
+    ): Drawable = runBlocking { imageLoader.execute(request) }
 }
 ```
 
 Then call the `ImageLoaderCompat` function from Java:
 
 ```java
-GetRequest request = imageLoader.get()
+GetRequest request = GetRequest.Builder()
     .data("https://www.example.com/image.jpg")
     .size(1080, 1920)
     .build();

--- a/docs/java_compatibility.md
+++ b/docs/java_compatibility.md
@@ -1,24 +1,20 @@
 # Java Compatibility
 
-Coil's API was designed to be Kotlin-first. It leverages Kotlin language features such as inlined lambdas, receiver params, default arguments, and extension functions, which are not available in Java.
+Coil's API is designed to be Kotlin-first. It leverages Kotlin language features such as inlined lambdas, receiver params, default arguments, and extension functions, which are not available in Java.
 
-Also, suspend functions cannot be implemented in Java. This means custom [Transformations](transformations.md), [Size Resolvers](../api/coil-base/coil.size/-size-resolver), [Fetchers](../image_pipeline/#fetchers), and [Decoders](../image_pipeline/#decoders) **must** be implemented in Kotlin.
+Importantly, suspend functions cannot be implemented in Java. This means custom [Transformations](transformations.md), [Size Resolvers](../api/coil-base/coil.size/-size-resolver), [Fetchers](../image_pipeline/#fetchers), and [Decoders](../image_pipeline/#decoders) **must** be implemented in Kotlin.
 
-With these limitations in mind, here is the recommended way to execute `load` requests from Java:
+With these limitations in mind, Coil is still mostly Java compatible. The syntax to launch a `LoadRequest` is the same in Java and Kotlin:
 
 ```java
-LoadRequest request = imageLoader.load(context)
-        .data("https://www.example.com/image.jpg")
-        .crossfade(true)
-        .target(imageView)
-        .build();
-imageLoader.load(request);
+imageLoader.load(context)
+    .data("https://www.example.com/image.jpg")
+    .crossfade(true)
+    .target(imageView)
+    .launch();
 ```
 
-If you're using the default `ImageLoader`, you can get it via `Coil.imageLoader(context)`.
-
-!!! Note
-    You should not use the [API extension functions](../getting_started/#extension-functions) in Java. Instead, you should create `Request` objects manually like above.
+If you're using the `io.coil-kt:coil` artifact, you can use `Coil.load(context)`.
 
 `suspend` functions cannot be easily called from Java. Thus, to get an image synchronously you'll have to create a wrapper function for `get`:
 
@@ -29,7 +25,7 @@ object ImageLoaderCompat {
     fun getBlocking(
         imageLoader: ImageLoader,
         request: GetRequest
-    ): Drawable = runBlocking { imageLoader.get(request) }
+    ): Drawable = runBlocking { imageLoader.launch(request) }
 }
 ```
 
@@ -37,9 +33,9 @@ Then call the `ImageLoaderCompat` function from Java:
 
 ```java
 GetRequest request = imageLoader.get()
-        .data("https://www.example.com/image.jpg")
-        .size(1080, 1920)
-        .build();
+    .data("https://www.example.com/image.jpg")
+    .size(1080, 1920)
+    .build();
 Drawable drawable = ImageLoaderCompat.getBlocking(imageLoader, request);
 ```
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -78,7 +78,7 @@ Picasso.get()
     })
 
 // Coil
-Coil.load(context)
+val request = LoadRequest.Builder(context)
     .data(url)
     .target(
         onStart = { drawable ->
@@ -91,7 +91,8 @@ Coil.load(context)
             // Handle the error drawable.
         }
     )
-    .launch()
+    .build()
+Coil.imageLoader(context).execute(request)
 ```
 
 ### Background Thread
@@ -110,8 +111,9 @@ val drawable = Picasso.get()
     .get()
 
 // Coil (suspends the current context; thread safe)
-val drawable = Coil.get(context)
+val request = GetRequest.Builder()
     .data(url)
     .size(width, height)
-    .launch()
+    .build()
+Coil.imageLoader(context).execute(request)
 ```

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -77,12 +77,21 @@ Picasso.get()
         }
     })
 
-// Coil (has optional callbacks for start and error)
-Coil.load(context, url) {
-    target { drawable ->
-        // Handle the successful result.
-    }
-}
+// Coil
+Coil.load(context)
+    .data(url)
+    .target(
+        onStart = { drawable ->
+            // Handle the placeholder drawable.
+        },
+        onSuccess = {
+            // Handle the successful result.
+        },
+        onError = {
+            // Handle the error drawable.
+        }
+    )
+    .launch()
 ```
 
 ### Background Thread
@@ -101,7 +110,8 @@ val drawable = Picasso.get()
     .get()
 
 // Coil (suspends the current context; thread safe)
-val drawable = Coil.get(context, url) {
-    size(width, height)
-}
+val drawable = Coil.get(context)
+    .data(url)
+    .size(width, height)
+    .launch()
 ```

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -5,19 +5,17 @@ Requests are [value objects](https://publicobject.com/2019/06/10/value-objects-s
 Requests can be created using a builder:
 
 ```kotlin
-val request = LoadRequest.Builder(context, imageLoader)
+val request = LoadRequest.Builder(context)
     .data("https://www.example.com/image.jpg")
     .crossfade(true)
     .target(imageView)
     .build()
 ```
 
-Once you've created a request call `launch` to execute it:
+Once you've created a request pass it to an `ImageLoader` to execute it:
 
 ```kotlin
-request.launch()
+imageLoader.execute(request)
 ```
-
-Internally, this calls `imageLoader.load(request)` on the `imageLoader` that was provided in the `LoadRequest.Builder` constructor.
 
 See the [API documentation](../api/coil-base/coil.request/-request/) for more information.

--- a/docs/requests.md
+++ b/docs/requests.md
@@ -5,18 +5,19 @@ Requests are [value objects](https://publicobject.com/2019/06/10/value-objects-s
 Requests can be created using a builder:
 
 ```kotlin
-val request = LoadRequest.Builder(context, imageLoader.defaults)
+val request = LoadRequest.Builder(context, imageLoader)
     .data("https://www.example.com/image.jpg")
     .crossfade(true)
+    .target(imageView)
     .build()
 ```
 
-Once you've created a request, pass it to an `ImageLoader` to execute it:
+Once you've created a request call `launch` to execute it:
 
 ```kotlin
-imageLoader.load(request)
+request.launch()
 ```
 
-Optionally, you can use the [type-safe `load` and `get` extension functions](../getting_started/#extension-functions) to create and execute requests.
+Internally, this calls `imageLoader.load(request)` on the `imageLoader` that was provided in the `LoadRequest.Builder` constructor.
 
 See the [API documentation](../api/coil-base/coil.request/-request/) for more information.

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -5,11 +5,20 @@ Targets handle the result of an image request. They often act as "view adapters"
 Here's the easiest way to create a custom target:
 
 ```kotlin
-Coil.load(context, "https://www.example.com/image.jpg") {
-    target { drawable ->
-        // Handle the successful result.
-    }
-}
+Coil.load(context)
+    .data("https://www.example.com/image.jpg")
+    .target(
+        onStart = { drawable ->
+            // Handle the placeholder drawable.
+        },
+        onSuccess = {
+            // Handle the successful result.
+        },
+        onError = {
+            // Handle the error drawable.
+        }
+    )
+    .launch()
 ```
 
 There are 3 types of targets:

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -1,24 +1,25 @@
 # Targets
 
-Targets handle the result of an image request. They often act as "view adapters" by taking the placeholder/error/success Drawables and applying them to a `View`.
+Targets receive the result of a `LoadRequest`. They often act as "view adapters" by taking the placeholder/error/success drawables and applying them to a `View` (e.g. `ImageViewTarget`).
 
 Here's the easiest way to create a custom target:
 
 ```kotlin
-Coil.load(context)
+val request = LoadRequest.Builder(context)
     .data("https://www.example.com/image.jpg")
     .target(
-        onStart = { drawable ->
+        onStart = { placeholder ->
             // Handle the placeholder drawable.
         },
-        onSuccess = {
+        onSuccess = { result ->
             // Handle the successful result.
         },
-        onError = {
+        onError = { error ->
             // Handle the error drawable.
         }
     )
-    .launch()
+    .build()
+imageLoader.execute(request)
 ```
 
 There are 3 types of targets:

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -2,8 +2,13 @@
 
 Transitions allow you to animate setting the result of an image request on a `Target`.
 
-Both `ImageLoader` and `LoadRequest` builders accept a `Transition`. Transitions allow you to intercept setting the `Drawable` on the `Target`. This allows you to animate the target's view or wrap the input drawable.
+Both `ImageLoader` and `LoadRequest` builders accept a `Transition`. Transitions allow you to control how the sucess/error drawable is set on the `Target`. This allows you to animate the target's view or wrap the input drawable.
 
-By default, Coil comes packaged with 1 transition: [crossfade](../api/coil-base/coil.transition/-crossfade-transition/). Take a look at the [`CrossfadeTransition`](https://github.com/coil-kt/coil/blob/master/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt) source code for an example of how to write a custom `Transition`.
+By default, Coil comes packaged with 2 transitions:
+
+- [`CrossfadeTransition`](../api/coil-base/coil.transition/-crossfade-transition/) which crossfades from the current drawable to the sucess/error drawable.
+- [`Transition.NONE`](../api/coil-base/coil.transition/-transition/-n-o-n-e/) which sets the drawable on the `Target` immediately without animating.
+
+Take a look at the [`CrossfadeTransition` source code](https://github.com/coil-kt/coil/blob/master/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt) for an example of how to write a custom `Transition`.
 
 See the [API doc](../api/coil-base/coil.transition/-transition/) for more information.

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -2,7 +2,7 @@
 
 Transitions allow you to animate setting the result of an image request on a `Target`.
 
-Both `ImageLoader` and `Request` builders accept a `Transition`. Transitions allow you to intercept setting the `Drawable` on the `Target`. This allows you to animate the target's view or wrap the input drawable.
+Both `ImageLoader` and `LoadRequest` builders accept a `Transition`. Transitions allow you to intercept setting the `Drawable` on the `Target`. This allows you to animate the target's view or wrap the input drawable.
 
 By default, Coil comes packaged with 1 transition: [crossfade](../api/coil-base/coil.transition/-crossfade-transition/). Take a look at the [`CrossfadeTransition`](https://github.com/coil-kt/coil/blob/master/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt) source code for an example of how to write a custom `Transition`.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - 'Java Compatibility': java_compatibility.md
   - 'GIFs': gifs.md
   - 'SVGs': svgs.md
+  - 'Video Frames': videos.md
   - 'FAQ': faq.md
   - 'API':
     - 'coil': api/coil-default/index.md


### PR DESCRIPTION
Looking for feedback on this!

This PR deprecates the `ImageLoader.load(context, data)`, `ImageLoader.get(data)`, `Coil.load(context, data)`, and `Coil.get(data)` functions in favour of a more standard builder syntax:

```kotlin
// LoadRequest
val request = LoadRequest.Builder(context)
    .data("https://www.example.com/image.jpg")
    .target(imageView)
    .build()
val disposable = imageLoader.launch(request)

// GetRequest
val request = GetRequest.Builder()
    .data("https://www.example.com/image.jpg")
    .size(1080, 1920)
    .build()
val drawable = imageLoader.launch(request)
```

NOTE: This does not deprecate `ImageView.load`.

Why deprecate these functions? I covered a lot of my thoughts on builders [here](https://github.com/coil-kt/coil/pull/267) that I think apply here as well.

Upsides:
- Remove DSL syntax
- Java compatibility

Downsides:
- Type safety (`data(Any)`)

Overall, I think this makes it clearer that requests are value objects that can be constructed now and executed later:

```kotlin
val request = LoadRequest.Builder(context)
    .data("https://www.example.com/image.jpg")
    .transformations(GrayscaleTransformation())
    .build()

// Then later...
val disposable = imageLoader.launch(request.newBuilder().target(imageView).build())
```

Open questions:
- Should there be a `target` + `launch` function similar to Glide and Picasso's `into`?
- Is it clear enough that you need to call `data` when constructing a request?