### PR TITLE
Parallelize CI steps. Run instrumentation tests against multiple API levels.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                api-level: [16, 19, 21, 25, 29]
+                api-level: [14, 19, 21, 25, 29]
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
         runs-on: macOS-latest
         timeout-minutes: 10
         strategy:
+            fail-fast: false
             matrix:
                 api-level: [16, 19, 21, 25, 29]
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: gradle/wrapper-validation-action@v1
 
             # Ensure .gradle/caches is empty before writing to it.
             # This helps us stay within Github's cache size limits.
@@ -43,10 +43,10 @@ jobs:
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: gradle/wrapper-validation-action@v1
             - name: Clean cache
               run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
             - uses: actions/cache@v1
@@ -60,16 +60,16 @@ jobs:
     instrumentation-tests:
         name: Instrumentation tests
         runs-on: macOS-latest
-        timeout-minutes: 30
+        timeout-minutes: 15
         strategy:
             matrix:
                 api-level: [16, 19, 21, 25, 29]
         steps:
             - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: gradle/wrapper-validation-action@v1
             - name: Clean cache
               run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
             - uses: actions/cache@v1
@@ -85,17 +85,17 @@ jobs:
                   script: ./gradlew connectedDebugAndroidTest
 
     deploy-snapshot:
-        name: Instrumentation tests
+        name: Deploy snapshot
         runs-on: macOS-latest
         timeout-minutes: 15
         if: github.ref == 'refs/heads/master'
         needs: [check, unit-tests, instrumentation-tests]
         steps:
             - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - uses: gradle/wrapper-validation-action@v1
             - name: Clean cache
               run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
             - uses: actions/cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     instrumentation-tests:
         name: Instrumentation tests
         runs-on: macOS-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
         runs-on: macOS-latest
         timeout-minutes: 20
         strategy:
-            fail-fast: false
             matrix:
                 api-level: [15, 19, 21, 25, 29]
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,25 +5,22 @@ on:
             - master
     pull_request:
 jobs:
-    ci:
-        name: Build + Test
+    check:
+        name: Check
         runs-on: macOS-latest
-        timeout-minutes: 30
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@v2
-
-            - name: Set Up Java
-              uses: actions/setup-java@v1
+            - uses: actions/setup-java@v1
               with:
                   java-version: 11
-
-            # Validate the Gradle wrapper JAR files.
             - uses: gradle/wrapper-validation-action@v1
 
             # Ensure .gradle/caches is empty before writing to it.
             # This helps us stay within Github's cache size limits.
-            - name: Clean Cache
-              run: rm -rf ~/.gradle/caches
+            # Rename the folder instead of deleting it as it's faster.
+            - name: Clean cache
+              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
 
             # Restore the cache.
             # Intentionally don't set 'restore-keys' so the cache never contains redundant dependencies.
@@ -32,26 +29,81 @@ jobs:
                   path: ~/.gradle/caches
                   key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/src/main/kotlin/Library.kt') }}
 
-            - name: Ktlint
+            - name: Check style
               run: ./gradlew ktlintCheck
 
             # Check if there has been a binary incompatible change to the API.
             # If this change is intentional, run `./gradlew apiDump` and commit the new API files.
-            - name: Check Binary Compatibility
+            - name: Check binary compatibility
               run: ./gradlew apiCheck
 
-            - name: Unit Tests
+    unit-tests:
+        name: Unit tests
+        runs-on: macOS-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            - uses: gradle/wrapper-validation-action@v1
+            - name: Clean cache
+              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/src/main/kotlin/Library.kt') }}
+
+            - name: Unit tests
               run: ./gradlew testDebugUnitTest
 
-            - name: Instrumentation Tests
+    instrumentation-tests:
+        name: Instrumentation tests
+        runs-on: macOS-latest
+        timeout-minutes: 30
+        strategy:
+            matrix:
+                api-level: [16, 19, 21, 25, 29]
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            - uses: gradle/wrapper-validation-action@v1
+            - name: Clean cache
+              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/src/main/kotlin/Library.kt') }}
+
+            - name: Instrumentation tests
               uses: reactivecircus/android-emulator-runner@v2
               with:
-                  api-level: 25
+                  api-level: ${{ matrix.api-level }}
                   arch: x86
                   script: ./gradlew connectedDebugAndroidTest
 
+    deploy-snapshot:
+        name: Instrumentation tests
+        runs-on: macOS-latest
+        timeout-minutes: 15
+        if: github.ref == 'refs/heads/master'
+        needs: [check, unit-tests, instrumentation-tests]
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: 11
+            - uses: gradle/wrapper-validation-action@v1
+            - name: Clean cache
+              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
+            - uses: actions/cache@v1
+              with:
+                  path: ~/.gradle/caches
+                  key: gradle-${{ runner.os }}-${{ hashFiles('**/build.gradle.kts') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/src/main/kotlin/Library.kt') }}
+
             - name: Deploy Snapshot
-              if: github.ref == 'refs/heads/master'
               env:
                   SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
                   SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     check:
         name: Check
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -31,7 +31,7 @@ jobs:
     unit-tests:
         name: Unit tests
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
@@ -49,7 +49,7 @@ jobs:
     instrumentation-tests:
         name: Instrumentation tests
         runs-on: macOS-latest
-        timeout-minutes: 15
+        timeout-minutes: 10
         strategy:
             matrix:
                 api-level: [16, 19, 21, 25, 29]
@@ -83,7 +83,7 @@ jobs:
     deploy-snapshot:
         name: Deploy snapshot
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 10
         if: github.ref == 'refs/heads/master'
         needs: [check, unit-tests, instrumentation-tests]
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,6 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-
-            # Ensure .gradle/caches is empty before writing to it.
-            # This helps us stay within Github's cache size limits.
-            # Rename the folder instead of deleting it as it's faster.
-            - name: Clean cache
-              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
-
-            # Restore the cache.
-            # Intentionally don't set 'restore-keys' so the cache never contains redundant dependencies.
             - uses: actions/cache@v1
               with:
                   path: ~/.gradle/caches
@@ -47,8 +38,6 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - name: Clean cache
-              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
             - uses: actions/cache@v1
               with:
                   path: ~/.gradle/caches
@@ -70,8 +59,15 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
+
+            # Ensure .gradle/caches is empty before writing to it.
+            # This helps us stay within Github's cache size limits.
+            # Rename the folder instead of deleting it as it's faster.
             - name: Clean cache
               run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
+
+            # Restore the cache.
+            # Intentionally don't set 'restore-keys' so the cache never contains redundant dependencies.
             - uses: actions/cache@v1
               with:
                   path: ~/.gradle/caches
@@ -96,8 +92,6 @@ jobs:
             - uses: actions/setup-java@v1
               with:
                   java-version: 11
-            - name: Clean cache
-              run: mv ~/.gradle/caches ~/.gradle/.invalid_caches
             - uses: actions/cache@v1
               with:
                   path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                api-level: [14, 19, 21, 25, 29]
+                api-level: [15, 19, 21, 25, 29]
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
     check:
         name: Check
-        runs-on: macOS-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
 
     unit-tests:
         name: Unit tests
-        runs-on: macOS-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v2
@@ -86,7 +86,7 @@ jobs:
 
     deploy-snapshot:
         name: Deploy snapshot
-        runs-on: macOS-latest
+        runs-on: ubuntu-latest
         timeout-minutes: 15
         if: github.ref == 'refs/heads/master'
         needs: [check, unit-tests, instrumentation-tests]

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -87,7 +87,7 @@ class BitmapFactoryDecoderTest {
     fun originalSizeDimensionsAreResolvedCorrectly() {
         val size = OriginalSize
         val normal = decode("normal.jpg", size)
-        assertEquals(PixelSize(1080, 1350), normal.run { PixelSize(width, height) })
+        assertEquals(PixelSize(1080, 1350), normal.size)
     }
 
     @Test
@@ -116,7 +116,7 @@ class BitmapFactoryDecoderTest {
             size = PixelSize(1500, 1500),
             options = { createOptions(scale = Scale.FIT, allowInexactSize = true) }
         )
-        assertEquals(PixelSize(1080, 1350), result.run { PixelSize(width, height) })
+        assertEquals(PixelSize(1080, 1350), result.size)
     }
 
     @Test
@@ -126,7 +126,7 @@ class BitmapFactoryDecoderTest {
             size = PixelSize(1500, 1500),
             options = { createOptions(scale = Scale.FIT, allowInexactSize = false) }
         )
-        assertEquals(PixelSize(1200, 1500), result.run { PixelSize(width, height) })
+        assertEquals(PixelSize(1200, 1500), result.size)
     }
 
     private fun decode(

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -3,6 +3,7 @@ package coil.decode
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build.VERSION.SDK_INT
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.BitmapPool
 import coil.size.OriginalSize
@@ -30,7 +31,7 @@ class BitmapFactoryDecoderTest {
     @Before
     fun before() {
         context = ApplicationProvider.getApplicationContext()
-        pool = BitmapPool(0)
+        pool = BitmapPool(Long.MAX_VALUE)
         service = BitmapFactoryDecoder(context)
     }
 
@@ -127,6 +128,47 @@ class BitmapFactoryDecoderTest {
             options = { createOptions(scale = Scale.FIT, allowInexactSize = false) }
         )
         assertEquals(PixelSize(1200, 1500), result.size)
+    }
+
+    @Test
+    fun pooledBitmap_exactSize() {
+        val pooledBitmap = Bitmap.createBitmap(1080, 1350, Bitmap.Config.ARGB_8888)
+        pool.put(pooledBitmap)
+
+        val result = decode(
+            fileName = "normal.jpg",
+            size = PixelSize(1080, 1350),
+            options = {
+                createOptions(
+                    config = Bitmap.Config.ARGB_8888,
+                    scale = Scale.FIT,
+                    allowInexactSize = false
+                )
+            }
+        )
+        assertEquals(PixelSize(1080, 1350), result.size)
+        assertEquals(pooledBitmap, result)
+    }
+
+    @Test
+    fun pooledBitmap_inexactSize() {
+        val pooledBitmap = Bitmap.createBitmap(1080, 1350, Bitmap.Config.ARGB_8888)
+        pool.put(pooledBitmap)
+
+        val result = decode(
+            fileName = "normal.jpg",
+            size = PixelSize(500, 500),
+            options = {
+                createOptions(
+                    config = Bitmap.Config.ARGB_8888,
+                    scale = Scale.FILL,
+                    allowInexactSize = false
+                )
+            }
+        )
+        assertEquals(PixelSize(500, 625), result.size)
+        // The bitmap should not be re-used on pre-API 19.
+        assertEquals(pooledBitmap === result, SDK_INT >= 19)
     }
 
     private fun decode(

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -97,7 +97,7 @@ class BitmapFactoryDecoderTest {
 
         for (index in 1..8) {
             val other = decode("exif/$index.jpg", size)
-            assertTrue(normal.isSimilarTo(other), "Image with index $index is incorrect.")
+            assertTrue(normal.isSimilarTo(other, threshold = 0.95), "Image with index $index is incorrect.")
         }
     }
 

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -97,7 +97,7 @@ class BitmapFactoryDecoderTest {
 
         for (index in 1..8) {
             val other = decode("exif/$index.jpg", size)
-            assertTrue(normal.isSimilarTo(other, threshold = 0.95), "Image with index $index is incorrect.")
+            assertTrue(normal.isSimilarTo(other), "Image with index $index is incorrect.")
         }
     }
 

--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -67,8 +67,8 @@ class ResourceUriFetcherTest {
 
     @Test
     fun externalPackageRasterDrawable() {
-        // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable/regulatory_info.png
-        val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/regulatory_info".toUri()
+        // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable-xhdpi/ic_power_system.png
+        val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/ic_power_system".toUri()
         val uri = ResourceUriMapper(context).map(rawUri)
 
         assertTrue(fetcher.handles(uri))

--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -3,6 +3,7 @@ package coil.fetch
 import android.content.ContentResolver.SCHEME_ANDROID_RESOURCE
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.base.test.R
@@ -12,6 +13,7 @@ import coil.map.ResourceUriMapper
 import coil.size.PixelSize
 import coil.util.createOptions
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -66,8 +68,7 @@ class ResourceUriFetcherTest {
     @Test
     fun externalPackageRasterDrawable() {
         // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable/regulatory_info.png
-        val packageName = "com.android.settings"
-        val rawUri = "$SCHEME_ANDROID_RESOURCE://$packageName/drawable/regulatory_info".toUri()
+        val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/regulatory_info".toUri()
         val uri = ResourceUriMapper(context).map(rawUri)
 
         assertTrue(fetcher.handles(uri))
@@ -83,9 +84,11 @@ class ResourceUriFetcherTest {
 
     @Test
     fun externalPackageVectorDrawable() {
+        // com.android.settings/drawable/ic_cancel was added in API 23.
+        assumeTrue(SDK_INT >= 23)
+
         // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable/ic_cancel.xml
-        val packageName = "com.android.settings"
-        val rawUri = "$SCHEME_ANDROID_RESOURCE://$packageName/drawable/ic_cancel".toUri()
+        val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/ic_cancel".toUri()
         val uri = ResourceUriMapper(context).map(rawUri)
 
         assertTrue(fetcher.handles(uri))

--- a/coil-base/src/androidTest/java/coil/map/ResourceUriMapperTest.kt
+++ b/coil-base/src/androidTest/java/coil/map/ResourceUriMapperTest.kt
@@ -36,9 +36,9 @@ class ResourceUriMapperTest {
 
     @Test
     fun externalResourceNameUri() {
-        // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable/regulatory_info.png
+        // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable-xhdpi/ic_power_system.png
         val packageName = "com.android.settings"
-        val input = "$SCHEME_ANDROID_RESOURCE://$packageName/drawable/regulatory_info".toUri()
+        val input = "$SCHEME_ANDROID_RESOURCE://$packageName/drawable/ic_power_system".toUri()
 
         assertTrue(mapper.handles(input))
 

--- a/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
@@ -1,6 +1,8 @@
 package coil.transform
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.BitmapPool
 import coil.size.OriginalSize
@@ -27,8 +29,12 @@ class GrayscaleTransformationTest {
 
     @Test
     fun basic() {
-        val input = context.decodeBitmapAsset("normal.jpg")
-        val expected = context.decodeBitmapAsset("normal_grayscale.jpg")
+        val options = BitmapFactory.Options().apply {
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+            inSampleSize = 2 // Downsample the image to avoid running out of memory on pre-API 21.
+        }
+        val input = context.decodeBitmapAsset("normal.jpg", options)
+        val expected = context.decodeBitmapAsset("normal_grayscale.jpg", options)
 
         val actual = runBlocking {
             transformation.transform(pool, input, OriginalSize)

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -85,7 +85,7 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
                     inBitmap = pool.getDirtyOrNull(outWidth, outHeight, inPreferredConfig)
                 }
             }
-            SDK_INT >= 19 -> {
+            else -> {
                 val (width, height) = size
                 inSampleSize = DecodeUtils.calculateInSampleSize(srcWidth, srcHeight, width, height, options.scale)
 
@@ -124,19 +124,6 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
                         height = ceil(scale * sampledOutHeight + 0.5).toInt(),
                         config = inPreferredConfig
                     )
-                }
-            }
-            else -> {
-                // We can only re-use bitmaps that exactly match the size of the image.
-                if (inMutable) {
-                    inBitmap = pool.getDirtyOrNull(outWidth, outHeight, inPreferredConfig)
-                }
-
-                // Sample size must be 1 if we are re-using a bitmap.
-                inSampleSize = if (inBitmap != null) {
-                    1
-                } else {
-                    DecodeUtils.calculateInSampleSize(srcWidth, srcHeight, size.width, size.height, options.scale)
                 }
             }
         }

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -56,9 +56,11 @@ internal object Utils {
     }
 
     fun getDefaultBitmapPoolPercentage(): Double {
+        // Allocate less memory for bitmap pooling on API 18 and below as the requirements
+        // for bitmap reuse are quite strict.
         // Allocate less memory for bitmap pooling on API 26 and above since we default to
-        // hardware bitmaps, which cannot be added to the pool.
-        return if (SDK_INT >= 26) 0.25 else 0.5
+        // hardware bitmaps, which cannot be reused.
+        return if (SDK_INT in 19..25) 0.5 else 0.25
     }
 
     fun getDefaultBitmapConfig(): Bitmap.Config {

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ColorSpace
+import androidx.annotation.RequiresApi
 import coil.decode.Options
 import coil.request.CachePolicy
 import coil.request.GetRequest
@@ -35,6 +36,32 @@ fun createMockWebServer(context: Context, vararg images: String): MockWebServer 
     }
 }
 
+fun createOptions(
+    config: Bitmap.Config = Bitmap.Config.ARGB_8888,
+    scale: Scale = Scale.FILL,
+    allowInexactSize: Boolean = false,
+    allowRgb565: Boolean = false,
+    headers: Headers = Headers.Builder().build(),
+    parameters: Parameters = Parameters.Builder().build(),
+    memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    diskCachePolicy: CachePolicy = CachePolicy.ENABLED,
+    networkCachePolicy: CachePolicy = CachePolicy.ENABLED
+): Options {
+    return Options(
+        config,
+        null,
+        scale,
+        allowInexactSize,
+        allowRgb565,
+        headers,
+        parameters,
+        memoryCachePolicy,
+        diskCachePolicy,
+        networkCachePolicy
+    )
+}
+
+@RequiresApi(26)
 fun createOptions(
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
     colorSpace: ColorSpace? = null,

--- a/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
+++ b/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
@@ -3,6 +3,7 @@ package coil.fetch
 import android.content.ContentResolver.SCHEME_FILE
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.bitmappool.BitmapPool
@@ -14,6 +15,7 @@ import coil.util.createOptions
 import coil.util.decodeBitmapAsset
 import coil.util.isSimilarTo
 import kotlinx.coroutines.runBlocking
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -35,6 +37,9 @@ class VideoFrameFetcherTest {
 
     @Test
     fun noSetFrameTime() {
+        // MediaMetadataRetriever.getFrameAtTime does not work on the emulator pre-API 23.
+        assumeTrue(SDK_INT >= 23)
+
         val result = runBlocking {
             fetcher.fetch(
                 pool = pool,
@@ -55,6 +60,9 @@ class VideoFrameFetcherTest {
 
     @Test
     fun specificFrameTime() {
+        // MediaMetadataRetriever.getFrameAtTime does not work on the emulator pre-API 23.
+        assumeTrue(SDK_INT >= 23)
+
         val result = runBlocking {
             fetcher.fetch(
                 pool = pool,

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -101,8 +101,8 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
             val option = options.parameters.videoFrameOption() ?: OPTION_CLOSEST_SYNC
             val frameMicros = options.parameters.videoFrameMicros() ?: 0L
 
-            // Resolve the dimensions to decode the video frame at
-            // accounting for the source's aspect ratio and the target's size.
+            // Resolve the dimensions to decode the video frame at accounting
+            // for the source's aspect ratio and the target's size.
             var srcWidth = 0
             var srcHeight = 0
             val destSize = when (size) {
@@ -132,14 +132,17 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
                 is OriginalSize -> OriginalSize
             }
 
-            val rawBitmap = if (SDK_INT >= 27 && destSize is PixelSize) {
+            val rawBitmap: Bitmap? = if (SDK_INT >= 27 && destSize is PixelSize) {
                 retriever.getScaledFrameAtTime(frameMicros, option, destSize.width, destSize.height)
             } else {
-                retriever.getFrameAtTime(frameMicros, option).also {
+                retriever.getFrameAtTime(frameMicros, option)?.also {
                     srcWidth = it.width
                     srcHeight = it.height
                 }
             }
+
+            // If you encounter this exception, ensure your video is encoded in a supported codec.
+            // https://developer.android.com/guide/topics/media/media-formats#video-formats
             checkNotNull(rawBitmap) { "Failed to decode frame at $frameMicros microseconds." }
 
             val bitmap = normalizeBitmap(pool, rawBitmap, destSize, options)


### PR DESCRIPTION
Also adjusts the bitmap pooling behaviour on pre-API 19 so it results in always respects the requested size, however at the cost of lower bitmap reuse.