### PR TITLE
Fix failing to read EXIF data on pre-API 23.

### DIFF
--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -232,7 +232,7 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
         }
     }
 
-    /** Wrap [delegate] so that it always returns [Int.MAX_VALUE] for [available]. */
+    /** Wrap [delegate] so that it always returns 1GB for [available]. */
     private class AlwaysAvailableInputStream(private val delegate: InputStream) : InputStream() {
 
         override fun read() = delegate.read()
@@ -243,7 +243,7 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
 
         override fun skip(n: Long) = delegate.skip(n)
 
-        override fun available() = Int.MAX_VALUE
+        override fun available() = 1024 * 1024 * 1024 // 1GB
 
         override fun close() = delegate.close()
 


### PR DESCRIPTION
Figured this out while working on https://github.com/coil-kt/coil/pull/330.

`AlwaysAvailableInputStream` returns `Int.MAX_VALUE` for `available()`. This seems to work fine on API 23+, but will cause an int overflow in `BufferedInputStream.available()`. Then when `ExifInterface` reads the stream it throws an `EOFException` because `available` is negative.

To fix this, we still use a really large number (1GB) that has no chance of overflowing.

This case is covered by tests in https://github.com/coil-kt/coil/pull/330.

Fixes: https://github.com/coil-kt/coil/issues/250