### PR TITLE
Preallocate bitmap when decoding software bitmap.

### DIFF
--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -129,12 +129,13 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
                             // downsampling algorithm across different API levels.
                             val sampledOutWidth = outWidth / inSampleSize.toDouble()
                             val sampledOutHeight = outHeight / inSampleSize.toDouble()
-                            pool.getDirtyOrNull(
+                            pool.getDirty(
                                 width = ceil(scale * sampledOutWidth + 0.5).toInt(),
                                 height = ceil(scale * sampledOutHeight + 0.5).toInt(),
                                 config = inPreferredConfig
                             )
                         }
+                        // Else, let BitmapFactory allocate the bitmap internally.
                         else -> null
                     }
                 }


### PR DESCRIPTION
This should greatly improve the bitmap pool hit rate if decoding subsequent images that are exactly the same size.

According to my benchmarks preallocating vs. letting `BitmapFactory` allocate the bitmap has no performance difference.