### PR TITLE
Fix memory cache miss when Transformation reduces input bitmap's size.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -587,6 +587,7 @@ public final class coil/request/Parameters : java/lang/Iterable, kotlin/jvm/inte
 	public final fun isEmpty ()Z
 	public fun iterator ()Ljava/util/Iterator;
 	public final fun newBuilder ()Lcoil/request/Parameters$Builder;
+	public fun toString ()Ljava/lang/String;
 	public final fun value (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun values ()Ljava/util/Map;
 }

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -577,8 +577,9 @@ public final class coil/request/Parameters : java/lang/Iterable, kotlin/jvm/inte
 	public static final field Companion Lcoil/request/Parameters$Companion;
 	public static final field EMPTY Lcoil/request/Parameters;
 	public fun <init> ()V
-	public synthetic fun <init> (Ljava/util/SortedMap;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun cacheKey (Ljava/lang/String;)Ljava/lang/String;
+	public final fun cacheKeys ()Ljava/util/Map;
 	public final fun count ()I
 	public final fun entry (Ljava/lang/String;)Lcoil/request/Parameters$Entry;
 	public fun equals (Ljava/lang/Object;)Z
@@ -586,8 +587,8 @@ public final class coil/request/Parameters : java/lang/Iterable, kotlin/jvm/inte
 	public final fun isEmpty ()Z
 	public fun iterator ()Ljava/util/Iterator;
 	public final fun newBuilder ()Lcoil/request/Parameters$Builder;
-	public fun toString ()Ljava/lang/String;
 	public final fun value (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun values ()Ljava/util/Map;
 }
 
 public final class coil/request/Parameters$Builder {

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -200,28 +200,28 @@ internal class RealImageLoader(
 
             // Check the memory cache.
             val memoryCachePolicy = request.memoryCachePolicy ?: defaults.memoryCachePolicy
-            val cacheValue = takeIf(memoryCachePolicy.readEnabled) {
+            val cachedValue = takeIf(memoryCachePolicy.readEnabled) {
                 memoryCache.getValue(cacheKey) ?: request.aliasKeys.firstNotNullIndices { memoryCache.getValue(MemoryCache.Key(it)) }
             }
 
             // Ignore the cached bitmap if it is hardware-backed and the request disallows hardware bitmaps.
-            val cacheDrawable = cacheValue?.bitmap
+            val cachedDrawable = cachedValue?.bitmap
                 ?.takeIf { requestService.isConfigValidForHardware(request, it.safeConfig) }
                 ?.toDrawable(context)
 
             // If we didn't resolve the size earlier, resolve it now.
-            val size = lazySizeResolver.size(cacheDrawable)
+            val size = lazySizeResolver.size(cachedDrawable)
 
             // Resolve the scale.
             val scale = requestService.scale(request, sizeResolver)
 
             // Short circuit if the cached drawable is valid for the target.
-            if (cacheDrawable != null && memoryCacheService.isCachedDrawableValid(cacheKey, cacheValue, request, sizeResolver, size, scale)) {
+            if (cachedDrawable != null && memoryCacheService.isCachedDrawableValid(cacheKey, cachedValue, request, sizeResolver, size, scale)) {
                 logger?.log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
-                targetDelegate.success(cacheDrawable, true, request.transition ?: defaults.transition)
+                targetDelegate.success(cachedDrawable, true, request.transition ?: defaults.transition)
                 eventListener.onSuccess(request, DataSource.MEMORY)
                 request.listener?.onSuccess(request, DataSource.MEMORY)
-                return@innerJob cacheDrawable
+                return@innerJob cachedDrawable
             }
 
             // Fetch and decode the image.

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -216,7 +216,7 @@ internal class RealImageLoader(
             val scale = requestService.scale(request, sizeResolver)
 
             // Short circuit if the cached drawable is valid for the target.
-            if (cachedDrawable != null && memoryCacheService.isCachedDrawableValid(cacheKey, cachedValue, request, sizeResolver, size, scale)) {
+            if (cachedDrawable != null && memoryCacheService.isCachedValueValid(cacheKey, cachedValue, request, sizeResolver, size, scale)) {
                 logger?.log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
                 targetDelegate.success(cachedDrawable, true, request.transition ?: defaults.transition)
                 eventListener.onSuccess(request, DataSource.MEMORY)

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -103,17 +103,17 @@ internal interface MemoryCache {
             if (this === other) return true
             if (other !is Key) return false
             if (baseKey != other.baseKey) return false
-            if (parameterKeys != other.parameterKeys) return false
             if (transformationKeys != other.transformationKeys) return false
             if (size != other.size) return false
+            if (parameterKeys != other.parameterKeys) return false
             return true
         }
 
         override fun hashCode(): Int {
             var result = baseKey.hashCode()
-            result = 31 * result + parameterKeys.hashCode()
             result = 31 * result + transformationKeys.hashCode()
             result = 31 * result + (size?.hashCode() ?: 0)
+            result = 31 * result + parameterKeys.hashCode()
             return result
         }
 

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -101,11 +101,11 @@ internal interface MemoryCache {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            return other is Key
-                && baseKey == other.baseKey
-                && transformationKeys == other.transformationKeys
-                && size == other.size
-                && parameterKeys == other.parameterKeys
+            return other is Key &&
+                baseKey == other.baseKey &&
+                transformationKeys == other.transformationKeys &&
+                size == other.size &&
+                parameterKeys == other.parameterKeys
         }
 
         override fun hashCode(): Int {

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -101,12 +101,11 @@ internal interface MemoryCache {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            if (other !is Key) return false
-            if (baseKey != other.baseKey) return false
-            if (transformationKeys != other.transformationKeys) return false
-            if (size != other.size) return false
-            if (parameterKeys != other.parameterKeys) return false
-            return true
+            return other is Key
+                && baseKey == other.baseKey
+                && transformationKeys == other.transformationKeys
+                && size == other.size
+                && parameterKeys == other.parameterKeys
         }
 
         override fun hashCode(): Int {

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -1,7 +1,6 @@
 package coil.memory
 
 import android.graphics.Bitmap
-import android.graphics.drawable.BitmapDrawable
 import android.util.Log
 import coil.DefaultRequestOptions
 import coil.decode.DecodeUtils
@@ -30,18 +29,17 @@ internal class MemoryCacheService(
 
     /** Return true if the [Bitmap] returned from [MemoryCache] satisfies the [Request]. */
     fun isCachedDrawableValid(
-        cached: BitmapDrawable,
-        isSampled: Boolean,
+        cacheKey: MemoryCache.Key?,
+        cacheValue: MemoryCache.Value,
         request: Request,
         sizeResolver: SizeResolver,
         size: Size,
         scale: Scale
     ): Boolean {
         // Ensure the size is valid for the target.
-        val bitmap = cached.bitmap
         when (size) {
             is OriginalSize -> {
-                if (isSampled) {
+                if (cacheValue.isSampled) {
                     logger?.log(TAG, Log.DEBUG) {
                         "${request.data}: Requested original size, but cached image is sampled."
                     }
@@ -49,24 +47,37 @@ internal class MemoryCacheService(
                 }
             }
             is PixelSize -> {
+                val cachedWidth: Int
+                val cachedHeight: Int
+                when (val cachedSize = cacheKey?.size) {
+                    is PixelSize -> {
+                        cachedWidth = cachedSize.width
+                        cachedHeight = cachedSize.height
+                    }
+                    OriginalSize, null -> {
+                        val bitmap = cacheValue.bitmap
+                        cachedWidth = bitmap.width
+                        cachedHeight = bitmap.height
+                    }
+                }
                 val multiple = DecodeUtils.computeSizeMultiplier(
-                    srcWidth = bitmap.width,
-                    srcHeight = bitmap.height,
+                    srcWidth = cachedWidth,
+                    srcHeight = cachedHeight,
                     dstWidth = size.width,
                     dstHeight = size.height,
                     scale = scale
                 )
                 if (multiple != 1.0 && !requestService.allowInexactSize(request, sizeResolver)) {
                     logger?.log(TAG, Log.DEBUG) {
-                        "${request.data}: Cached image's size (${bitmap.width}, ${bitmap.height}) " +
-                            "does not exactly match the requested size (${size.width}, ${size.height})."
+                        "${request.data}: Cached image's request size ($cachedWidth, $cachedHeight) " +
+                            "does not exactly match the requested size signature (${size.width}, ${size.height}, $scale)."
                     }
                     return false
                 }
-                if (multiple > 1.0 && isSampled) {
+                if (multiple > 1.0 && cacheValue.isSampled) {
                     logger?.log(TAG, Log.DEBUG) {
-                        "${request.data}: Cached image's size (${bitmap.width}, ${bitmap.height}) " +
-                            "is smaller than the requested size (${size.width}, ${size.height})."
+                        "${request.data}: Cached image's request size ($cachedWidth, $cachedHeight) " +
+                            "is smaller than the requested size signature (${size.width}, ${size.height}, $scale)."
                     }
                     return false
                 }
@@ -74,7 +85,7 @@ internal class MemoryCacheService(
         }
 
         // Ensure we don't return a hardware bitmap if the request doesn't allow it.
-        if (!requestService.isConfigValidForHardware(request, bitmap.safeConfig)) {
+        if (!requestService.isConfigValidForHardware(request, cacheValue.bitmap.safeConfig)) {
             logger?.log(TAG, Log.DEBUG) {
                 "${request.data}: Cached bitmap is hardware-backed, which is incompatible with the request."
             }
@@ -82,13 +93,13 @@ internal class MemoryCacheService(
         }
 
         // Allow returning a cached RGB_565 bitmap if allowRgb565 is enabled.
-        if ((request.allowRgb565 ?: defaults.allowRgb565) && bitmap.config == Bitmap.Config.RGB_565) {
+        if ((request.allowRgb565 ?: defaults.allowRgb565) && cacheValue.bitmap.config == Bitmap.Config.RGB_565) {
             return true
         }
 
         // Ensure the requested config matches the cached config.
         // Hardware and ARGB_8888 bitmaps are treated as equal for this comparison.
-        val cachedConfig = bitmap.config.toSoftware()
+        val cachedConfig = cacheValue.bitmap.config.toSoftware()
         val requestedConfig = request.bitmapConfigOrDefault(defaults).toSoftware()
         if (cachedConfig != requestedConfig) {
             logger?.log(TAG, Log.DEBUG) {

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -28,7 +28,7 @@ internal class MemoryCacheService(
     }
 
     /** Return true if the [Bitmap] returned from [MemoryCache] satisfies the [Request]. */
-    fun isCachedDrawableValid(
+    fun isCachedValueValid(
         cacheKey: MemoryCache.Key?,
         cacheValue: MemoryCache.Value,
         request: Request,
@@ -36,7 +36,7 @@ internal class MemoryCacheService(
         size: Size,
         scale: Scale
     ): Boolean {
-        // Ensure the size is valid for the target.
+        // Ensure the size of the cached bitmap is valid for the request.
         when (size) {
             is OriginalSize -> {
                 if (cacheValue.isSampled) {

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -70,14 +70,14 @@ internal class MemoryCacheService(
                 if (multiple != 1.0 && !requestService.allowInexactSize(request, sizeResolver)) {
                     logger?.log(TAG, Log.DEBUG) {
                         "${request.data}: Cached image's request size ($cachedWidth, $cachedHeight) " +
-                            "does not exactly match the requested size signature (${size.width}, ${size.height}, $scale)."
+                            "does not exactly match the requested size (${size.width}, ${size.height}, $scale)."
                     }
                     return false
                 }
                 if (multiple > 1.0 && cacheValue.isSampled) {
                     logger?.log(TAG, Log.DEBUG) {
                         "${request.data}: Cached image's request size ($cachedWidth, $cachedHeight) " +
-                            "is smaller than the requested size signature (${size.width}, ${size.height}, $scale)."
+                            "is smaller than the requested size (${size.width}, ${size.height}, $scale)."
                     }
                     return false
                 }

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -67,8 +67,8 @@ class Parameters private constructor(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        return other is Parameters
-            && map == other.map
+        return other is Parameters &&
+            map == other.map
     }
 
     override fun hashCode() = map.hashCode()

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -67,9 +67,8 @@ class Parameters private constructor(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is Parameters) return false
-        if (map != other.map) return false
-        return true
+        return other is Parameters
+            && map == other.map
     }
 
     override fun hashCode() = map.hashCode()

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -72,7 +72,9 @@ class Parameters private constructor(
         return true
     }
 
-    override fun hashCode(): Int = map.hashCode()
+    override fun hashCode() = map.hashCode()
+
+    override fun toString() = "Parameters(map=$map)"
 
     fun newBuilder() = Builder(this)
 

--- a/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
@@ -2,6 +2,7 @@ package coil.memory
 
 import coil.bitmappool.BitmapPool
 import coil.bitmappool.RealBitmapPool
+import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.count
 import coil.util.createBitmap
@@ -51,9 +52,10 @@ class BitmapReferenceCounterTest {
 
     @Test
     fun `valid bitmap is added to pool if count reaches zero`() {
+        val key = Key("key")
         val bitmap = createBitmap()
 
-        weakMemoryCache.set("key", bitmap, false, 0)
+        weakMemoryCache.set(key, bitmap, false, 0)
         counter.increment(bitmap)
 
         assertEquals(1, counter.count(bitmap))
@@ -64,14 +66,15 @@ class BitmapReferenceCounterTest {
         assertEquals(bitmap, pool.getDirtyOrNull(bitmap.width, bitmap.height, bitmap.config))
 
         // The bitmap should be removed from the weak memory cache.
-        assertNull(weakMemoryCache.get("key"))
+        assertNull(weakMemoryCache.get(key))
     }
 
     @Test
     fun `invalid bitmap is added to weak memory cache if count reaches zero`() {
+        val key = Key("key")
         val bitmap = createBitmap()
 
-        weakMemoryCache.set("key", bitmap, false, 0)
+        weakMemoryCache.set(key, bitmap, false, 0)
         counter.increment(bitmap)
         counter.invalidate(bitmap)
 
@@ -83,6 +86,6 @@ class BitmapReferenceCounterTest {
         assertNull(pool.getDirtyOrNull(bitmap.width, bitmap.height, bitmap.config))
 
         // The bitmap should still be present in the weak memory cache.
-        assertEquals(bitmap, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap, weakMemoryCache.get(key)?.bitmap)
     }
 }

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -40,48 +40,48 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - fill`() {
+    fun `isCachedValueValid - fill`() {
         val request = createGetRequest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
         val cached = createBitmap()
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(200, 200),
             scale = Scale.FILL
         ))
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(150, 50),
             scale = Scale.FILL
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FILL
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(50, 100),
             scale = Scale.FILL
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FILL
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = createBitmap(width = 400, height = 200),
             isSampled = true,
             request = request,
@@ -91,48 +91,48 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - fit`() {
+    fun `isCachedValueValid - fit`() {
         val request = createGetRequest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
         val cached = createBitmap()
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(200, 200),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(150, 50),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(50, 100),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FIT
         ))
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = createBitmap(width = 200, height = 400),
             isSampled = true,
             request = request,
@@ -142,12 +142,12 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - small not sampled cached drawable is valid`() {
+    fun `isCachedValueValid - small not sampled cached drawable is valid`() {
         val request = createGetRequest {
             precision(Precision.INEXACT)
         }
         val cached = createBitmap()
-        val isValid = service.isCachedDrawableValid(
+        val isValid = service.isCachedValueValid(
             cached = cached,
             isSampled = false,
             request = request,
@@ -158,12 +158,12 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - bitmap config must be equal`() {
+    fun `isCachedValueValid - bitmap config must be equal`() {
         val request = createGetRequest()
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
             val cached = createBitmap(config = config)
-            return service.isCachedDrawableValid(
+            return service.isCachedValueValid(
                 cached = cached,
                 isSampled = true,
                 request = request,
@@ -180,7 +180,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - allowRgb565=true allows matching any config if cached bitmap is RGB_565`() {
+    fun `isCachedValueValid - allowRgb565=true allows matching any config if cached bitmap is RGB_565`() {
         fun isBitmapConfigValid(
             cachedConfig: Bitmap.Config,
             requestedConfig: Bitmap.Config
@@ -189,7 +189,7 @@ class MemoryCacheServiceTest {
                 allowRgb565(true)
                 bitmapConfig(requestedConfig)
             }
-            return service.isCachedDrawableValid(
+            return service.isCachedValueValid(
                 cached = createBitmap(config = cachedConfig),
                 isSampled = true,
                 request = request,
@@ -212,14 +212,14 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - allowHardware=false prevents using cached hardware bitmap`() {
+    fun `isCachedValueValid - allowHardware=false prevents using cached hardware bitmap`() {
         val request = createGetRequest {
             allowHardware(false)
         }
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
             val cached = createBitmap(config = config)
-            return service.isCachedDrawableValid(
+            return service.isCachedValueValid(
                 cached = cached,
                 isSampled = true,
                 request = request,
@@ -234,60 +234,60 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - exact precision`() {
+    fun `isCachedValueValid - exact precision`() {
         val request = createLoadRequest(context) {
             precision(Precision.EXACT)
         }
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FILL
         ))
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 50),
             scale = Scale.FILL
         ))
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 50),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FILL
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FIT
         ))
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             cached = createBitmap(width = 400, height = 200),
             isSampled = true,
             request = request,
             size = PixelSize(400, 200),
             scale = Scale.FILL
         ))
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             cached = createBitmap(width = 200, height = 400),
             isSampled = true,
             request = request,
@@ -297,7 +297,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedDrawableValid - transformation that reduces size of output bitmap`() {
+    fun `isCachedValueValid - transformation that reduces size of output bitmap`() {
         val transformations = listOf(CircleCropTransformation())
         val cachedSize = PixelSize(1000, 500) // The size of the previous request.
         val key = Key("key", transformations, cachedSize)
@@ -307,7 +307,7 @@ class MemoryCacheServiceTest {
         }
         val request = createLoadRequest(context)
 
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             key,
             value,
             request.newBuilder().precision(Precision.INEXACT).build(),
@@ -315,7 +315,7 @@ class MemoryCacheServiceTest {
             Scale.FIT
         ))
 
-        assertTrue(service.isCachedDrawableValid(
+        assertTrue(service.isCachedValueValid(
             key,
             value,
             request.newBuilder().precision(Precision.EXACT).build(),
@@ -323,7 +323,7 @@ class MemoryCacheServiceTest {
             Scale.FIT
         ))
 
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             key,
             value,
             request.newBuilder().precision(Precision.INEXACT).build(),
@@ -331,7 +331,7 @@ class MemoryCacheServiceTest {
             Scale.FIT
         ))
 
-        assertFalse(service.isCachedDrawableValid(
+        assertFalse(service.isCachedValueValid(
             key,
             value,
             request.newBuilder().precision(Precision.EXACT).build(),
@@ -340,7 +340,7 @@ class MemoryCacheServiceTest {
         ))
     }
 
-    private fun MemoryCacheService.isCachedDrawableValid(
+    private fun MemoryCacheService.isCachedValueValid(
         cached: Bitmap,
         isSampled: Boolean,
         request: Request,
@@ -352,15 +352,15 @@ class MemoryCacheServiceTest {
             override val bitmap = cached
             override val isSampled = isSampled
         }
-        return isCachedDrawableValid(key, value, request, size, scale)
+        return isCachedValueValid(key, value, request, size, scale)
     }
 
     /** Convenience function to avoid having to specify the [SizeResolver] explicitly. */
-    private fun MemoryCacheService.isCachedDrawableValid(
+    private fun MemoryCacheService.isCachedValueValid(
         cacheKey: Key?,
         cacheValue: Value,
         request: Request,
         size: Size,
         scale: Scale
-    ): Boolean = isCachedDrawableValid(cacheKey, cacheValue, request, SizeResolver(size), size, scale)
+    ): Boolean = isCachedValueValid(cacheKey, cacheValue, request, SizeResolver(size), size, scale)
 }

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -302,5 +302,12 @@ class MemoryCacheServiceTest {
         request: Request,
         size: Size,
         scale: Scale
-    ): Boolean = isCachedDrawableValid(cached, isSampled, request, SizeResolver(size), size, scale)
+    ): Boolean {
+        val key = MemoryCache.Key("key")
+        val value = object : MemoryCache.Value {
+            override val bitmap = cached.bitmap
+            override val isSampled = isSampled
+        }
+        return isCachedDrawableValid(key, value, request, SizeResolver(size), size, scale)
+    }
 }

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -2,20 +2,21 @@ package coil.memory
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.drawable.BitmapDrawable
 import androidx.test.core.app.ApplicationProvider
 import coil.DefaultRequestOptions
 import coil.annotation.ExperimentalCoilApi
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 import coil.request.Request
 import coil.size.PixelSize
 import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
 import coil.size.SizeResolver
+import coil.transform.CircleCropTransformation
 import coil.util.createBitmap
 import coil.util.createGetRequest
 import coil.util.createLoadRequest
-import coil.util.toDrawable
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +45,7 @@ class MemoryCacheServiceTest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
-        val cached = createBitmap().toDrawable(context)
+        val cached = createBitmap()
         assertFalse(service.isCachedDrawableValid(
             cached = cached,
             isSampled = true,
@@ -81,7 +82,7 @@ class MemoryCacheServiceTest {
             scale = Scale.FILL
         ))
         assertTrue(service.isCachedDrawableValid(
-            cached = createBitmap(width = 400, height = 200).toDrawable(context),
+            cached = createBitmap(width = 400, height = 200),
             isSampled = true,
             request = request,
             size = PixelSize(400, 200),
@@ -95,7 +96,7 @@ class MemoryCacheServiceTest {
             size(100, 100)
             precision(Precision.INEXACT)
         }
-        val cached = createBitmap().toDrawable(context)
+        val cached = createBitmap()
         assertFalse(service.isCachedDrawableValid(
             cached = cached,
             isSampled = true,
@@ -132,7 +133,7 @@ class MemoryCacheServiceTest {
             scale = Scale.FIT
         ))
         assertFalse(service.isCachedDrawableValid(
-            cached = createBitmap(width = 200, height = 400).toDrawable(context),
+            cached = createBitmap(width = 200, height = 400),
             isSampled = true,
             request = request,
             size = PixelSize(400, 800),
@@ -145,7 +146,7 @@ class MemoryCacheServiceTest {
         val request = createGetRequest {
             precision(Precision.INEXACT)
         }
-        val cached = createBitmap().toDrawable(context)
+        val cached = createBitmap()
         val isValid = service.isCachedDrawableValid(
             cached = cached,
             isSampled = false,
@@ -161,7 +162,7 @@ class MemoryCacheServiceTest {
         val request = createGetRequest()
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
-            val cached = createBitmap(config = config).toDrawable(context)
+            val cached = createBitmap(config = config)
             return service.isCachedDrawableValid(
                 cached = cached,
                 isSampled = true,
@@ -189,7 +190,7 @@ class MemoryCacheServiceTest {
                 bitmapConfig(requestedConfig)
             }
             return service.isCachedDrawableValid(
-                cached = createBitmap(config = cachedConfig).toDrawable(context),
+                cached = createBitmap(config = cachedConfig),
                 isSampled = true,
                 request = request,
                 size = PixelSize(100, 100),
@@ -217,7 +218,7 @@ class MemoryCacheServiceTest {
         }
 
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
-            val cached = createBitmap(config = config).toDrawable(context)
+            val cached = createBitmap(config = config)
             return service.isCachedDrawableValid(
                 cached = cached,
                 isSampled = true,
@@ -238,56 +239,56 @@ class MemoryCacheServiceTest {
             precision(Precision.EXACT)
         }
         assertFalse(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FILL
         ))
         assertFalse(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(50, 50),
             scale = Scale.FIT
         ))
         assertTrue(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 50),
             scale = Scale.FILL
         ))
         assertFalse(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 50),
             scale = Scale.FIT
         ))
         assertTrue(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FILL
         ))
         assertTrue(service.isCachedDrawableValid(
-            cached = createBitmap(width = 100, height = 100).toDrawable(context),
+            cached = createBitmap(width = 100, height = 100),
             isSampled = true,
             request = request,
             size = PixelSize(100, 100),
             scale = Scale.FIT
         ))
         assertTrue(service.isCachedDrawableValid(
-            cached = createBitmap(width = 400, height = 200).toDrawable(context),
+            cached = createBitmap(width = 400, height = 200),
             isSampled = true,
             request = request,
             size = PixelSize(400, 200),
             scale = Scale.FILL
         ))
         assertFalse(service.isCachedDrawableValid(
-            cached = createBitmap(width = 200, height = 400).toDrawable(context),
+            cached = createBitmap(width = 200, height = 400),
             isSampled = true,
             request = request,
             size = PixelSize(400, 800),
@@ -295,19 +296,71 @@ class MemoryCacheServiceTest {
         ))
     }
 
-    /** Convenience function to avoid having to specify the [SizeResolver] explicitly. */
+    @Test
+    fun `isCachedDrawableValid - transformation that reduces size of output bitmap`() {
+        val transformations = listOf(CircleCropTransformation())
+        val cachedSize = PixelSize(1000, 500) // The size of the previous request.
+        val key = Key("key", transformations, cachedSize)
+        val value = object : Value {
+            override val bitmap = createBitmap(width = 200, height = 200) // The small cached bitmap.
+            override val isSampled = true
+        }
+        val request = createLoadRequest(context)
+
+        assertTrue(service.isCachedDrawableValid(
+            key,
+            value,
+            request.newBuilder().precision(Precision.INEXACT).build(),
+            PixelSize(650, 400),
+            Scale.FIT
+        ))
+
+        assertTrue(service.isCachedDrawableValid(
+            key,
+            value,
+            request.newBuilder().precision(Precision.EXACT).build(),
+            PixelSize(1000, 500),
+            Scale.FIT
+        ))
+
+        assertFalse(service.isCachedDrawableValid(
+            key,
+            value,
+            request.newBuilder().precision(Precision.INEXACT).build(),
+            PixelSize(1500, 1000),
+            Scale.FIT
+        ))
+
+        assertFalse(service.isCachedDrawableValid(
+            key,
+            value,
+            request.newBuilder().precision(Precision.EXACT).build(),
+            PixelSize(800, 500),
+            Scale.FIT
+        ))
+    }
+
     private fun MemoryCacheService.isCachedDrawableValid(
-        cached: BitmapDrawable,
+        cached: Bitmap,
         isSampled: Boolean,
         request: Request,
         size: Size,
         scale: Scale
     ): Boolean {
-        val key = MemoryCache.Key("key")
-        val value = object : MemoryCache.Value {
-            override val bitmap = cached.bitmap
+        val key = Key("key")
+        val value = object : Value {
+            override val bitmap = cached
             override val isSampled = isSampled
         }
-        return isCachedDrawableValid(key, value, request, SizeResolver(size), size, scale)
+        return isCachedDrawableValid(key, value, request, size, scale)
     }
+
+    /** Convenience function to avoid having to specify the [SizeResolver] explicitly. */
+    private fun MemoryCacheService.isCachedDrawableValid(
+        cacheKey: Key?,
+        cacheValue: Value,
+        request: Request,
+        size: Size,
+        scale: Scale
+    ): Boolean = isCachedDrawableValid(cacheKey, cacheValue, request, SizeResolver(size), size, scale)
 }

--- a/coil-base/src/test/java/coil/memory/MemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheTest.kt
@@ -1,6 +1,7 @@
 package coil.memory
 
 import coil.bitmappool.BitmapPool
+import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.createBitmap
 import org.junit.Test
@@ -21,9 +22,9 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE).toInt(), null)
 
         val bitmap = createBitmap()
-        cache.set("1", bitmap, false)
+        cache.set(Key("1"), bitmap, false)
 
-        assertEquals(bitmap, cache.get("1")?.bitmap)
+        assertEquals(bitmap, cache.get(Key("1"))?.bitmap)
     }
 
     @Test
@@ -34,15 +35,15 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE).toInt(), null)
 
         val first = createBitmap()
-        cache.set("1", first, false)
+        cache.set(Key("1"), first, false)
 
         val second = createBitmap()
-        cache.set("2", second, false)
+        cache.set(Key("2"), second, false)
 
         val third = createBitmap()
-        cache.set("3", third, false)
+        cache.set(Key("3"), third, false)
 
-        assertNull(cache.get("1"))
+        assertNull(cache.get(Key("1")))
     }
 
     @Test
@@ -53,9 +54,9 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, 0, null)
 
         val bitmap = createBitmap()
-        cache.set("1", bitmap, false)
+        cache.set(Key("1"), bitmap, false)
 
-        assertNull(cache.get("1"))
+        assertNull(cache.get(Key("1")))
     }
 
     @Test
@@ -66,10 +67,10 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE).toInt(), null)
 
         val bitmap = createBitmap()
-        cache.set("1", bitmap, false)
-        cache.invalidate("1")
+        cache.set(Key("1"), bitmap, false)
+        cache.invalidate(Key("1"))
 
-        assertNull(cache.get("1"))
+        assertNull(cache.get(Key("1")))
     }
 
     @Test
@@ -80,15 +81,15 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE.toInt(), null)
 
         val first = createBitmap()
-        cache.set("1", first, false)
+        cache.set(Key("1"), first, false)
 
-        assertNotNull(cache.get("1"))
+        assertNotNull(cache.get(Key("1")))
 
         val second = createBitmap()
-        cache.set("2", second, false)
+        cache.set(Key("2"), second, false)
 
-        assertNull(cache.get("1"))
-        assertNull(weakMemoryCache.get("1"))
+        assertNull(cache.get(Key("1")))
+        assertNull(weakMemoryCache.get(Key("1")))
         assertEquals(first, pool.getDirtyOrNull(first.width, first.height, first.config))
     }
 
@@ -100,19 +101,19 @@ class MemoryCacheTest {
         val cache = MemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE.toInt(), null)
 
         val first = createBitmap()
-        cache.set("key", first, false)
+        cache.set(Key("key"), first, false)
 
-        assertNotNull(cache.get("key"))
+        assertNotNull(cache.get(Key("key")))
 
         // Invalidate the first bitmap.
         counter.invalidate(first)
 
         // Overwrite the value in the memory cache.
         val second = createBitmap()
-        cache.set("key", second, false)
+        cache.set(Key("key"), second, false)
 
-        assertEquals(second, cache.get("key")?.bitmap)
-        assertEquals(first, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(second, cache.get(Key("key"))?.bitmap)
+        assertEquals(first, weakMemoryCache.get(Key("key"))?.bitmap)
         assertNull(pool.getDirtyOrNull(first.width, first.height, first.config))
     }
 }

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -3,6 +3,7 @@ package coil.memory
 import android.content.Context
 import androidx.collection.arraySetOf
 import androidx.test.core.app.ApplicationProvider
+import coil.memory.MemoryCache.Key
 import coil.util.clear
 import coil.util.count
 import coil.util.createBitmap
@@ -33,7 +34,7 @@ class WeakMemoryCacheTest {
 
     @Test
     fun `can retrieve cached value`() {
-        val key = "key"
+        val key = Key("key")
         val bitmap = reference(createBitmap())
         val isSampled = false
         val size = bitmap.getAllocationByteCountCompat()
@@ -49,28 +50,28 @@ class WeakMemoryCacheTest {
     @Test
     fun `can hold multiple values`() {
         val bitmap1 = reference(createBitmap())
-        weakMemoryCache.set("key1", bitmap1, false, 100)
+        weakMemoryCache.set(Key("key1"), bitmap1, false, 100)
 
         val bitmap2 = reference(createBitmap())
-        weakMemoryCache.set("key2", bitmap2, false, 100)
+        weakMemoryCache.set(Key("key2"), bitmap2, false, 100)
 
         val bitmap3 = reference(createBitmap())
-        weakMemoryCache.set("key3", bitmap3, false, 100)
+        weakMemoryCache.set(Key("key3"), bitmap3, false, 100)
 
-        assertEquals(bitmap1, weakMemoryCache.get("key1")?.bitmap)
-        assertEquals(bitmap2, weakMemoryCache.get("key2")?.bitmap)
-        assertEquals(bitmap3, weakMemoryCache.get("key3")?.bitmap)
+        assertEquals(bitmap1, weakMemoryCache.get(Key("key1"))?.bitmap)
+        assertEquals(bitmap2, weakMemoryCache.get(Key("key2"))?.bitmap)
+        assertEquals(bitmap3, weakMemoryCache.get(Key("key3"))?.bitmap)
 
         weakMemoryCache.clear(bitmap2)
 
-        assertEquals(bitmap1, weakMemoryCache.get("key1")?.bitmap)
-        assertNull(weakMemoryCache.get("key2"))
-        assertEquals(bitmap3, weakMemoryCache.get("key3")?.bitmap)
+        assertEquals(bitmap1, weakMemoryCache.get(Key("key1"))?.bitmap)
+        assertNull(weakMemoryCache.get(Key("key2")))
+        assertEquals(bitmap3, weakMemoryCache.get(Key("key3"))?.bitmap)
     }
 
     @Test
     fun `invalidate removes from cache`() {
-        val key = "key"
+        val key = Key("key")
         val bitmap = reference(createBitmap())
 
         weakMemoryCache.set(key, bitmap, false, 100)
@@ -90,59 +91,59 @@ class WeakMemoryCacheTest {
         val bitmap7 = reference(createBitmap())
         val bitmap8 = reference(createBitmap())
 
-        weakMemoryCache.set("key", bitmap1, false, 1)
-        weakMemoryCache.set("key", bitmap3, false, 3)
-        weakMemoryCache.set("key", bitmap5, false, 5)
-        weakMemoryCache.set("key", bitmap7, false, 7)
-        weakMemoryCache.set("key", bitmap8, false, 8)
-        weakMemoryCache.set("key", bitmap4, false, 4)
-        weakMemoryCache.set("key", bitmap6, false, 6)
-        weakMemoryCache.set("key", bitmap2, false, 2)
+        weakMemoryCache.set(Key("key"), bitmap1, false, 1)
+        weakMemoryCache.set(Key("key"), bitmap3, false, 3)
+        weakMemoryCache.set(Key("key"), bitmap5, false, 5)
+        weakMemoryCache.set(Key("key"), bitmap7, false, 7)
+        weakMemoryCache.set(Key("key"), bitmap8, false, 8)
+        weakMemoryCache.set(Key("key"), bitmap4, false, 4)
+        weakMemoryCache.set(Key("key"), bitmap6, false, 6)
+        weakMemoryCache.set(Key("key"), bitmap2, false, 2)
 
-        assertEquals(bitmap8, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap8, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap8)
 
-        assertEquals(bitmap7, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap7, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap7)
 
-        assertEquals(bitmap6, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap6, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap6)
 
-        assertEquals(bitmap5, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap5, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap5)
 
-        assertEquals(bitmap4, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap4, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap4)
 
-        assertEquals(bitmap3, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap3, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap3)
 
-        assertEquals(bitmap2, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap2, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap2)
 
-        assertEquals(bitmap1, weakMemoryCache.get("key")?.bitmap)
+        assertEquals(bitmap1, weakMemoryCache.get(Key("key"))?.bitmap)
         weakMemoryCache.invalidate(bitmap1)
 
         // All the values are invalidated.
-        assertNull(weakMemoryCache.get("key"))
+        assertNull(weakMemoryCache.get(Key("key")))
     }
 
     @Test
     fun `cleanUp clears all collected values`() {
         val bitmap1 = reference(createBitmap())
-        weakMemoryCache.set("key1", bitmap1, false, 100)
+        weakMemoryCache.set(Key("key1"), bitmap1, false, 100)
 
         val bitmap2 = reference(createBitmap())
-        weakMemoryCache.set("key2", bitmap2, false, 100)
+        weakMemoryCache.set(Key("key2"), bitmap2, false, 100)
 
         val bitmap3 = reference(createBitmap())
-        weakMemoryCache.set("key3", bitmap3, false, 100)
+        weakMemoryCache.set(Key("key3"), bitmap3, false, 100)
 
         weakMemoryCache.clear(bitmap1)
-        assertNull(weakMemoryCache.get("key1"))
+        assertNull(weakMemoryCache.get(Key("key1")))
 
         weakMemoryCache.clear(bitmap3)
-        assertNull(weakMemoryCache.get("key3"))
+        assertNull(weakMemoryCache.get(Key("key3")))
 
         assertEquals(3, weakMemoryCache.count())
 
@@ -150,18 +151,19 @@ class WeakMemoryCacheTest {
 
         assertEquals(1, weakMemoryCache.count())
 
-        assertNull(weakMemoryCache.get("key1"))
-        assertEquals(bitmap2, weakMemoryCache.get("key2")?.bitmap)
-        assertNull(weakMemoryCache.get("key3"))
+        assertNull(weakMemoryCache.get(Key("key1")))
+        assertEquals(bitmap2, weakMemoryCache.get(Key("key2"))?.bitmap)
+        assertNull(weakMemoryCache.get(Key("key3")))
     }
 
     @Test
     fun `value is removed after invalidate is called`() {
+        val key = Key("1")
         val bitmap = createBitmap()
-        weakMemoryCache.set("1", bitmap, false, bitmap.getAllocationByteCountCompat())
-        weakMemoryCache.invalidate("1")
+        weakMemoryCache.set(key, bitmap, false, bitmap.getAllocationByteCountCompat())
+        weakMemoryCache.invalidate(key)
 
-        assertNull(weakMemoryCache.get("1"))
+        assertNull(weakMemoryCache.get(key))
     }
 
     /** Hold a strong reference to the value for the duration of the test to prevent it from being garbage collected. */


### PR DESCRIPTION
This fixes a bug where a request could miss the memory cache if it uses a transformation that decreases the output bitmap's height (e.g. `CircleCropTransformation`). It's reproducible on master if you add a `CircleCropTransformation` in `ImageListAdapter`.

This requires a broader refactor to convert the memory cache's key from `String` to a custom object so we can hold onto the request's resolved size. Overall, I've been planning to move away from using a String cache key for a while as it has gotchas (like `Parameters` having to always order its entries the same way irrespective of insertion order).

Added regression tests to guard against this going forward.