### PR TITLE
Reduce the default memory cache size to 20%.

### DIFF
--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -19,7 +19,7 @@ internal object Utils {
 
     private const val DISK_CACHE_PERCENTAGE = 0.02
 
-    private const val STANDARD_MULTIPLIER = 0.25
+    private const val STANDARD_MULTIPLIER = 0.2
     private const val LOW_MEMORY_MULTIPLIER = 0.15
 
     /** Return the in memory size of a [Bitmap] with the given width, height, and [Bitmap.Config]. */


### PR DESCRIPTION
25% of an app's memory works well for image-heavy applications, however it's slightly high for a default - especially since Coil doesn't require a singleton like other libraries. For reference these are the percentages used by other libraries to compute their memory cache sizes:

- Glide: Depends on display size, only ~12% on my Pixel 1 but can be higher
- Picasso: 15%
- Fresco: 25%