### PR TITLE
Interrupt thread while decoding if coroutine is cancelled.

### DIFF
--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -175,7 +175,9 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
             safeSource.exception?.let { throw it }
         } catch (throwable: Throwable) {
             inBitmap?.let(pool::put)
-            outBitmap?.let(pool::put)
+            if (outBitmap !== inBitmap) {
+                outBitmap?.let(pool::put)
+            }
             throw throwable
         }
 

--- a/coil-gif/src/main/java/coil/decode/GifDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/GifDecoder.kt
@@ -9,6 +9,7 @@ import coil.bitmappool.BitmapPool
 import coil.drawable.MovieDrawable
 import coil.extension.repeatCount
 import coil.size.Size
+import kotlinx.coroutines.runInterruptible
 import okio.BufferedSource
 
 /**
@@ -31,7 +32,7 @@ class GifDecoder : Decoder {
         source: BufferedSource,
         size: Size,
         options: Options
-    ): DecodeResult {
+    ): DecodeResult = runInterruptible {
         // Movie requires an InputStream to resettable on API 18 and below.
         // Read the data as a ByteArray to work around this.
         val movie = if (SDK_INT <= 18) {
@@ -58,7 +59,7 @@ class GifDecoder : Decoder {
 
         drawable.setRepeatCount(options.parameters.repeatCount() ?: MovieDrawable.REPEAT_INFINITE)
 
-        return DecodeResult(
+        DecodeResult(
             drawable = drawable,
             isSampled = false
         )

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -15,6 +15,7 @@ import coil.drawable.ScaleDrawable
 import coil.extension.repeatCount
 import coil.size.PixelSize
 import coil.size.Size
+import kotlinx.coroutines.runInterruptible
 import okio.BufferedSource
 import okio.sink
 import java.io.File
@@ -44,7 +45,7 @@ class ImageDecoderDecoder : Decoder {
         source: BufferedSource,
         size: Size,
         options: Options
-    ): DecodeResult {
+    ): DecodeResult = runInterruptible {
         var tempFile: File? = null
 
         try {
@@ -110,7 +111,7 @@ class ImageDecoderDecoder : Decoder {
                 baseDrawable
             }
 
-            return DecodeResult(
+            DecodeResult(
                 drawable = drawable,
                 isSampled = isSampled
             )

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -12,6 +12,7 @@ import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size
 import com.caverock.androidsvg.SVG
+import kotlinx.coroutines.runInterruptible
 import okio.BufferedSource
 
 /**
@@ -31,7 +32,7 @@ class SvgDecoder(private val context: Context) : Decoder {
         source: BufferedSource,
         size: Size,
         options: Options
-    ): DecodeResult {
+    ): DecodeResult = runInterruptible {
         val svg = source.use { SVG.getFromInputStream(it.inputStream()) }
 
         val svgWidth = svg.documentWidth
@@ -82,7 +83,7 @@ class SvgDecoder(private val context: Context) : Decoder {
         val bitmap = pool.get(bitmapWidth, bitmapHeight, config)
         svg.renderToCanvas(Canvas(bitmap))
 
-        return DecodeResult(
+        DecodeResult(
             drawable = bitmap.toDrawable(context.resources),
             isSampled = true // SVGs can always be re-decoded at a higher resolution.
         )

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -93,6 +93,8 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
         size: Size,
         options: Options
     ): FetchResult {
+        // NOTE: we don't use 'runInterruptible' as MediaMetadataRetriever will
+        // continue its work even if its thread is interrupted.
         val retriever = MediaMetadataRetriever()
 
         try {


### PR DESCRIPTION
This allows for much faster cancellation as we can cancel in-flight decode operations.

Fixes #378