### PR TITLE
Allow suspending through multiple predraw passes.

### DIFF
--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -45,14 +45,9 @@ interface ViewSizeResolver<T : View> : SizeResolver {
             val viewTreeObserver = view.viewTreeObserver
 
             val preDrawListener = object : ViewTreeObserver.OnPreDrawListener {
-                private var isResumed = false
-
                 override fun onPreDraw(): Boolean {
-                    if (isResumed) return true
-
                     val size = getSize(false)
                     if (size != null) {
-                        isResumed = true
                         viewTreeObserver.removePreDrawListenerSafe(this)
                         continuation.resume(size)
                     }

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -3,7 +3,6 @@ package coil.size
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
-import coil.util.takeIf
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
@@ -70,9 +69,9 @@ interface ViewSizeResolver<T : View> : SizeResolver {
     }
 
     private fun getSize(isLayoutRequested: Boolean): PixelSize? {
-        val width = getWidth(isLayoutRequested)
-        val height = getHeight(isLayoutRequested)
-        return takeIf(width > 0 && height > 0) { PixelSize(width, height) }
+        val width = getWidth(isLayoutRequested).also { if (it <= 0) return null }
+        val height = getHeight(isLayoutRequested).also { if (it <= 0) return null }
+        return PixelSize(width, height)
     }
 
     private fun getWidth(isLayoutRequested: Boolean): Int {

--- a/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
+++ b/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class ViewSizeResolverTest {
@@ -68,6 +69,12 @@ class ViewSizeResolverTest {
         val deferred = scope.async(Dispatchers.Main.immediate) {
             resolver.size()
         }
+
+        // Predraw passes should be ignored until the view is measured.
+        view.viewTreeObserver.dispatchOnPreDraw()
+        assertTrue(deferred.isActive)
+        view.viewTreeObserver.dispatchOnPreDraw()
+        assertTrue(deferred.isActive)
 
         view.setPadding(20)
         view.layoutParams = ViewGroup.LayoutParams(160, 160)


### PR DESCRIPTION
Previously, we waited for at most one `onPreDraw` pass for the view to be measured. Now we wait for any number until the view is measured.

Fixes: #387