### PR TITLE
Fix possible cache miss in RealBitmapPool.

### DIFF
--- a/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
@@ -92,7 +92,7 @@ internal class SizeStrategy : BitmapPoolStrategy {
         return "[${Utils.calculateAllocationByteCount(width, height, config)}]"
     }
 
-    override fun toString() = "SizeStrategy: $entries"
+    override fun toString() = "SizeStrategy: entries=$entries, sizes=$sizes"
 
     companion object {
         private const val MAX_SIZE_MULTIPLE = 8
@@ -119,7 +119,7 @@ internal class AttributeStrategy : BitmapPoolStrategy {
 
     override fun stringify(width: Int, height: Int, config: Bitmap.Config) = "[$width x $height], $config"
 
-    override fun toString() = "AttributeStrategy: $entries"
+    override fun toString() = "AttributeStrategy: entries=$entries"
 
     private data class Key(
         @Px val width: Int,

--- a/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import coil.collection.LinkedMultimap
 import coil.util.Utils
 import coil.util.allocationByteCountCompat
+import java.util.TreeMap
 
 /** The [Bitmap] reuse algorithm used by [RealBitmapPool]. */
 internal interface BitmapPoolStrategy {
@@ -42,23 +43,49 @@ internal interface BitmapPoolStrategy {
 @RequiresApi(19)
 internal class SizeStrategy : BitmapPoolStrategy {
 
-    private val entries = LinkedMultimap<Int, Bitmap>(sorted = true)
+    private val entries = LinkedMultimap<Int, Bitmap>()
+    private val sizes = TreeMap<Int, Int>()
 
     override fun put(bitmap: Bitmap) {
-        entries.add(bitmap.allocationByteCountCompat, bitmap)
+        val size = bitmap.allocationByteCountCompat
+        entries.put(size, bitmap)
+
+        val count = sizes[size]
+        sizes[size] = if (count == null) 1 else count + 1
     }
 
     override fun get(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {
         val size = Utils.calculateAllocationByteCount(width, height, config)
 
-        // Find the least key greater than size.
-        val bestSize = entries.ceilingKey(size)?.takeIf { it <= MAX_SIZE_MULTIPLE * size } ?: size
+        // Find the least key greater than or equal to size.
+        val bestSize = sizes.ceilingKey(size)?.takeIf { it <= MAX_SIZE_MULTIPLE * size } ?: size
 
         // Always call removeLast so bestSize becomes the head of the linked list.
-        return entries.removeLast(bestSize)?.apply { reconfigure(width, height, config) }
+        val bitmap = entries.removeLast(bestSize)
+        if (bitmap != null) {
+            // Decrement must be called before reconfigure.
+            decrementSize(bestSize)
+            bitmap.reconfigure(width, height, config)
+        }
+        return bitmap
     }
 
-    override fun removeLast() = entries.removeLast()
+    override fun removeLast(): Bitmap? {
+        val bitmap = entries.removeLast()
+        if (bitmap != null) {
+            decrementSize(bitmap.allocationByteCount)
+        }
+        return bitmap
+    }
+
+    private fun decrementSize(size: Int) {
+        val count = sizes.getValue(size)
+        if (count == 1) {
+            sizes -= size
+        } else {
+            sizes[size] = count - 1
+        }
+    }
 
     override fun stringify(bitmap: Bitmap) = "[${bitmap.allocationByteCountCompat}]"
 
@@ -80,7 +107,7 @@ internal class AttributeStrategy : BitmapPoolStrategy {
     private val entries = LinkedMultimap<Key, Bitmap>()
 
     override fun put(bitmap: Bitmap) {
-        entries.add(Key(bitmap.width, bitmap.height, bitmap.config), bitmap)
+        entries.put(Key(bitmap.width, bitmap.height, bitmap.config), bitmap)
     }
 
     override fun get(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {

--- a/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmappool/BitmapPoolStrategy.kt
@@ -63,7 +63,6 @@ internal class SizeStrategy : BitmapPoolStrategy {
         // Always call removeLast so bestSize becomes the head of the linked list.
         val bitmap = entries.removeLast(bestSize)
         if (bitmap != null) {
-            // Decrement must be called before reconfigure.
             decrementSize(bestSize)
             bitmap.reconfigure(width, height, config)
         }

--- a/coil-base/src/main/java/coil/collection/LinkedMultimap.kt
+++ b/coil-base/src/main/java/coil/collection/LinkedMultimap.kt
@@ -1,24 +1,20 @@
 package coil.collection
 
 import coil.util.removeLast
-import java.util.TreeMap
 
 /**
  * An access-ordered map that stores multiple values for each key.
  *
- * @param sorted If true, [LinkedMultimap] will use a [TreeMap] as its backing map.
- *  Calling [ceilingKey] will throw an exception if the map is not created with `sorted = true`.
- *
  * Adapted from [Glide](https://github.com/bumptech/glide)'s GroupedLinkedMap.
  * Glide's license information is available [here](https://github.com/bumptech/glide/blob/master/LICENSE).
  */
-internal class LinkedMultimap<K, V>(sorted: Boolean = false) {
+internal class LinkedMultimap<K, V> {
 
     private val head = LinkedEntry<K, V>(null)
-    private val entries: MutableMap<K, LinkedEntry<K, V>> = if (sorted) TreeMap() else HashMap()
+    private val entries = HashMap<K, LinkedEntry<K, V>>()
 
     /** Add [value] to [key]'s associate value list. */
-    fun add(key: K, value: V) {
+    fun put(key: K, value: V) {
         val entry = entries.getOrPut(key) {
             LinkedEntry<K, V>(key).apply(::makeTail)
         }
@@ -50,12 +46,6 @@ internal class LinkedMultimap<K, V>(sorted: Boolean = false) {
         }
 
         return null
-    }
-
-    /** Return the least key greater than [key]. If no such key exists, return null. */
-    fun ceilingKey(key: K): K? {
-        check(entries is TreeMap) { "LinkedMultimap is not sorted." }
-        return entries.ceilingKey(key)
     }
 
     override fun toString() = buildString {

--- a/coil-base/src/main/java/coil/collection/LinkedMultimap.kt
+++ b/coil-base/src/main/java/coil/collection/LinkedMultimap.kt
@@ -1,7 +1,5 @@
 package coil.collection
 
-import coil.util.removeLast
-
 /**
  * An access-ordered map that stores multiple values for each key.
  *
@@ -95,6 +93,7 @@ internal class LinkedMultimap<K, V> {
         entry.next.prev = entry.prev
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     private class LinkedEntry<K, V>(val key: K?) {
 
         private var values: MutableList<V>? = null
@@ -104,7 +103,7 @@ internal class LinkedMultimap<K, V> {
 
         val size: Int get() = values?.size ?: 0
 
-        fun removeLast(): V? = values?.removeLast()
+        fun removeLast(): V? = values?.removeLastOrNull()
 
         fun add(value: V) {
             (values ?: mutableListOf<V>().also { values = it }) += value

--- a/coil-base/src/main/java/coil/util/Collections.kt
+++ b/coil-base/src/main/java/coil/util/Collections.kt
@@ -86,10 +86,6 @@ internal inline fun <T> MutableList<T>.removeIfIndices(predicate: (T) -> Boolean
     }
 }
 
-internal inline fun <T> MutableList<T>.removeLast(): T? {
-    return if (isNotEmpty()) removeAt(lastIndex) else null
-}
-
 /**
  * Returns a list containing the **non null** results of applying the given
  * [transform] function to each entry in the original map.

--- a/coil-base/src/test/java/coil/bitmappool/SizeStrategyTest.kt
+++ b/coil-base/src/test/java/coil/bitmappool/SizeStrategyTest.kt
@@ -41,4 +41,14 @@ class SizeStrategyTest {
 
         assertEquals(bitmap, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
     }
+
+    @Test
+    fun `only puts are factored into ceilingKey`() {
+        strategy.put(createBitmap(100, 100, Bitmap.Config.ARGB_8888))
+        strategy.get(200, 100, Bitmap.Config.ARGB_8888)
+        val expected = createBitmap(300, 100, Bitmap.Config.ARGB_8888)
+        strategy.put(expected)
+
+        assertEquals(expected, strategy.get(200, 100, Bitmap.Config.ARGB_8888))
+    }
 }

--- a/coil-base/src/test/java/coil/collection/LinkedMultimapTest.kt
+++ b/coil-base/src/test/java/coil/collection/LinkedMultimapTest.kt
@@ -1,26 +1,20 @@
 package coil.collection
 
-import org.junit.Assume.assumeTrue
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-@RunWith(Parameterized::class)
-class LinkedMultimapTest(private val sorted: Boolean) {
-
-    companion object {
-        @JvmStatic @Parameters fun sorted() = listOf(true, false)
-    }
+@RunWith(AndroidJUnit4::class)
+class LinkedMultimapTest {
 
     private lateinit var map: LinkedMultimap<Key, Any>
 
     @Before
     fun before() {
-        map = LinkedMultimap(sorted)
+        map = LinkedMultimap()
     }
 
     @Test
@@ -34,7 +28,7 @@ class LinkedMultimapTest(private val sorted: Boolean) {
         val key = Key("key", 1, 1)
         val expected = Any()
 
-        map.add(key, expected)
+        map.put(key, expected)
 
         assertEquals(expected, map.removeLast(key))
     }
@@ -46,7 +40,7 @@ class LinkedMultimapTest(private val sorted: Boolean) {
         val numToAdd = 10
 
         for (i in 0 until numToAdd) {
-            map.add(key, value)
+            map.put(key, value)
         }
 
         for (i in 0 until numToAdd) {
@@ -58,12 +52,12 @@ class LinkedMultimapTest(private val sorted: Boolean) {
     fun `least recently retrieved key is least recently used`() {
         val firstKey = Key("key", 1, 1)
         val firstValue = 10
-        map.add(firstKey, firstValue)
-        map.add(firstKey, firstValue)
+        map.put(firstKey, firstValue)
+        map.put(firstKey, firstValue)
 
         val secondKey = Key("key", 2, 2)
         val secondValue = 20
-        map.add(secondKey, secondValue)
+        map.put(secondKey, secondValue)
 
         map.removeLast(firstKey)
 
@@ -75,32 +69,15 @@ class LinkedMultimapTest(private val sorted: Boolean) {
         val firstKey = Key("key", 1, 1)
         val firstValue = 10
 
-        map.add(firstKey, firstValue)
-        map.add(firstKey, firstValue)
+        map.put(firstKey, firstValue)
+        map.put(firstKey, firstValue)
 
         map.removeLast(firstKey)
 
         val secondValue = 20
-        map.add(Key("key", 2, 2), secondValue)
+        map.put(Key("key", 2, 2), secondValue)
 
         assertEquals(secondValue, map.removeLast())
-    }
-
-    @Test
-    fun `sorted map - ceilingKey returns least key greater than input key`() {
-        // ceilingKey throws an exception if the map is not sorted.
-        assumeTrue(sorted)
-
-        val map = LinkedMultimap<Int, Int>(sorted = true)
-        map.add(3, 2)
-        map.add(8, 4)
-        map.add(5, 9)
-        map.add(4, 9)
-        map.add(1, 1)
-
-        assertNull(map.ceilingKey(9))
-        assertEquals(5, map.ceilingKey(5))
-        assertEquals(3, map.ceilingKey(2))
     }
 
     private data class Key(


### PR DESCRIPTION
Reverts part of https://github.com/coil-kt/coil/pull/407. I thought I could fold the `TreeMap` into `LinkedMultimap`, but turns out it needs to be separate. Added a regression test case.