### PR TITLE
Add option to disable adding File.lastModified to the cache key.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -128,6 +128,7 @@ public final class coil/ImageLoader$Companion {
 
 public final class coil/ImageLoaderBuilder {
 	public fun <init> (Landroid/content/Context;)V
+	public final fun addLastModifiedToFileCacheKey (Z)Lcoil/ImageLoaderBuilder;
 	public final fun allowHardware (Z)Lcoil/ImageLoaderBuilder;
 	public final fun allowRgb565 (Z)Lcoil/ImageLoaderBuilder;
 	public final fun availableMemoryPercentage (D)Lcoil/ImageLoaderBuilder;

--- a/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
@@ -23,7 +23,7 @@ class FileFetcherTest {
     @Before
     fun before() {
         context = ApplicationProvider.getApplicationContext()
-        fetcher = FileFetcher()
+        fetcher = FileFetcher(true)
         pool = BitmapPool(0)
     }
 
@@ -54,5 +54,18 @@ class FileFetcherTest {
         val secondKey = fetcher.key(file)
 
         assertNotEquals(secondKey, firstKey)
+    }
+
+    @Test
+    fun fileCacheKeyWithoutLastModified() {
+        val file = context.copyAssetToFile("normal.jpg")
+
+        file.setLastModified(1234L)
+        val firstKey = fetcher.key(file)
+
+        file.setLastModified(4321L)
+        val secondKey = fetcher.key(file)
+
+        assertEquals(secondKey, firstKey)
     }
 }

--- a/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
@@ -17,18 +17,17 @@ import kotlin.test.assertTrue
 class FileFetcherTest {
 
     private lateinit var context: Context
-    private lateinit var fetcher: FileFetcher
     private lateinit var pool: BitmapPool
 
     @Before
     fun before() {
         context = ApplicationProvider.getApplicationContext()
-        fetcher = FileFetcher(true)
         pool = BitmapPool(0)
     }
 
     @Test
     fun basic() {
+        val fetcher = FileFetcher(true)
         val file = context.copyAssetToFile("normal.jpg")
 
         assertTrue(fetcher.handles(file))
@@ -45,6 +44,7 @@ class FileFetcherTest {
 
     @Test
     fun fileCacheKeyWithLastModified() {
+        val fetcher = FileFetcher(true)
         val file = context.copyAssetToFile("normal.jpg")
 
         file.setLastModified(1234L)
@@ -58,6 +58,7 @@ class FileFetcherTest {
 
     @Test
     fun fileCacheKeyWithoutLastModified() {
+        val fetcher = FileFetcher(false)
         val file = context.copyAssetToFile("normal.jpg")
 
         file.setLastModified(1234L)

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -67,6 +67,7 @@ class SystemCallbacksTest {
             OkHttpClient(),
             EventListener.Factory.NONE,
             ComponentRegistry(),
+            true,
             null
         )
         val systemCallbacks = SystemCallbacks(imageLoader, context)

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -58,17 +58,17 @@ class SystemCallbacksTest {
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
         val memoryCache = MemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         val imageLoader = RealImageLoader(
-            context,
-            DefaultRequestOptions(),
-            bitmapPool,
-            referenceCounter,
-            memoryCache,
-            weakMemoryCache,
-            OkHttpClient(),
-            EventListener.Factory.NONE,
-            ComponentRegistry(),
-            true,
-            null
+            context = context,
+            defaults = DefaultRequestOptions(),
+            bitmapPool = bitmapPool,
+            referenceCounter = referenceCounter,
+            memoryCache = memoryCache,
+            weakMemoryCache = weakMemoryCache,
+            callFactory = OkHttpClient(),
+            eventListenerFactory = EventListener.Factory.NONE,
+            registry = ComponentRegistry(),
+            addLastModifiedToFileCacheKey = true,
+            logger = null
         )
         val systemCallbacks = SystemCallbacks(imageLoader, context)
 

--- a/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
+++ b/coil-base/src/main/java/coil/ImageLoaderBuilder.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import okhttp3.Call
 import okhttp3.OkHttpClient
+import java.io.File
 
 /** Builder for an [ImageLoader]. */
 @BuilderMarker
@@ -46,6 +47,7 @@ class ImageLoaderBuilder(context: Context) {
     private var availableMemoryPercentage = Utils.getDefaultAvailableMemoryPercentage(applicationContext)
     private var bitmapPoolPercentage = Utils.getDefaultBitmapPoolPercentage()
     private var trackWeakReferences = true
+    private var addLastModifiedToFileCacheKey = true
 
     /**
      * Set the [OkHttpClient] used for network requests.
@@ -183,6 +185,18 @@ class ImageLoaderBuilder(context: Context) {
      */
     fun trackWeakReferences(enable: Boolean) = apply {
         this.trackWeakReferences = enable
+    }
+
+    /**
+     * Enables adding [File.lastModified] to the memory cache key when loading an image from a [File].
+     *
+     * This allows subsequent requests that load the same file to miss the memory cache if the file has been updated.
+     * To ensure a cached image is returned synchronously, [File.lastModified] is called on the main thread.
+     *
+     * Default: true
+     */
+    fun addLastModifiedToFileCacheKey(enable: Boolean) = apply {
+        this.addLastModifiedToFileCacheKey = enable
     }
 
     /**
@@ -342,6 +356,7 @@ class ImageLoaderBuilder(context: Context) {
             callFactory = callFactory ?: buildDefaultCallFactory(),
             eventListenerFactory = eventListenerFactory ?: EventListener.Factory.NONE,
             registry = registry ?: ComponentRegistry(),
+            addLastModifiedToFileCacheKey = addLastModifiedToFileCacheKey,
             logger = logger
         )
     }

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -95,6 +95,7 @@ internal class RealImageLoader(
     callFactory: Call.Factory,
     private val eventListenerFactory: EventListener.Factory,
     registry: ComponentRegistry,
+    addLastModifiedToFileCacheKey: Boolean,
     internal val logger: Logger?
 ) : ImageLoader {
 
@@ -120,7 +121,7 @@ internal class RealImageLoader(
         // Fetchers
         .add(HttpUriFetcher(callFactory))
         .add(HttpUrlFetcher(callFactory))
-        .add(FileFetcher())
+        .add(FileFetcher(addLastModifiedToFileCacheKey))
         .add(AssetUriFetcher(context))
         .add(ContentUriFetcher(context))
         .add(ResourceUriFetcher(context, drawableDecoder))

--- a/coil-base/src/main/java/coil/fetch/FileFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/FileFetcher.kt
@@ -9,9 +9,15 @@ import okio.buffer
 import okio.source
 import java.io.File
 
-internal class FileFetcher : Fetcher<File> {
+internal class FileFetcher(private val addLastModifiedToFileCacheKey: Boolean) : Fetcher<File> {
 
-    override fun key(data: File) = "${data.path}:${data.lastModified()}"
+    override fun key(data: File): String {
+        return if (addLastModifiedToFileCacheKey) {
+            "${data.path}:${data.lastModified()}"
+        } else {
+            data.path
+        }
+    }
 
     override suspend fun fetch(
         pool: BitmapPool,

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -75,6 +75,7 @@ class RealImageLoaderBasicTest {
             OkHttpClient(),
             EventListener.Factory.NONE,
             ComponentRegistry(),
+            true,
             null
         )
     }

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -66,17 +66,17 @@ class RealImageLoaderBasicTest {
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
         memoryCache = MemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         imageLoader = RealImageLoader(
-            context,
-            DefaultRequestOptions(),
-            bitmapPool,
-            referenceCounter,
-            memoryCache,
-            weakMemoryCache,
-            OkHttpClient(),
-            EventListener.Factory.NONE,
-            ComponentRegistry(),
-            true,
-            null
+            context = context,
+            defaults = DefaultRequestOptions(),
+            bitmapPool = bitmapPool,
+            referenceCounter = referenceCounter,
+            memoryCache = memoryCache,
+            weakMemoryCache = weakMemoryCache,
+            callFactory = OkHttpClient(),
+            eventListenerFactory = EventListener.Factory.NONE,
+            registry = ComponentRegistry(),
+            addLastModifiedToFileCacheKey = true,
+            logger = null
         )
     }
 


### PR DESCRIPTION
Fixes #383 by adding an option to disable the `lastModified` check.