### PR TITLE
Expose FetchResult and DecodeResult in the EventListener API.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -56,9 +56,9 @@ public final class coil/DefaultRequestOptions {
 public abstract interface class coil/EventListener : coil/request/Request$Listener {
 	public static final field Companion Lcoil/EventListener$Companion;
 	public static final field NONE Lcoil/EventListener;
-	public abstract fun decodeEnd (Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
+	public abstract fun decodeEnd (Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;Lcoil/decode/DecodeResult;)V
 	public abstract fun decodeStart (Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
-	public abstract fun fetchEnd (Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;)V
+	public abstract fun fetchEnd (Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;Lcoil/fetch/FetchResult;)V
 	public abstract fun fetchStart (Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;)V
 	public abstract fun mapEnd (Lcoil/request/Request;Ljava/lang/Object;)V
 	public abstract fun mapStart (Lcoil/request/Request;Ljava/lang/Object;)V
@@ -67,10 +67,10 @@ public abstract interface class coil/EventListener : coil/request/Request$Listen
 	public abstract fun onError (Lcoil/request/Request;Ljava/lang/Throwable;)V
 	public abstract fun onStart (Lcoil/request/Request;)V
 	public abstract fun onSuccess (Lcoil/request/Request;Lcoil/decode/DataSource;)V
-	public abstract fun resolveSizeEnd (Lcoil/request/Request;Lcoil/size/Size;)V
-	public abstract fun resolveSizeStart (Lcoil/request/Request;)V
-	public abstract fun transformEnd (Lcoil/request/Request;)V
-	public abstract fun transformStart (Lcoil/request/Request;)V
+	public abstract fun resolveSizeEnd (Lcoil/request/Request;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
+	public abstract fun resolveSizeStart (Lcoil/request/Request;Lcoil/size/SizeResolver;)V
+	public abstract fun transformEnd (Lcoil/request/Request;Landroid/graphics/Bitmap;)V
+	public abstract fun transformStart (Lcoil/request/Request;Landroid/graphics/Bitmap;)V
 	public abstract fun transitionEnd (Lcoil/request/Request;Lcoil/transition/Transition;)V
 	public abstract fun transitionStart (Lcoil/request/Request;Lcoil/transition/Transition;)V
 }
@@ -79,9 +79,9 @@ public final class coil/EventListener$Companion {
 }
 
 public final class coil/EventListener$DefaultImpls {
-	public static fun decodeEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
+	public static fun decodeEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;Lcoil/decode/DecodeResult;)V
 	public static fun decodeStart (Lcoil/EventListener;Lcoil/request/Request;Lcoil/decode/Decoder;Lcoil/decode/Options;)V
-	public static fun fetchEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;)V
+	public static fun fetchEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;Lcoil/fetch/FetchResult;)V
 	public static fun fetchStart (Lcoil/EventListener;Lcoil/request/Request;Lcoil/fetch/Fetcher;Lcoil/decode/Options;)V
 	public static fun mapEnd (Lcoil/EventListener;Lcoil/request/Request;Ljava/lang/Object;)V
 	public static fun mapStart (Lcoil/EventListener;Lcoil/request/Request;Ljava/lang/Object;)V
@@ -90,10 +90,10 @@ public final class coil/EventListener$DefaultImpls {
 	public static fun onError (Lcoil/EventListener;Lcoil/request/Request;Ljava/lang/Throwable;)V
 	public static fun onStart (Lcoil/EventListener;Lcoil/request/Request;)V
 	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/Request;Lcoil/decode/DataSource;)V
-	public static fun resolveSizeEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/size/Size;)V
-	public static fun resolveSizeStart (Lcoil/EventListener;Lcoil/request/Request;)V
-	public static fun transformEnd (Lcoil/EventListener;Lcoil/request/Request;)V
-	public static fun transformStart (Lcoil/EventListener;Lcoil/request/Request;)V
+	public static fun resolveSizeEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
+	public static fun resolveSizeStart (Lcoil/EventListener;Lcoil/request/Request;Lcoil/size/SizeResolver;)V
+	public static fun transformEnd (Lcoil/EventListener;Lcoil/request/Request;Landroid/graphics/Bitmap;)V
+	public static fun transformStart (Lcoil/EventListener;Lcoil/request/Request;Landroid/graphics/Bitmap;)V
 	public static fun transitionEnd (Lcoil/EventListener;Lcoil/request/Request;Lcoil/transition/Transition;)V
 	public static fun transitionStart (Lcoil/EventListener;Lcoil/request/Request;Lcoil/transition/Transition;)V
 }

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -2,18 +2,22 @@ package coil
 
 import android.content.ContentResolver.SCHEME_ANDROID_RESOURCE
 import android.content.Context
+import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
 import coil.base.test.R
 import coil.decode.DataSource
+import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
+import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.LoadRequest
 import coil.request.LoadRequestBuilder
 import coil.request.Request
 import coil.size.Size
+import coil.size.SizeResolver
 import coil.transform.CircleCropTransformation
 import coil.transition.Transition
 import kotlinx.coroutines.CancellationException
@@ -195,17 +199,17 @@ class EventListenerTest {
     ) : EventListener {
 
         override fun onDispatch(request: Request) = onDispatch.call()
-        override fun mapStart(request: Request, data: Any) = mapStart.call()
-        override fun mapEnd(request: Request, mappedData: Any) = mapEnd.call()
+        override fun mapStart(request: Request, input: Any) = mapStart.call()
+        override fun mapEnd(request: Request, output: Any) = mapEnd.call()
         override fun onStart(request: Request) = onStart.call()
-        override fun resolveSizeStart(request: Request) = resolveSizeStart.call()
-        override fun resolveSizeEnd(request: Request, size: Size) = resolveSizeEnd.call()
+        override fun resolveSizeStart(request: Request, sizeResolver: SizeResolver) = resolveSizeStart.call()
+        override fun resolveSizeEnd(request: Request, sizeResolver: SizeResolver, size: Size) = resolveSizeEnd.call()
         override fun fetchStart(request: Request, fetcher: Fetcher<*>, options: Options) = fetchStart.call()
-        override fun fetchEnd(request: Request, fetcher: Fetcher<*>, options: Options) = fetchEnd.call()
+        override fun fetchEnd(request: Request, fetcher: Fetcher<*>, options: Options, result: FetchResult) = fetchEnd.call()
         override fun decodeStart(request: Request, decoder: Decoder, options: Options) = decodeStart.call()
-        override fun decodeEnd(request: Request, decoder: Decoder, options: Options) = decodeEnd.call()
-        override fun transformStart(request: Request) = transformStart.call()
-        override fun transformEnd(request: Request) = transformEnd.call()
+        override fun decodeEnd(request: Request, decoder: Decoder, options: Options, result: DecodeResult) = decodeEnd.call()
+        override fun transformStart(request: Request, input: Bitmap) = transformStart.call()
+        override fun transformEnd(request: Request, output: Bitmap) = transformEnd.call()
         override fun transitionStart(request: Request, transition: Transition) = transitionStart.call()
         override fun transitionEnd(request: Request, transition: Transition) = transitionEnd.call()
         override fun onSuccess(request: Request, source: DataSource) = onSuccess.call()

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -1,11 +1,14 @@
 package coil
 
+import android.graphics.Bitmap
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
+import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
+import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.fetch.SourceResult
 import coil.map.Mapper
@@ -18,8 +21,8 @@ import coil.transition.Transition
 import coil.transition.TransitionTarget
 
 /**
- * An [ImageLoader]-scoped listener for tracking the progress of an image request.
- * This class is useful for measuring analytics, performance, or other metrics tracking.
+ * A listener for tracking the progress of an image request. This class is useful for
+ * measuring analytics, performance, or other metrics tracking.
  *
  * @see ImageLoader.Builder.eventListener
  */
@@ -35,19 +38,19 @@ interface EventListener : Request.Listener {
     /**
      * Called before any [Mapper]s and/or [MeasuredMapper]s are called to convert the request's data.
      *
-     * @param data The data that will be converted.
+     * @param input The data that will be converted.
      */
     @MainThread
-    fun mapStart(request: Request, data: Any) {}
+    fun mapStart(request: Request, input: Any) {}
 
     /**
      * Called after the request's data has been converted by all applicable [Mapper]s and/or [MeasuredMapper]s.
      *
-     * @param mappedData The data after it has been converted.
-     *  If there were no applicable mappers, [mappedData] will be the same as [Request.data].
+     * @param output The data after it has been converted. If there were no applicable mappers,
+     *  [output] will be the same as [Request.data].
      */
     @MainThread
-    fun mapEnd(request: Request, mappedData: Any) {}
+    fun mapEnd(request: Request, output: Any) {}
 
     /**
      * @see Request.Listener.onStart
@@ -57,17 +60,20 @@ interface EventListener : Request.Listener {
 
     /**
      * Called before [SizeResolver.size].
+     *
+     * @param sizeResolver The [SizeResolver] that will be used to determine the [Size] for the request.
      */
     @MainThread
-    fun resolveSizeStart(request: Request) {}
+    fun resolveSizeStart(request: Request, sizeResolver: SizeResolver) {}
 
     /**
      * Called after [SizeResolver.size].
      *
+     * @param sizeResolver The [SizeResolver] that was used to determine the [Size] for the request.
      * @param size The resolved [Size] for this request.
      */
     @MainThread
-    fun resolveSizeEnd(request: Request, size: Size) {}
+    fun resolveSizeEnd(request: Request, sizeResolver: SizeResolver, size: Size) {}
 
     /**
      * Called before [Fetcher.fetch].
@@ -83,9 +89,11 @@ interface EventListener : Request.Listener {
      *
      * @param fetcher The [Fetcher] that was used to handle the request.
      * @param options The [Options] that were passed to [Fetcher.fetch].
+     * @param result The result of [Fetcher.fetch]. **Do not** keep a reference to [result] or its data
+     *  outside the scope of this method.
      */
     @WorkerThread
-    fun fetchEnd(request: Request, fetcher: Fetcher<*>, options: Options) {}
+    fun fetchEnd(request: Request, fetcher: Fetcher<*>, options: Options, result: FetchResult) {}
 
     /**
      * Called before [Decoder.decode].
@@ -105,25 +113,33 @@ interface EventListener : Request.Listener {
      *
      * @param decoder The [Decoder] that was used to handle the request.
      * @param options The [Options] that were passed to [Decoder.decode].
+     * @param result The result of [Decoder.decode]. **Do not** keep a reference to [result] or its data
+     *  outside the scope of this method.
      */
     @WorkerThread
-    fun decodeEnd(request: Request, decoder: Decoder, options: Options) {}
+    fun decodeEnd(request: Request, decoder: Decoder, options: Options, result: DecodeResult) {}
 
     /**
      * Called before any [Transformation]s are applied.
      *
      * This is skipped if [Request.transformations] is empty.
+     *
+     * @param input The [Bitmap] that will be transformed. **Do not** keep a reference to [input] outside
+     * the scope of this method.
      */
     @WorkerThread
-    fun transformStart(request: Request) {}
+    fun transformStart(request: Request, input: Bitmap) {}
 
     /**
      * Called after any [Transformation]s are applied.
      *
      * This is skipped if [Request.transformations] is empty.
+     *
+     * @param output The [Bitmap] that was transformed. **Do not** keep a reference to [output] outside
+     * the scope of this method.
      */
     @WorkerThread
-    fun transformEnd(request: Request) {}
+    fun transformEnd(request: Request, output: Bitmap) {}
 
     /**
      * Called before [Transition.transition].


### PR DESCRIPTION
Also exposes the input/output bitmaps for the transformation step and the `SizeResolver` for the size resolution step.