### PR TITLE
Introduce public interface for the MemoryCache.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -558,8 +558,8 @@ public final class coil/request/Metadata {
 	public final fun copy (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)Lcoil/request/Metadata;
 	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSource ()Lcoil/decode/DataSource;
 	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
-	public final fun getSource ()Lcoil/decode/DataSource;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -66,7 +66,7 @@ public abstract interface class coil/EventListener : coil/request/ImageRequest$L
 	public abstract fun onDispatch (Lcoil/request/ImageRequest;)V
 	public abstract fun onError (Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public abstract fun onStart (Lcoil/request/ImageRequest;)V
-	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/decode/DataSource;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
 	public abstract fun resolveSizeEnd (Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
 	public abstract fun resolveSizeStart (Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;)V
 	public abstract fun transformEnd (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
@@ -89,7 +89,7 @@ public final class coil/EventListener$DefaultImpls {
 	public static fun onDispatch (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
 	public static fun onError (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public static fun onStart (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
-	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/decode/DataSource;)V
+	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
 	public static fun resolveSizeEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
 	public static fun resolveSizeStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;)V
 	public static fun transformEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
@@ -115,7 +115,9 @@ public abstract interface class coil/ImageLoader {
 	public static fun create (Landroid/content/Context;)Lcoil/ImageLoader;
 	public abstract fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun execute (Lcoil/request/ImageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getBitmapPool ()Lcoil/bitmappool/BitmapPool;
 	public abstract fun getDefaults ()Lcoil/DefaultRequestOptions;
+	public abstract fun getMemoryCache ()Lcoil/memory/MemoryCache;
 	public abstract fun invalidate (Ljava/lang/String;)V
 	public abstract fun shutdown ()V
 }
@@ -157,6 +159,11 @@ public final class coil/ImageLoader$Builder {
 
 public final class coil/ImageLoader$Companion {
 	public final fun create (Landroid/content/Context;)Lcoil/ImageLoader;
+}
+
+public final class coil/ImageLoader$DefaultImpls {
+	public static fun clearMemory (Lcoil/ImageLoader;)V
+	public static fun invalidate (Lcoil/ImageLoader;Ljava/lang/String;)V
 }
 
 public abstract interface annotation class coil/annotation/ExperimentalCoilApi : java/lang/annotation/Annotation {
@@ -392,6 +399,23 @@ public final class coil/map/MeasuredMapper$DefaultImpls {
 	public static fun handles (Lcoil/map/MeasuredMapper;Ljava/lang/Object;)Z
 }
 
+public abstract interface class coil/memory/MemoryCache {
+	public abstract fun clear ()V
+	public abstract fun get (Lcoil/memory/MemoryCache$Key;)Landroid/graphics/Bitmap;
+	public abstract fun getMaxSize ()I
+	public abstract fun getSize ()I
+	public abstract fun remove (Lcoil/memory/MemoryCache$Key;)Z
+}
+
+public abstract class coil/memory/MemoryCache$Key {
+	public static final field Companion Lcoil/memory/MemoryCache$Key$Companion;
+	public static final fun create (Ljava/lang/String;)Lcoil/memory/MemoryCache$Key;
+}
+
+public final class coil/memory/MemoryCache$Key$Companion {
+	public final fun create (Ljava/lang/String;)Lcoil/memory/MemoryCache$Key;
+}
+
 public final class coil/network/HttpException : java/lang/RuntimeException {
 	public fun <init> (Lokhttp3/Response;)V
 	public final fun getResponse ()Lokhttp3/Response;
@@ -422,7 +446,7 @@ public final class coil/request/ErrorResult : coil/request/RequestResult {
 }
 
 public final class coil/request/ImageRequest {
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Object;Ljava/lang/String;Lcoil/target/Target;Lcoil/request/ImageRequest$Listener;Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/CoroutineDispatcher;Ljava/util/List;Lcoil/transition/Transition;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/SizeResolver;Lcoil/size/Scale;Lcoil/size/Precision;Lkotlin/Pair;Lcoil/decode/Decoder;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lokhttp3/Headers;Lcoil/request/Parameters;ILandroid/graphics/drawable/Drawable;ILandroid/graphics/drawable/Drawable;ILandroid/graphics/drawable/Drawable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Object;Lcoil/memory/MemoryCache$Key;Lcoil/target/Target;Lcoil/request/ImageRequest$Listener;Landroidx/lifecycle/Lifecycle;Lkotlinx/coroutines/CoroutineDispatcher;Ljava/util/List;Lcoil/transition/Transition;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/SizeResolver;Lcoil/size/Scale;Lcoil/size/Precision;Lkotlin/Pair;Lcoil/decode/Decoder;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lokhttp3/Headers;Lcoil/request/Parameters;ILandroid/graphics/drawable/Drawable;ILandroid/graphics/drawable/Drawable;ILandroid/graphics/drawable/Drawable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowHardware ()Ljava/lang/Boolean;
 	public final fun getAllowRgb565 ()Ljava/lang/Boolean;
@@ -437,7 +461,7 @@ public final class coil/request/ImageRequest {
 	public final fun getFallback ()Landroid/graphics/drawable/Drawable;
 	public final fun getFetcher ()Lkotlin/Pair;
 	public final fun getHeaders ()Lokhttp3/Headers;
-	public final fun getKey ()Ljava/lang/String;
+	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
 	public final fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
 	public final fun getListener ()Lcoil/request/ImageRequest$Listener;
 	public final fun getMemoryCachePolicy ()Lcoil/request/CachePolicy;
@@ -480,6 +504,7 @@ public final class coil/request/ImageRequest$Builder {
 	public final fun fallback (Landroid/graphics/drawable/Drawable;)Lcoil/request/ImageRequest$Builder;
 	public final fun fetcher (Ljava/lang/Class;Lcoil/fetch/Fetcher;)Lcoil/request/ImageRequest$Builder;
 	public final fun headers (Lokhttp3/Headers;)Lcoil/request/ImageRequest$Builder;
+	public final fun key (Lcoil/memory/MemoryCache$Key;)Lcoil/request/ImageRequest$Builder;
 	public final fun key (Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
 	public final fun lifecycle (Landroidx/lifecycle/Lifecycle;)Lcoil/request/ImageRequest$Builder;
 	public final fun lifecycle (Landroidx/lifecycle/LifecycleOwner;)Lcoil/request/ImageRequest$Builder;
@@ -516,14 +541,14 @@ public abstract interface class coil/request/ImageRequest$Listener {
 	public abstract fun onCancel (Lcoil/request/ImageRequest;)V
 	public abstract fun onError (Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public abstract fun onStart (Lcoil/request/ImageRequest;)V
-	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/decode/DataSource;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
 }
 
 public final class coil/request/ImageRequest$Listener$DefaultImpls {
 	public static fun onCancel (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
 	public static fun onError (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public static fun onStart (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
-	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/decode/DataSource;)V
+	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
 }
 
 public final class coil/request/NullRequestDataException : java/lang/RuntimeException {
@@ -586,13 +611,27 @@ public abstract class coil/request/RequestResult {
 }
 
 public final class coil/request/SuccessResult : coil/request/RequestResult {
-	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/decode/DataSource;)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
-	public final fun component2 ()Lcoil/decode/DataSource;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Lcoil/decode/DataSource;)Lcoil/request/SuccessResult;
-	public static synthetic fun copy$default (Lcoil/request/SuccessResult;Landroid/graphics/drawable/Drawable;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/SuccessResult;
+	public final fun component2 ()Lcoil/request/SuccessResult$Metadata;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;)Lcoil/request/SuccessResult;
+	public static synthetic fun copy$default (Lcoil/request/SuccessResult;Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;ILjava/lang/Object;)Lcoil/request/SuccessResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getMetadata ()Lcoil/request/SuccessResult$Metadata;
+	public final fun getSource ()Lcoil/decode/DataSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class coil/request/SuccessResult$Metadata {
+	public fun <init> (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)V
+	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
+	public final fun component2 ()Lcoil/decode/DataSource;
+	public final fun copy (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)Lcoil/request/SuccessResult$Metadata;
+	public static synthetic fun copy$default (Lcoil/request/SuccessResult$Metadata;Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/SuccessResult$Metadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
 	public final fun getSource ()Lcoil/decode/DataSource;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -66,7 +66,7 @@ public abstract interface class coil/EventListener : coil/request/ImageRequest$L
 	public abstract fun onDispatch (Lcoil/request/ImageRequest;)V
 	public abstract fun onError (Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public abstract fun onStart (Lcoil/request/ImageRequest;)V
-	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
 	public abstract fun resolveSizeEnd (Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
 	public abstract fun resolveSizeStart (Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;)V
 	public abstract fun transformEnd (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
@@ -89,7 +89,7 @@ public final class coil/EventListener$DefaultImpls {
 	public static fun onDispatch (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
 	public static fun onError (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public static fun onStart (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
-	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
+	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
 	public static fun resolveSizeEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;Lcoil/size/Size;)V
 	public static fun resolveSizeStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/SizeResolver;)V
 	public static fun transformEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
@@ -541,14 +541,27 @@ public abstract interface class coil/request/ImageRequest$Listener {
 	public abstract fun onCancel (Lcoil/request/ImageRequest;)V
 	public abstract fun onError (Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public abstract fun onStart (Lcoil/request/ImageRequest;)V
-	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
 }
 
 public final class coil/request/ImageRequest$Listener$DefaultImpls {
 	public static fun onCancel (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
 	public static fun onError (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public static fun onStart (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
-	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult$Metadata;)V
+	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
+}
+
+public final class coil/request/Metadata {
+	public fun <init> (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)V
+	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
+	public final fun component2 ()Lcoil/decode/DataSource;
+	public final fun copy (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)Lcoil/request/Metadata;
+	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
+	public final fun getSource ()Lcoil/decode/DataSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class coil/request/NullRequestDataException : java/lang/RuntimeException {
@@ -611,27 +624,14 @@ public abstract class coil/request/RequestResult {
 }
 
 public final class coil/request/SuccessResult : coil/request/RequestResult {
-	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/request/Metadata;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
-	public final fun component2 ()Lcoil/request/SuccessResult$Metadata;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;)Lcoil/request/SuccessResult;
-	public static synthetic fun copy$default (Lcoil/request/SuccessResult;Landroid/graphics/drawable/Drawable;Lcoil/request/SuccessResult$Metadata;ILjava/lang/Object;)Lcoil/request/SuccessResult;
+	public final fun component2 ()Lcoil/request/Metadata;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Lcoil/request/Metadata;)Lcoil/request/SuccessResult;
+	public static synthetic fun copy$default (Lcoil/request/SuccessResult;Landroid/graphics/drawable/Drawable;Lcoil/request/Metadata;ILjava/lang/Object;)Lcoil/request/SuccessResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getDrawable ()Landroid/graphics/drawable/Drawable;
-	public final fun getMetadata ()Lcoil/request/SuccessResult$Metadata;
-	public final fun getSource ()Lcoil/decode/DataSource;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class coil/request/SuccessResult$Metadata {
-	public fun <init> (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)V
-	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
-	public final fun component2 ()Lcoil/decode/DataSource;
-	public final fun copy (Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;)Lcoil/request/SuccessResult$Metadata;
-	public static synthetic fun copy$default (Lcoil/request/SuccessResult$Metadata;Lcoil/memory/MemoryCache$Key;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/SuccessResult$Metadata;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
+	public final fun getMetadata ()Lcoil/request/Metadata;
 	public final fun getSource ()Lcoil/decode/DataSource;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -7,13 +7,13 @@ import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
 import coil.base.test.R
-import coil.decode.DataSource
 import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.ImageRequest
+import coil.request.SuccessResult
 import coil.size.Size
 import coil.size.SizeResolver
 import coil.transform.CircleCropTransformation
@@ -210,7 +210,7 @@ class EventListenerTest {
         override fun transformEnd(request: ImageRequest, output: Bitmap) = transformEnd.call()
         override fun transitionStart(request: ImageRequest, transition: Transition) = transitionStart.call()
         override fun transitionEnd(request: ImageRequest, transition: Transition) = transitionEnd.call()
-        override fun onSuccess(request: ImageRequest, source: DataSource) = onSuccess.call()
+        override fun onSuccess(request: ImageRequest, metadata: SuccessResult.Metadata) = onSuccess.call()
         override fun onCancel(request: ImageRequest) = onCancel.call()
         override fun onError(request: ImageRequest, throwable: Throwable) = onError.call()
 

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -13,7 +13,7 @@ import coil.decode.Options
 import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.ImageRequest
-import coil.request.SuccessResult
+import coil.request.Metadata
 import coil.size.Size
 import coil.size.SizeResolver
 import coil.transform.CircleCropTransformation
@@ -210,7 +210,7 @@ class EventListenerTest {
         override fun transformEnd(request: ImageRequest, output: Bitmap) = transformEnd.call()
         override fun transitionStart(request: ImageRequest, transition: Transition) = transitionStart.call()
         override fun transitionEnd(request: ImageRequest, transition: Transition) = transitionEnd.call()
-        override fun onSuccess(request: ImageRequest, metadata: SuccessResult.Metadata) = onSuccess.call()
+        override fun onSuccess(request: ImageRequest, metadata: Metadata) = onSuccess.call()
         override fun onCancel(request: ImageRequest) = onCancel.call()
         override fun onError(request: ImageRequest, throwable: Throwable) = onError.call()
 

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderIntegrationTest.kt
@@ -369,6 +369,22 @@ class RealImageLoaderIntegrationTest {
         }
     }
 
+    @Test
+    fun loadedImageIsPresentInMemoryCache() {
+        val result = runBlocking {
+            val request = ImageRequest.Builder(context)
+                .data(server.url(IMAGE_NAME))
+                .size(100, 100)
+                .build()
+            imageLoader.execute(request)
+        }
+
+        assertTrue(result is SuccessResult)
+        val bitmap = (result.drawable as BitmapDrawable).bitmap
+        assertNotNull(bitmap)
+        assertEquals(bitmap, imageLoader.memoryCache.get(result.metadata.key!!))
+    }
+
     private fun testEnqueue(data: Any, expectedSize: PixelSize = PixelSize(80, 100)) {
         val imageView = ImageView(context)
         imageView.scaleType = ImageView.ScaleType.FIT_CENTER

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -14,8 +14,8 @@ import coil.RealImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.memory.BitmapReferenceCounter
-import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
+import coil.memory.StrongMemoryCache
 import okhttp3.OkHttpClient
 import org.junit.Before
 import org.junit.Test
@@ -56,7 +56,7 @@ class SystemCallbacksTest {
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
         val weakMemoryCache = RealWeakMemoryCache()
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        val memoryCache = MemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
+        val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         val imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),
@@ -73,13 +73,13 @@ class SystemCallbacksTest {
         val systemCallbacks = SystemCallbacks(imageLoader, context)
 
         memoryCache.set(
-            key = MemoryCache.Key("1"),
+            key = StrongMemoryCache.Key("1"),
             bitmap = createBitmap(1000, 1000, Bitmap.Config.ARGB_8888),
             isSampled = false
         )
 
         memoryCache.set(
-            key = MemoryCache.Key("2"),
+            key = StrongMemoryCache.Key("2"),
             bitmap = createBitmap(1000, 1000, Bitmap.Config.ARGB_8888),
             isSampled = false
         )

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -14,6 +14,7 @@ import coil.RealImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.memory.BitmapReferenceCounter
+import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
 import coil.memory.StrongMemoryCache
 import okhttp3.OkHttpClient
@@ -73,13 +74,13 @@ class SystemCallbacksTest {
         val systemCallbacks = SystemCallbacks(imageLoader, context)
 
         memoryCache.set(
-            key = StrongMemoryCache.Key("1"),
+            key = MemoryCache.Key("1"),
             bitmap = createBitmap(1000, 1000, Bitmap.Config.ARGB_8888),
             isSampled = false
         )
 
         memoryCache.set(
-            key = StrongMemoryCache.Key("2"),
+            key = MemoryCache.Key("2"),
             bitmap = createBitmap(1000, 1000, Bitmap.Config.ARGB_8888),
             isSampled = false
         )

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -84,10 +84,10 @@ class SystemCallbacksTest {
             isSampled = false
         )
 
-        assertTrue(memoryCache.size() == 8000000)
+        assertTrue(memoryCache.size == 8000000)
 
         systemCallbacks.onTrimMemory(TRIM_MEMORY_COMPLETE)
 
-        assertTrue(memoryCache.size() == 0)
+        assertTrue(memoryCache.size == 0)
     }
 }

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -55,9 +55,9 @@ class SystemCallbacksTest {
     @Test
     fun trimMemoryCallsArePassedThrough() {
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
-        val weakMemoryCache = RealWeakMemoryCache()
+        val weakMemoryCache = RealWeakMemoryCache(null)
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE)
+        val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         val imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -57,13 +57,13 @@ class SystemCallbacksTest {
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
         val weakMemoryCache = RealWeakMemoryCache()
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
+        val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE)
         val imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),
             bitmapPool = bitmapPool,
             referenceCounter = referenceCounter,
-            memoryCache = memoryCache,
+            strongMemoryCache = memoryCache,
             weakMemoryCache = weakMemoryCache,
             callFactory = OkHttpClient(),
             eventListenerFactory = EventListener.Factory.NONE,

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -13,7 +13,7 @@ import coil.fetch.SourceResult
 import coil.map.Mapper
 import coil.map.MeasuredMapper
 import coil.request.ImageRequest
-import coil.request.SuccessResult.Metadata
+import coil.request.Metadata
 import coil.size.Size
 import coil.size.SizeResolver
 import coil.transform.Transformation

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -4,7 +4,6 @@ import android.graphics.Bitmap
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import coil.annotation.ExperimentalCoilApi
-import coil.decode.DataSource
 import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
@@ -14,6 +13,7 @@ import coil.fetch.SourceResult
 import coil.map.Mapper
 import coil.map.MeasuredMapper
 import coil.request.ImageRequest
+import coil.request.SuccessResult.Metadata
 import coil.size.Size
 import coil.size.SizeResolver
 import coil.transform.Transformation
@@ -163,7 +163,7 @@ interface EventListener : ImageRequest.Listener {
      * @see ImageRequest.Listener.onSuccess
      */
     @MainThread
-    override fun onSuccess(request: ImageRequest, source: DataSource) {}
+    override fun onSuccess(request: ImageRequest, metadata: Metadata) {}
 
     /**
      * @see ImageRequest.Listener.onCancel

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -412,7 +412,7 @@ interface ImageLoader {
         /**
          * Set the [Logger] to write logs to.
          *
-         * NOTE: Setting a non-null [Logger] can reduce performance and should be avoided in release builds.
+         * NOTE: Setting a [Logger] can reduce performance and should be avoided in release builds.
          */
         fun logger(logger: Logger?) = apply {
             this.logger = logger
@@ -429,7 +429,7 @@ interface ImageLoader {
             val bitmapPool = RealBitmapPool(bitmapPoolSize, logger = logger)
             val weakMemoryCache = if (trackWeakReferences) RealWeakMemoryCache() else EmptyWeakMemoryCache
             val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
-            val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize, logger)
+            val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize)
 
             return RealImageLoader(
                 context = applicationContext,

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -101,10 +101,10 @@ interface ImageLoader {
      */
     @Deprecated(
         message = "Call the memory cache directly.",
-        replaceWith = ReplaceWith("memoryCache.remove(key)")
+        replaceWith = ReplaceWith("memoryCache.remove(MemoryCache.Key(key))", "coil.memory.MemoryCache")
     )
     fun invalidate(key: String) {
-        memoryCache.remove(key)
+        memoryCache.remove(MemoryCache.Key(key))
     }
 
     /**

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -427,9 +427,9 @@ interface ImageLoader {
             val memoryCacheSize = (availableMemorySize - bitmapPoolSize).toInt()
 
             val bitmapPool = RealBitmapPool(bitmapPoolSize, logger = logger)
-            val weakMemoryCache = if (trackWeakReferences) RealWeakMemoryCache() else EmptyWeakMemoryCache
+            val weakMemoryCache = if (trackWeakReferences) RealWeakMemoryCache(logger) else EmptyWeakMemoryCache
             val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
-            val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize)
+            val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize, logger)
 
             return RealImageLoader(
                 context = applicationContext,

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -9,6 +9,8 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import androidx.annotation.MainThread
+import coil.bitmappool.BitmapPool
+import coil.memory.PublicMemoryCache
 import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.RealBitmapPool
 import coil.drawable.CrossfadeDrawable
@@ -55,6 +57,16 @@ interface ImageLoader {
     val defaults: DefaultRequestOptions
 
     /**
+     * An in-memory cache of [Bitmap]s.
+     */
+    val memoryCache: PublicMemoryCache
+
+    /**
+     * An object pool of reusable [Bitmap]s.
+     */
+    val bitmapPool: BitmapPool
+
+    /**
      * Enqueue the [request] to be executed asynchronously.
      *
      * @param request The request to execute.
@@ -74,20 +86,6 @@ interface ImageLoader {
     suspend fun execute(request: ImageRequest): RequestResult
 
     /**
-     * Remove the value referenced by [key] from the memory cache.
-     *
-     * @param key The cache key to remove.
-     */
-    @MainThread
-    fun invalidate(key: String)
-
-    /**
-     * Clear this image loader's memory cache and bitmap pool.
-     */
-    @MainThread
-    fun clearMemory()
-
-    /**
      * Shutdown this image loader.
      *
      * All associated resources will be freed and any new requests will fail before starting.
@@ -97,6 +95,37 @@ interface ImageLoader {
      */
     @MainThread
     fun shutdown()
+
+    /**
+     * Remove the value referenced by [key] from the memory cache.
+     *
+     * @param key The cache key to remove.
+     */
+    @Deprecated(
+        message = "Call the memory cache directly.",
+        replaceWith = ReplaceWith("memoryCache.remove(key)")
+    )
+    @MainThread
+    fun invalidate(key: String) {
+        memoryCache.remove(key)
+    }
+
+    /**
+     * Clear this image loader's memory cache and bitmap pool.
+     */
+    @Deprecated(
+        message = "Call the memory cache and bitmap pool directly.",
+        replaceWith = ReplaceWith("" +
+            "apply {\n" +
+            "    memoryCache.clear()\n" +
+            "    bitmapPool.clear()\n" +
+            "}")
+    )
+    @MainThread
+    fun clearMemory() {
+        memoryCache.clear()
+        bitmapPool.clear()
+    }
 
     class Builder(context: Context) {
 

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -56,7 +56,7 @@ interface ImageLoader {
     val defaults: DefaultRequestOptions
 
     /**
-     * An in-memory cache of [Bitmap]s.
+     * An in-memory cache of recently loaded images.
      */
     val memoryCache: MemoryCache
 
@@ -89,7 +89,7 @@ interface ImageLoader {
      *
      * All associated resources will be freed and any new requests will fail before starting.
      *
-     * In progress [enqueue] requests will be cancelled instantly.
+     * In progress [enqueue] requests will be cancelled immediately.
      * In progress [execute] requests will continue until complete.
      */
     fun shutdown()

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -243,13 +243,11 @@ internal class RealImageLoader(
                 sizeResolver, size, scale, eventListener)
 
             // Cache the result.
-            if (memoryCachePolicy.writeEnabled) {
-                strongMemoryCache.set(cacheKey, drawable, isSampled)
-            }
+            val isCached = memoryCachePolicy.writeEnabled && strongMemoryCache.set(cacheKey, drawable, isSampled)
 
             // Set the result on the target.
             logger?.log(TAG, Log.INFO) { "${source.emoji} Successful (${source.name}) - $data" }
-            val metadata = Metadata(cacheKey, source)
+            val metadata = Metadata(cacheKey.takeIf { isCached }, source)
             val result = SuccessResult(drawable, metadata)
             targetDelegate.success(result, request.transition ?: defaults.transition)
             eventListener.onSuccess(request, metadata)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -61,7 +61,6 @@ import coil.util.awaitStarted
 import coil.util.closeQuietly
 import coil.util.emoji
 import coil.util.foldIndices
-import coil.util.get
 import coil.util.getLifecycle
 import coil.util.job
 import coil.util.log
@@ -107,9 +106,7 @@ internal class RealImageLoader(
     private val memoryCacheService = MemoryCacheService(requestService, logger)
     private val drawableDecoder = DrawableDecoderService(bitmapPool)
     private val systemCallbacks = SystemCallbacks(this, context)
-
     override val memoryCache = RealMemoryCache(registry, strongMemoryCache, weakMemoryCache, referenceCounter)
-
     private val registry = registry.newBuilder()
         // Mappers
         .add(StringMapper())
@@ -405,7 +402,6 @@ internal class RealImageLoader(
     }
 
     override fun shutdown() {
-        assertMainThread()
         if (isShutdown) return
         isShutdown = true
 

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -33,6 +33,7 @@ import coil.map.StringMapper
 import coil.memory.BitmapReferenceCounter
 import coil.memory.DelegateService
 import coil.memory.MemoryCacheService
+import coil.memory.RealMemoryCache
 import coil.memory.RequestService
 import coil.memory.StrongMemoryCache
 import coil.memory.TargetDelegate
@@ -106,6 +107,8 @@ internal class RealImageLoader(
     private val memoryCacheService = MemoryCacheService(requestService, logger)
     private val drawableDecoder = DrawableDecoderService(bitmapPool)
     private val systemCallbacks = SystemCallbacks(this, context)
+
+    override val memoryCache = RealMemoryCache(registry, strongMemoryCache, weakMemoryCache, referenceCounter)
 
     private val registry = registry.newBuilder()
         // Mappers

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -106,9 +106,9 @@ internal class RealImageLoader(
     private val delegateService = DelegateService(this, referenceCounter, logger)
     private val requestService = RequestService(defaults, logger)
     private val memoryCacheService = MemoryCacheService(requestService, logger)
+    override val memoryCache = RealMemoryCache(strongMemoryCache, weakMemoryCache, referenceCounter)
     private val drawableDecoder = DrawableDecoderService(bitmapPool)
     private val systemCallbacks = SystemCallbacks(this, context)
-    override val memoryCache = RealMemoryCache(registry, strongMemoryCache, weakMemoryCache, referenceCounter)
     private val registry = registry.newBuilder()
         // Mappers
         .add(StringMapper())
@@ -127,8 +127,7 @@ internal class RealImageLoader(
         // Decoders
         .add(BitmapFactoryDecoder(context))
         .build()
-
-    private var isShutdown = AtomicBoolean(false)
+    private val isShutdown = AtomicBoolean(false)
 
     override fun enqueue(request: ImageRequest): RequestDisposable {
         val job = scope.launch {

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -42,6 +42,7 @@ import coil.memory.WeakMemoryCache
 import coil.request.BaseTargetRequestDisposable
 import coil.request.ErrorResult
 import coil.request.ImageRequest
+import coil.request.Metadata
 import coil.request.NullRequestDataException
 import coil.request.Parameters
 import coil.request.RequestDisposable
@@ -229,7 +230,7 @@ internal class RealImageLoader(
             if (cachedDrawable != null && memoryCacheService
                     .isCachedValueValid(cacheKey, cachedValue, request, sizeResolver, size, scale)) {
                 logger?.log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
-                val metadata = SuccessResult.Metadata(cacheKey, DataSource.MEMORY_CACHE)
+                val metadata = Metadata(cacheKey, DataSource.MEMORY_CACHE)
                 val result = SuccessResult(cachedDrawable, metadata)
                 targetDelegate.success(result, request.transition ?: defaults.transition)
                 eventListener.onSuccess(request, metadata)
@@ -248,7 +249,7 @@ internal class RealImageLoader(
 
             // Set the result on the target.
             logger?.log(TAG, Log.INFO) { "${source.emoji} Successful (${source.name}) - $data" }
-            val metadata = SuccessResult.Metadata(cacheKey, source)
+            val metadata = Metadata(cacheKey, source)
             val result = SuccessResult(drawable, metadata)
             targetDelegate.success(result, request.transition ?: defaults.transition)
             eventListener.onSuccess(request, metadata)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -63,6 +63,7 @@ import coil.util.closeQuietly
 import coil.util.emoji
 import coil.util.foldIndices
 import coil.util.getLifecycle
+import coil.util.invoke
 import coil.util.job
 import coil.util.log
 import coil.util.mapData
@@ -228,10 +229,11 @@ internal class RealImageLoader(
             if (cachedDrawable != null && memoryCacheService
                     .isCachedValueValid(cacheKey, cachedValue, request, sizeResolver, size, scale)) {
                 logger?.log(TAG, Log.INFO) { "${Emoji.BRAIN} Cached - $data" }
-                val result = SuccessResult(cachedDrawable, DataSource.MEMORY_CACHE)
+                val metadata = SuccessResult.Metadata(cacheKey, DataSource.MEMORY_CACHE)
+                val result = SuccessResult(cachedDrawable, metadata)
                 targetDelegate.success(result, request.transition ?: defaults.transition)
-                eventListener.onSuccess(request, result.source)
-                request.listener?.onSuccess(request, result.source)
+                eventListener.onSuccess(request, metadata)
+                request.listener?.onSuccess(request, metadata)
                 return result
             }
 
@@ -246,10 +248,11 @@ internal class RealImageLoader(
 
             // Set the result on the target.
             logger?.log(TAG, Log.INFO) { "${source.emoji} Successful (${source.name}) - $data" }
-            val result = SuccessResult(drawable, source)
+            val metadata = SuccessResult.Metadata(cacheKey, source)
+            val result = SuccessResult(drawable, metadata)
             targetDelegate.success(result, request.transition ?: defaults.transition)
-            eventListener.onSuccess(request, source)
-            request.listener?.onSuccess(request, source)
+            eventListener.onSuccess(request, metadata)
+            request.listener?.onSuccess(request, metadata)
             return result
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) {

--- a/coil-base/src/main/java/coil/fetch/Fetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/Fetcher.kt
@@ -6,7 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import coil.bitmappool.BitmapPool
 import coil.decode.Options
-import coil.memory.MemoryCache
+import coil.memory.StrongMemoryCache
 import coil.size.Size
 import okio.BufferedSource
 
@@ -29,7 +29,7 @@ interface Fetcher<T : Any> {
     /**
      * Compute the memory cache key for [data].
      *
-     * Items with the same cache key will be treated as equivalent by the [MemoryCache].
+     * Items with the same cache key will be treated as equivalent by the [StrongMemoryCache].
      *
      * Returning null will prevent the result of [fetch] from being added to the memory cache.
      */

--- a/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
@@ -18,8 +18,6 @@ import java.lang.ref.WeakReference
  *
  * This class uses [System.identityHashCode] to determine bitmap identity as it provides a "unique-enough" key
  * for a [Bitmap] and it allows us to avoid using [WeakReference]s.
- *
- * NOTE: This class is not thread safe and its methods should only be called from the main thread.
  */
 internal class BitmapReferenceCounter(
     private val weakMemoryCache: WeakMemoryCache,
@@ -33,6 +31,7 @@ internal class BitmapReferenceCounter(
     /**
      * Increase the reference count for this [Bitmap] by one.
      */
+    @Synchronized
     fun increment(bitmap: Bitmap) {
         val key = bitmap.identityHashCode
         val count = counts[key]
@@ -48,6 +47,7 @@ internal class BitmapReferenceCounter(
      *
      * @return True if [bitmap] was added to [bitmapPool] as a result of this decrement operation.
      */
+    @Synchronized
     fun decrement(bitmap: Bitmap): Boolean {
         val key = bitmap.identityHashCode
         val count = counts[key]
@@ -73,6 +73,7 @@ internal class BitmapReferenceCounter(
      * Mark this bitmap as invalid so it is not returned to the bitmap pool
      * when it is no longer referenced.
      */
+    @Synchronized
     fun invalidate(bitmap: Bitmap) {
         invalidKeys += bitmap.identityHashCode
     }

--- a/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
@@ -45,7 +45,7 @@ internal class BitmapReferenceCounter(
      *
      * If the reference count is now zero, add the [Bitmap] to [bitmapPool].
      *
-     * @return True if [bitmap] was added to [bitmapPool] as a result of this decrement operation.
+     * @return `true` if [bitmap] was added to [bitmapPool] as a result of this decrement operation.
      */
     @Synchronized
     fun decrement(bitmap: Bitmap): Boolean {

--- a/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
  * This class uses [System.identityHashCode] to determine bitmap identity as it provides a "unique-enough" key
  * for a [Bitmap] and it allows us to avoid using [WeakReference]s.
  *
- * NOTE: This class is not thread safe. In practice, it will only be called from the main thread.
+ * NOTE: This class is not thread safe and its methods should only be called from the main thread.
  */
 internal class BitmapReferenceCounter(
     private val weakMemoryCache: WeakMemoryCache,
@@ -60,7 +60,7 @@ internal class BitmapReferenceCounter(
             val isValid = !invalidKeys.remove(key)
             if (isValid) {
                 // Remove the bitmap from the WeakMemoryCache and add it to the BitmapPool.
-                weakMemoryCache.invalidate(bitmap)
+                weakMemoryCache.remove(bitmap)
                 bitmapPool.put(bitmap)
                 return true
             }

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -6,7 +6,7 @@ import coil.request.Parameters
 import coil.size.Size
 import coil.transform.Transformation
 
-interface PublicMemoryCache {
+interface MemoryCache {
 
     /** The **current size** of the memory cache in bytes. */
     @get:MainThread val size: Int

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -25,7 +25,7 @@ interface MemoryCache {
     /**
      * Remove the [Bitmap] referenced by [key].
      *
-     * @return True if [key] was present in the cache. Else, return false.
+     * @return `true` if [key] was present in the cache. Else, return `false`.
      */
     fun remove(key: Key): Boolean
 

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -46,9 +46,10 @@ interface MemoryCache {
         internal data class Simple(val value: String) : Key()
 
         /**
-         * A complex memory cache key. Instances cannot be created directly - instead they are
-         * created by an [ImageLoader]'s image pipeline and are returned as part of a successful image request
-         * in [SuccessResult.Metadata] and [ImageRequest.Listener].
+         * A complex memory cache key. Instances cannot be created directly - instead they are created by an
+         * [ImageLoader]'s image pipeline and are returned as part of a successful image request in [Metadata].
+         *
+         * A request's metadata is accessible through [ImageRequest.Listener.onSuccess] and [SuccessResult].
          *
          * This class is an implementation detail and its fields may change in future releases.
          */

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -24,7 +24,8 @@ interface MemoryCache {
 
     /**
      * Remove the [Bitmap] referenced by [key].
-     * Return true if [key] was present in the cache. Else, return false.
+     *
+     * @return True if [key] was present in the cache. Else, return false.
      */
     fun remove(key: Key): Boolean
 

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -1,7 +1,6 @@
 package coil.memory
 
 import android.graphics.Bitmap
-import androidx.annotation.MainThread
 import coil.request.Parameters
 import coil.size.Size
 import coil.transform.Transformation
@@ -9,24 +8,19 @@ import coil.transform.Transformation
 interface MemoryCache {
 
     /** The **current size** of the memory cache in bytes. */
-    @get:MainThread val size: Int
+    val size: Int
 
     /** The **maximum size** of the memory cache in bytes. */
-    @get:MainThread val maxSize: Int
+    val maxSize: Int
 
-    @MainThread
     fun find(criteria: Criteria): Bitmap?
 
-    @MainThread
     fun find(key: String): Bitmap?
 
-    @MainThread
     fun remove(criteria: Criteria)
 
-    @MainThread
     fun remove(key: String)
 
-    @MainThread
     fun clear()
 
     data class Criteria(

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -20,7 +20,7 @@ interface MemoryCache {
     val maxSize: Int
 
     /** Get the [Bitmap] associated with [key]. */
-    fun get(key: Key): Bitmap?
+    operator fun get(key: Key): Bitmap?
 
     /**
      * Remove the [Bitmap] referenced by [key].

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -1,10 +1,13 @@
 package coil.memory
 
 import android.graphics.Bitmap
-import coil.annotation.ExperimentalCoilApi
+import coil.fetch.Fetcher
+import coil.request.Parameters
+import coil.size.Size
+import coil.transform.Transformation
+import coil.util.mapIndices
 
 /** An in-memory cache of recently loaded images. */
-@ExperimentalCoilApi
 interface MemoryCache {
 
     /** The current size of the cache in bytes. */
@@ -13,9 +16,78 @@ interface MemoryCache {
     /** The maximum size of the cache in bytes. */
     val maxSize: Int
 
-    fun get(key: String): Bitmap?
+    /** Get the value associated with [key]. */
+    fun get(key: Key): Value?
 
-    fun remove(key: String)
+    /** Remove the value referenced by [key] from this cache if it is present. */
+    fun remove(key: Key)
 
+    /** Remove all values from this cache. */
     fun clear()
+
+    class Key {
+
+        /** The base component of the cache key. This is typically [Fetcher.key]. */
+        internal val baseKey: String
+
+        /** An ordered list of [Transformation.key]s. */
+        internal val transformationKeys: List<String>
+
+        /** The resolved size for the request. This is null if [transformationKeys] is empty. */
+        internal val size: Size?
+
+        /** @see Parameters.cacheKeys */
+        internal val parameterKeys: Map<String, String>
+
+        @JvmOverloads
+        constructor(
+            baseKey: String,
+            parameters: Parameters = Parameters.EMPTY
+        ) {
+            this.baseKey = baseKey
+            this.transformationKeys = emptyList()
+            this.size = null
+            this.parameterKeys = parameters.cacheKeys()
+        }
+
+        @JvmOverloads
+        constructor(
+            baseKey: String,
+            transformations: List<Transformation>,
+            size: Size,
+            parameters: Parameters = Parameters.EMPTY
+        ) {
+            this.baseKey = baseKey
+            if (transformations.isEmpty()) {
+                this.transformationKeys = emptyList()
+                this.size = null
+            } else {
+                this.transformationKeys = transformations.mapIndices { it.key() }
+                this.size = size
+            }
+            this.parameterKeys = parameters.cacheKeys()
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return other is Key &&
+                baseKey == other.baseKey &&
+                transformationKeys == other.transformationKeys &&
+                size == other.size &&
+                parameterKeys == other.parameterKeys
+        }
+
+        override fun hashCode(): Int {
+            var result = baseKey.hashCode()
+            result = 31 * result + transformationKeys.hashCode()
+            result = 31 * result + (size?.hashCode() ?: 0)
+            result = 31 * result + parameterKeys.hashCode()
+            return result
+        }
+    }
+
+    interface Value {
+        val bitmap: Bitmap
+        val isSampled: Boolean
+    }
 }

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -34,38 +34,41 @@ interface MemoryCache {
 
     class Key {
 
-        internal val simple: Boolean
+        internal val complex: Boolean
         internal val base: String
         internal val transformations: List<String>
         internal val size: Size?
         internal val parameters: Map<String, String>
 
+        /** Public constructor to create a simple cache key. */
         constructor(base: String) {
-            this.simple = true
+            this.complex = false
             this.base = base
             this.transformations = emptyList()
             this.size = null
             this.parameters = emptyMap()
         }
 
+        /** Internal constructor to create a complex cache key. */
         internal constructor(
             base: String,
             parameters: Parameters
         ) {
-            this.simple = false
+            this.complex = true
             this.base = base
             this.transformations = emptyList()
             this.size = null
             this.parameters = parameters.cacheKeys()
         }
 
+        /** Internal constructor to create a complex cache key. */
         internal constructor(
             base: String,
             transformations: List<Transformation>,
             size: Size,
             parameters: Parameters
         ) {
-            this.simple = false
+            this.complex = true
             this.base = base
             if (transformations.isEmpty()) {
                 this.transformations = emptyList()
@@ -80,7 +83,7 @@ interface MemoryCache {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             return other is Key &&
-                simple == other.simple &&
+                complex == other.complex &&
                 base == other.base &&
                 transformations == other.transformations &&
                 size == other.size &&
@@ -88,7 +91,7 @@ interface MemoryCache {
         }
 
         override fun hashCode(): Int {
-            var result = simple.hashCode()
+            var result = complex.hashCode()
             result = 31 * result + base.hashCode()
             result = 31 * result + transformations.hashCode()
             result = 31 * result + (size?.hashCode() ?: 0)
@@ -97,7 +100,7 @@ interface MemoryCache {
         }
 
         override fun toString(): String {
-            return "Key(simple=$simple, base=$base, transformations=$transformations, size=$size, parameters=$parameters)"
+            return "Key(complex=$complex, base=$base, transformations=$transformations, size=$size, parameters=$parameters)"
         }
     }
 }

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -1,32 +1,21 @@
 package coil.memory
 
 import android.graphics.Bitmap
-import coil.request.Parameters
-import coil.size.Size
-import coil.transform.Transformation
+import coil.annotation.ExperimentalCoilApi
 
+/** An in-memory cache of recently loaded images. */
+@ExperimentalCoilApi
 interface MemoryCache {
 
-    /** The **current size** of the memory cache in bytes. */
+    /** The current size of the cache in bytes. */
     val size: Int
 
-    /** The **maximum size** of the memory cache in bytes. */
+    /** The maximum size of the cache in bytes. */
     val maxSize: Int
 
-    fun find(criteria: Criteria): Bitmap?
-
-    fun find(key: String): Bitmap?
-
-    fun remove(criteria: Criteria)
+    fun get(key: String): Bitmap?
 
     fun remove(key: String)
 
     fun clear()
-
-    data class Criteria(
-        val data: Any,
-        val size: Size? = null,
-        val transformations: List<Transformation>? = null,
-        val parameters: Parameters? = null
-    )
 }

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -1,9 +1,10 @@
 package coil.memory
 
 import android.util.Log
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.DecodeUtils
 import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
+import coil.memory.RealMemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.OriginalSize
 import coil.size.PixelSize
@@ -16,6 +17,7 @@ import coil.util.safeConfig
 import kotlin.math.abs
 
 /** Handles operations related to the memory cache. */
+@OptIn(ExperimentalCoilApi::class)
 internal class MemoryCacheService(
     private val requestService: RequestService,
     private val logger: Logger?

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -70,7 +70,7 @@ internal class MemoryCacheService(
             is PixelSize -> {
                 val cachedWidth: Int
                 val cachedHeight: Int
-                when (val cachedSize = cacheKey?.size) {
+                when (val cachedSize = (cacheKey as? Key.Complex)?.size) {
                     is PixelSize -> {
                         cachedWidth = cachedSize.width
                         cachedHeight = cachedSize.height

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -2,8 +2,8 @@ package coil.memory
 
 import android.util.Log
 import coil.decode.DecodeUtils
-import coil.memory.StrongMemoryCache.Key
-import coil.memory.StrongMemoryCache.Value
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.OriginalSize
 import coil.size.PixelSize

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -2,6 +2,8 @@ package coil.memory
 
 import android.util.Log
 import coil.decode.DecodeUtils
+import coil.memory.StrongMemoryCache.Key
+import coil.memory.StrongMemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.OriginalSize
 import coil.size.PixelSize
@@ -13,7 +15,7 @@ import coil.util.log
 import coil.util.safeConfig
 import kotlin.math.abs
 
-/** Handles operations related to the [MemoryCache]. */
+/** Handles operations related to the memory cache. */
 internal class MemoryCacheService(
     private val requestService: RequestService,
     private val logger: Logger?
@@ -21,8 +23,8 @@ internal class MemoryCacheService(
 
     /** Return true if [cacheValue] satisfies the [request]. */
     fun isCachedValueValid(
-        cacheKey: MemoryCache.Key?,
-        cacheValue: MemoryCache.Value,
+        cacheKey: Key?,
+        cacheValue: Value,
         request: ImageRequest,
         sizeResolver: SizeResolver,
         size: Size,
@@ -47,8 +49,8 @@ internal class MemoryCacheService(
 
     /** Return true if [cacheValue]'s size satisfies the [request]. */
     private fun isSizeValid(
-        cacheKey: MemoryCache.Key?,
-        cacheValue: MemoryCache.Value,
+        cacheKey: Key?,
+        cacheValue: Value,
         request: ImageRequest,
         sizeResolver: SizeResolver,
         size: Size,

--- a/coil-base/src/main/java/coil/memory/PublicMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/PublicMemoryCache.kt
@@ -1,0 +1,38 @@
+package coil.memory
+
+import android.graphics.Bitmap
+import androidx.annotation.MainThread
+import coil.request.Parameters
+import coil.size.Size
+import coil.transform.Transformation
+
+interface PublicMemoryCache {
+
+    /** The **current size** of the memory cache in bytes. */
+    @get:MainThread val size: Int
+
+    /** The **maximum size** of the memory cache in bytes. */
+    @get:MainThread val maxSize: Int
+
+    @MainThread
+    fun find(criteria: Criteria): Bitmap?
+
+    @MainThread
+    fun find(key: String): Bitmap?
+
+    @MainThread
+    fun remove(criteria: Criteria)
+
+    @MainThread
+    fun remove(key: String)
+
+    @MainThread
+    fun clear()
+
+    data class Criteria(
+        val data: Any,
+        val size: Size? = null,
+        val transformations: List<Transformation>? = null,
+        val parameters: Parameters? = null
+    )
+}

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -1,11 +1,9 @@
 package coil.memory
 
-import android.graphics.Bitmap
 import coil.ComponentRegistry
-import coil.annotation.ExperimentalCoilApi
-import coil.memory.StrongMemoryCache.Key
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 
-@OptIn(ExperimentalCoilApi::class)
 internal class RealMemoryCache(
     private val componentRegistry: ComponentRegistry,
     private val strongMemoryCache: StrongMemoryCache,
@@ -17,16 +15,14 @@ internal class RealMemoryCache(
 
     override val maxSize get() = strongMemoryCache.maxSize
 
-    override fun get(key: String): Bitmap? {
-        val cacheKey = Key(key)
-        val value = strongMemoryCache.get(cacheKey) ?: weakMemoryCache.get(cacheKey)
-        return value?.bitmap?.also(bitmapReferenceCounter::invalidate)
+    override fun get(key: Key): Value? {
+        val value = strongMemoryCache.get(key) ?: weakMemoryCache.get(key)
+        return value?.also { bitmapReferenceCounter.invalidate(it.bitmap) }
     }
 
-    override fun remove(key: String) {
-        val cacheKey = Key(key)
-        strongMemoryCache.remove(cacheKey)
-        weakMemoryCache.remove(cacheKey)
+    override fun remove(key: Key) {
+        strongMemoryCache.remove(key)
+        weakMemoryCache.remove(key)
     }
 
     override fun clear() {

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -2,9 +2,10 @@ package coil.memory
 
 import android.graphics.Bitmap
 import coil.ComponentRegistry
-import coil.memory.MemoryCache.Criteria
+import coil.annotation.ExperimentalCoilApi
 import coil.memory.StrongMemoryCache.Key
 
+@OptIn(ExperimentalCoilApi::class)
 internal class RealMemoryCache(
     private val componentRegistry: ComponentRegistry,
     private val strongMemoryCache: StrongMemoryCache,
@@ -16,19 +17,10 @@ internal class RealMemoryCache(
 
     override val maxSize get() = strongMemoryCache.maxSize
 
-    override fun find(key: String): Bitmap? {
-        return invalidate(strongMemoryCache.get(Key(key))?.bitmap)
-    }
-
-    override fun find(criteria: Criteria): Bitmap? {
-        val predicate = criteria.toPredicate()
-        strongMemoryCache.find(predicate)?.let {
-            return invalidate(strongMemoryCache.get(it)?.bitmap)
-        }
-        weakMemoryCache.find(predicate)?.let {
-            return invalidate(weakMemoryCache.get(it)?.bitmap)
-        }
-        return null
+    override fun get(key: String): Bitmap? {
+        val cacheKey = Key(key)
+        val value = strongMemoryCache.get(cacheKey) ?: weakMemoryCache.get(cacheKey)
+        return value?.bitmap?.also(bitmapReferenceCounter::invalidate)
     }
 
     override fun remove(key: String) {
@@ -37,37 +29,8 @@ internal class RealMemoryCache(
         weakMemoryCache.remove(cacheKey)
     }
 
-    override fun remove(criteria: Criteria) {
-        val predicate = criteria.toPredicate()
-        strongMemoryCache.find(predicate)?.let(strongMemoryCache::remove)
-        weakMemoryCache.find(predicate)?.let(weakMemoryCache::remove)
-    }
-
     override fun clear() {
         strongMemoryCache.clearMemory()
         weakMemoryCache.clearMemory()
-    }
-
-    private fun invalidate(bitmap: Bitmap?): Bitmap? {
-        if (bitmap != null) {
-            bitmapReferenceCounter.invalidate(bitmap)
-        }
-        return bitmap
-    }
-
-    private fun Criteria.toPredicate(): (Key) -> Boolean {
-        TODO()
-        /*val mappedData = componentRegistry.mapData(data) { measuredMapper ->
-            checkNotNull(size) { "'$measuredMapper' requires a non null size to map '$data'." }
-        }
-        val baseKey = componentRegistry.requireFetcher(mappedData).key(mappedData)
-        val transformationKeys = transformations?.mapIndices { it.key() }
-        val parameterKeys = parameters?.cacheKeys()
-        return { key ->
-            baseKey == key.baseKey &&
-                transformationKeys == null || transformationKeys == key.transformationKeys &&
-                parameterKeys == null || parameterKeys == key.parameterKeys
-                size == null || size == key.size
-        }*/
     }
 }

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -4,9 +4,6 @@ import android.graphics.Bitmap
 import coil.ComponentRegistry
 import coil.memory.MemoryCache.Criteria
 import coil.memory.StrongMemoryCache.Key
-import coil.util.assertMainThread
-import coil.util.mapData
-import coil.util.mapIndices
 
 internal class RealMemoryCache(
     private val componentRegistry: ComponentRegistry,
@@ -15,27 +12,15 @@ internal class RealMemoryCache(
     private val bitmapReferenceCounter: BitmapReferenceCounter
 ) : MemoryCache {
 
-    override val size: Int
-        get() {
-            assertMainThread()
-            return strongMemoryCache.size
-        }
+    override val size get() = strongMemoryCache.size
 
-    override val maxSize: Int
-        get() {
-            assertMainThread()
-            return strongMemoryCache.maxSize
-        }
+    override val maxSize get() = strongMemoryCache.maxSize
 
     override fun find(key: String): Bitmap? {
-        assertMainThread()
-
         return invalidate(strongMemoryCache.get(Key(key))?.bitmap)
     }
 
     override fun find(criteria: Criteria): Bitmap? {
-        assertMainThread()
-
         val predicate = criteria.toPredicate()
         strongMemoryCache.find(predicate)?.let {
             return invalidate(strongMemoryCache.get(it)?.bitmap)
@@ -47,24 +32,18 @@ internal class RealMemoryCache(
     }
 
     override fun remove(key: String) {
-        assertMainThread()
-
         val cacheKey = Key(key)
         strongMemoryCache.remove(cacheKey)
         weakMemoryCache.remove(cacheKey)
     }
 
     override fun remove(criteria: Criteria) {
-        assertMainThread()
-
         val predicate = criteria.toPredicate()
         strongMemoryCache.find(predicate)?.let(strongMemoryCache::remove)
         weakMemoryCache.find(predicate)?.let(weakMemoryCache::remove)
     }
 
     override fun clear() {
-        assertMainThread()
-
         strongMemoryCache.clearMemory()
         weakMemoryCache.clearMemory()
     }
@@ -77,7 +56,8 @@ internal class RealMemoryCache(
     }
 
     private fun Criteria.toPredicate(): (Key) -> Boolean {
-        val mappedData = componentRegistry.mapData(data) { measuredMapper ->
+        TODO()
+        /*val mappedData = componentRegistry.mapData(data) { measuredMapper ->
             checkNotNull(size) { "'$measuredMapper' requires a non null size to map '$data'." }
         }
         val baseKey = componentRegistry.requireFetcher(mappedData).key(mappedData)
@@ -88,6 +68,6 @@ internal class RealMemoryCache(
                 transformationKeys == null || transformationKeys == key.transformationKeys &&
                 parameterKeys == null || parameterKeys == key.parameterKeys
                 size == null || size == key.size
-        }
+        }*/
     }
 }

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -1,11 +1,11 @@
 package coil.memory
 
-import coil.ComponentRegistry
+import android.graphics.Bitmap
+import coil.annotation.ExperimentalCoilApi
 import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
 
+@OptIn(ExperimentalCoilApi::class)
 internal class RealMemoryCache(
-    private val componentRegistry: ComponentRegistry,
     private val strongMemoryCache: StrongMemoryCache,
     private val weakMemoryCache: WeakMemoryCache,
     private val bitmapReferenceCounter: BitmapReferenceCounter
@@ -15,18 +15,25 @@ internal class RealMemoryCache(
 
     override val maxSize get() = strongMemoryCache.maxSize
 
-    override fun get(key: Key): Value? {
+    override fun get(key: Key): Bitmap? {
         val value = strongMemoryCache.get(key) ?: weakMemoryCache.get(key)
-        return value?.also { bitmapReferenceCounter.invalidate(it.bitmap) }
+        return value?.bitmap?.also { bitmapReferenceCounter.invalidate(it) }
     }
 
-    override fun remove(key: Key) {
-        strongMemoryCache.remove(key)
-        weakMemoryCache.remove(key)
+    override fun remove(key: Key): Boolean {
+        // Do not short circuit.
+        val removedStrong = strongMemoryCache.remove(key)
+        val removedWeak = weakMemoryCache.remove(key)
+        return removedStrong || removedWeak
     }
 
     override fun clear() {
         strongMemoryCache.clearMemory()
         weakMemoryCache.clearMemory()
+    }
+
+    interface Value {
+        val bitmap: Bitmap
+        val isSampled: Boolean
     }
 }

--- a/coil-base/src/main/java/coil/memory/RealPublicMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealPublicMemoryCache.kt
@@ -1,0 +1,85 @@
+package coil.memory
+
+import android.graphics.Bitmap
+import coil.ComponentRegistry
+import coil.memory.PublicMemoryCache.Criteria
+import coil.util.assertMainThread
+import coil.util.mapData
+import coil.util.mapIndices
+
+internal class RealPublicMemoryCache(
+    private val componentRegistry: ComponentRegistry,
+    private val memoryCache: MemoryCache,
+    private val weakMemoryCache: WeakMemoryCache,
+    private val bitmapReferenceCounter: BitmapReferenceCounter
+) : PublicMemoryCache {
+
+    override val size: Int
+        get() {
+            assertMainThread()
+            return memoryCache.size
+        }
+
+    override val maxSize: Int
+        get() {
+            assertMainThread()
+            return memoryCache.maxSize
+        }
+
+    override fun find(key: String): Bitmap? {
+        assertMainThread()
+
+        val bitmap = memoryCache.get(MemoryCache.Key(key))?.bitmap
+        if (bitmap != null) {
+            bitmapReferenceCounter.invalidate(bitmap)
+        }
+        return bitmap
+    }
+
+    override fun find(criteria: Criteria): Bitmap? {
+        assertMainThread()
+
+        val predicate = criteria.toPredicate()
+        memoryCache.find(predicate)?.let { return memoryCache.get(it)?.bitmap }
+        weakMemoryCache.find(predicate)?.let { return weakMemoryCache.get(it)?.bitmap }
+        return null
+    }
+
+    override fun remove(key: String) {
+        assertMainThread()
+
+        val cacheKey = MemoryCache.Key(key)
+        memoryCache.remove(cacheKey)
+        weakMemoryCache.remove(cacheKey)
+    }
+
+    override fun remove(criteria: Criteria) {
+        assertMainThread()
+
+        val predicate = criteria.toPredicate()
+        memoryCache.find(predicate)?.let(memoryCache::remove)
+        weakMemoryCache.find(predicate)?.let(weakMemoryCache::remove)
+    }
+
+    override fun clear() {
+        assertMainThread()
+
+        memoryCache.clearMemory()
+        weakMemoryCache.clearMemory()
+    }
+
+    private fun Criteria.toPredicate(): (MemoryCache.Key) -> Boolean {
+        val mappedData = componentRegistry.mapData(data) { measuredMapper ->
+            checkNotNull(size) { "'$measuredMapper' requires a non null size to map '$data'." }
+        }
+        val baseKey = componentRegistry.requireFetcher(mappedData).key(mappedData)
+        val transformationKeys = transformations?.mapIndices { it.key() }
+        val parameterKeys = parameters?.cacheKeys()
+        return { key ->
+            baseKey == key.baseKey &&
+                transformationKeys == null || transformationKeys == key.transformationKeys &&
+                parameterKeys == null || parameterKeys == key.parameterKeys
+                size == null || size == key.size
+        }
+    }
+}

--- a/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
@@ -213,7 +213,7 @@ private class RealStrongMemoryCache(
     }
 
     override fun remove(key: Key) {
-        logger?.log(TAG, Log.VERBOSE) { "invalidate, key=$key" }
+        logger?.log(TAG, Log.VERBOSE) { "remove, key=$key" }
         cache.remove(key)
     }
 

--- a/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
@@ -7,16 +7,11 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.collection.LruCache
-import coil.fetch.Fetcher
-import coil.memory.StrongMemoryCache.Key
-import coil.memory.StrongMemoryCache.Value
-import coil.request.Parameters
-import coil.size.Size
-import coil.transform.Transformation
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 import coil.util.Logger
 import coil.util.allocationByteCountCompat
 import coil.util.log
-import coil.util.mapIndices
 
 /** An in-memory cache that holds strong references [Bitmap]s. */
 internal interface StrongMemoryCache {
@@ -56,72 +51,6 @@ internal interface StrongMemoryCache {
 
     /** @see ComponentCallbacks2.onTrimMemory */
     fun trimMemory(level: Int)
-
-    /** Cache key for [StrongMemoryCache] and [WeakMemoryCache]. */
-    class Key {
-
-        /** The base component of the cache key. This is typically [Fetcher.key]. */
-        val baseKey: String
-
-        /** An ordered list of [Transformation.key]s. */
-        val transformationKeys: List<String>
-
-        /** The resolved size for the request. This is null if [transformationKeys] is empty. */
-        val size: Size?
-
-        /** @see Parameters.cacheKeys */
-        val parameterKeys: Map<String, String>
-
-        constructor(
-            baseKey: String,
-            parameters: Parameters = Parameters.EMPTY
-        ) {
-            this.baseKey = baseKey
-            this.transformationKeys = emptyList()
-            this.size = null
-            this.parameterKeys = parameters.cacheKeys()
-        }
-
-        constructor(
-            baseKey: String,
-            transformations: List<Transformation>,
-            size: Size,
-            parameters: Parameters = Parameters.EMPTY
-        ) {
-            this.baseKey = baseKey
-            if (transformations.isEmpty()) {
-                this.transformationKeys = emptyList()
-                this.size = null
-            } else {
-                this.transformationKeys = transformations.mapIndices { it.key() }
-                this.size = size
-            }
-            this.parameterKeys = parameters.cacheKeys()
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            return other is Key &&
-                baseKey == other.baseKey &&
-                transformationKeys == other.transformationKeys &&
-                size == other.size &&
-                parameterKeys == other.parameterKeys
-        }
-
-        override fun hashCode(): Int {
-            var result = baseKey.hashCode()
-            result = 31 * result + transformationKeys.hashCode()
-            result = 31 * result + (size?.hashCode() ?: 0)
-            result = 31 * result + parameterKeys.hashCode()
-            return result
-        }
-    }
-
-    /** Cache value for [StrongMemoryCache] and [WeakMemoryCache]. */
-    interface Value {
-        val bitmap: Bitmap
-        val isSampled: Boolean
-    }
 }
 
 /** A [StrongMemoryCache] implementation that caches nothing. */

--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -6,8 +6,8 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
 import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.VisibleForTesting
-import coil.memory.StrongMemoryCache.Key
-import coil.memory.StrongMemoryCache.Value
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 import coil.util.firstNotNullIndices
 import coil.util.identityHashCode
 import coil.util.removeIfIndices
@@ -101,6 +101,7 @@ internal class RealWeakMemoryCache : WeakMemoryCache {
         cleanUpIfNecessary()
     }
 
+    @Synchronized
     override fun remove(key: Key) {
         val value = get(key)
         if (value != null) {

--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -6,8 +6,8 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
 import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.VisibleForTesting
-import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
+import coil.memory.StrongMemoryCache.Key
+import coil.memory.StrongMemoryCache.Value
 import coil.util.firstNotNullIndices
 import coil.util.identityHashCode
 import coil.util.removeIfIndices
@@ -16,8 +16,8 @@ import java.lang.ref.WeakReference
 /**
  * An in-memory cache that holds weak references to [Bitmap]s.
  *
- * This is used as a secondary caching layer for [MemoryCache]. [MemoryCache] holds strong references to its bitmaps.
- * Bitmaps are added to this cache when they're removed from [MemoryCache].
+ * This is used as a secondary caching layer for [StrongMemoryCache]. [StrongMemoryCache] holds strong references
+ * to its bitmaps. Bitmaps are added to this cache when they're removed from [StrongMemoryCache].
  *
  * NOTE: This class is not thread safe and its methods should only be called from the main thread.
  */

--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -63,7 +63,7 @@ internal object EmptyWeakMemoryCache : WeakMemoryCache {
     override fun trimMemory(level: Int) {}
 }
 
-/** A [WeakMemoryCache] implementation backed by a [HashMap]. */
+/** A [WeakMemoryCache] implementation backed by a [MutableMap]. */
 internal class RealWeakMemoryCache : WeakMemoryCache {
 
     @VisibleForTesting internal val cache = hashMapOf<Key, ArrayList<WeakValue>>()

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -25,7 +25,6 @@ import coil.fetch.Fetcher
 import coil.memory.MemoryCache
 import coil.memory.RequestService
 import coil.request.ImageRequest.Builder
-import coil.request.SuccessResult.Metadata
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Precision

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -378,6 +378,7 @@ class ImageRequest private constructor(
         /**
          * Set the cache key for this request.
          */
+        @ExperimentalCoilApi
         fun key(key: MemoryCache.Key?) = apply {
             this.key = key
         }

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -19,13 +19,13 @@ import androidx.lifecycle.LifecycleOwner
 import coil.ComponentRegistry
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.drawable.CrossfadeDrawable
 import coil.fetch.Fetcher
 import coil.memory.MemoryCache
 import coil.memory.RequestService
 import coil.request.ImageRequest.Builder
+import coil.request.SuccessResult.Metadata
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Precision
@@ -233,7 +233,7 @@ class ImageRequest private constructor(
          * Called if the request completes successfully.
          */
         @MainThread
-        fun onSuccess(request: ImageRequest, source: DataSource) {}
+        fun onSuccess(request: ImageRequest, metadata: Metadata) {}
 
         /**
          * Called if the request is cancelled.
@@ -359,10 +359,10 @@ class ImageRequest private constructor(
          *
          * The default supported data types are:
          * - [String] (mapped to a [Uri])
-         * - [HttpUrl]
          * - [Uri] ("android.resource", "content", "file", "http", and "https" schemes only)
+         * - [HttpUrl]
          * - [File]
-         * - @DrawableRes [Int]
+         * - [DrawableRes]
          * - [Drawable]
          * - [Bitmap]
          */
@@ -372,11 +372,14 @@ class ImageRequest private constructor(
 
         /**
          * Set the cache key for this request.
-         *
-         * By default, the cache key is computed by the [Fetcher], any [Parameters], and any [Transformation]s.
          */
-        fun key(key: String?) = apply {
-            this.key = key?.let { MemoryCache.Key(it) }
+        fun key(key: String?) = key(key?.let { MemoryCache.Key(it) })
+
+        /**
+         * Set the cache key for this request.
+         */
+        fun key(key: MemoryCache.Key?) = apply {
+            this.key = key
         }
 
         /**
@@ -386,12 +389,12 @@ class ImageRequest private constructor(
             crossinline onStart: (request: ImageRequest) -> Unit = {},
             crossinline onCancel: (request: ImageRequest) -> Unit = {},
             crossinline onError: (request: ImageRequest, throwable: Throwable) -> Unit = { _, _ -> },
-            crossinline onSuccess: (request: ImageRequest, source: DataSource) -> Unit = { _, _ -> }
+            crossinline onSuccess: (request: ImageRequest, metadata: Metadata) -> Unit = { _, _ -> }
         ) = listener(object : Listener {
             override fun onStart(request: ImageRequest) = onStart(request)
             override fun onCancel(request: ImageRequest) = onCancel(request)
             override fun onError(request: ImageRequest, throwable: Throwable) = onError(request, throwable)
-            override fun onSuccess(request: ImageRequest, source: DataSource) = onSuccess(request, source)
+            override fun onSuccess(request: ImageRequest, metadata: Metadata) = onSuccess(request, metadata)
         })
 
         /**

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -23,6 +23,7 @@ import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.drawable.CrossfadeDrawable
 import coil.fetch.Fetcher
+import coil.memory.MemoryCache
 import coil.memory.RequestService
 import coil.request.ImageRequest.Builder
 import coil.size.OriginalSize
@@ -57,7 +58,7 @@ class ImageRequest private constructor(
     val data: Any?,
 
     /** @see Builder.key */
-    val key: String?,
+    val key: MemoryCache.Key?,
 
     /** @see Builder.target */
     val target: Target?,
@@ -251,7 +252,7 @@ class ImageRequest private constructor(
 
         private val context: Context
         private var data: Any?
-        private var key: String?
+        private var key: MemoryCache.Key?
 
         private var target: Target?
         private var listener: Listener?
@@ -375,7 +376,7 @@ class ImageRequest private constructor(
          * By default, the cache key is computed by the [Fetcher], any [Parameters], and any [Transformation]s.
          */
         fun key(key: String?) = apply {
-            this.key = key
+            this.key = key?.let { MemoryCache.Key(it) }
         }
 
         /**

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -1,0 +1,18 @@
+@file:OptIn(ExperimentalCoilApi::class)
+
+package coil.request
+
+import coil.annotation.ExperimentalCoilApi
+import coil.decode.DataSource
+import coil.memory.MemoryCache
+
+/**
+ * Supplemental information about a successful image request.
+ *
+ * @param key The cache key for the image in the memory cache.
+ * @param source The data source that the image was loaded from.
+ */
+data class Metadata(
+    val key: MemoryCache.Key?,
+    val source: DataSource
+)

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -10,9 +10,10 @@ import coil.memory.MemoryCache
  * Supplemental information about a successful image request.
  *
  * @param key The cache key for the image in the memory cache.
- * @param source The data source that the image was loaded from.
+ *  It is null if the image was not written to the memory cache.
+ * @param dataSource The data source that the image was loaded from.
  */
 data class Metadata(
     val key: MemoryCache.Key?,
-    val source: DataSource
+    val dataSource: DataSource
 )

--- a/coil-base/src/main/java/coil/request/RequestResult.kt
+++ b/coil-base/src/main/java/coil/request/RequestResult.kt
@@ -1,12 +1,8 @@
-@file:OptIn(ExperimentalCoilApi::class)
-
 package coil.request
 
 import android.graphics.drawable.Drawable
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
-import coil.memory.MemoryCache
 
 /**
  * Represents the result of an image request.
@@ -29,21 +25,10 @@ data class SuccessResult(
 ) : RequestResult() {
 
     @Deprecated(
-        message = "Moved to SuccessResult.Metadata.",
-        replaceWith = ReplaceWith("info.source")
+        message = "Moved to Metadata.",
+        replaceWith = ReplaceWith("metadata.source")
     )
     val source: DataSource get() = metadata.source
-
-    /**
-     * Supplemental information about the request.
-     *
-     * @param key The cache key for the image in the memory cache.
-     * @param source The data source that the image was loaded from.
-     */
-    data class Metadata(
-        val key: MemoryCache.Key?,
-        val source: DataSource
-    )
 }
 
 /**

--- a/coil-base/src/main/java/coil/request/RequestResult.kt
+++ b/coil-base/src/main/java/coil/request/RequestResult.kt
@@ -26,9 +26,9 @@ data class SuccessResult(
 
     @Deprecated(
         message = "Moved to Metadata.",
-        replaceWith = ReplaceWith("metadata.source")
+        replaceWith = ReplaceWith("metadata.dataSource")
     )
-    val source: DataSource get() = metadata.source
+    val source: DataSource get() = metadata.dataSource
 }
 
 /**

--- a/coil-base/src/main/java/coil/request/RequestResult.kt
+++ b/coil-base/src/main/java/coil/request/RequestResult.kt
@@ -1,8 +1,12 @@
+@file:OptIn(ExperimentalCoilApi::class)
+
 package coil.request
 
 import android.graphics.drawable.Drawable
 import coil.ImageLoader
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
+import coil.memory.MemoryCache
 
 /**
  * Represents the result of an image request.
@@ -17,12 +21,30 @@ sealed class RequestResult {
  * Indicates that the request completed successfully.
  *
  * @param drawable The result drawable.
- * @param source The data source that the image was loaded from.
+ * @param metadata Metadata about the request that created this response.
  */
 data class SuccessResult(
     override val drawable: Drawable,
-    val source: DataSource
-) : RequestResult()
+    val metadata: Metadata
+) : RequestResult() {
+
+    @Deprecated(
+        message = "Moved to SuccessResult.Metadata.",
+        replaceWith = ReplaceWith("info.source")
+    )
+    val source: DataSource get() = metadata.source
+
+    /**
+     * Supplemental information about the request.
+     *
+     * @param key The cache key for the image in the memory cache.
+     * @param source The data source that the image was loaded from.
+     */
+    data class Metadata(
+        val key: MemoryCache.Key?,
+        val source: DataSource
+    )
+}
 
 /**
  * Indicates that an error occurred while executing the request.

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -30,7 +30,7 @@ class CrossfadeTransition @JvmOverloads constructor(
         result: RequestResult
     ) {
         // Don't animate if the request was fulfilled by the memory cache.
-        if (result is SuccessResult && result.source == DataSource.MEMORY_CACHE) {
+        if (result is SuccessResult && result.metadata.source == DataSource.MEMORY_CACHE) {
             target.onSuccess(result.drawable)
             return
         }

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -30,7 +30,7 @@ class CrossfadeTransition @JvmOverloads constructor(
         result: RequestResult
     ) {
         // Don't animate if the request was fulfilled by the memory cache.
-        if (result is SuccessResult && result.metadata.source == DataSource.MEMORY_CACHE) {
+        if (result is SuccessResult && result.metadata.dataSource == DataSource.MEMORY_CACHE) {
             target.onSuccess(result.drawable)
             return
         }

--- a/coil-base/src/main/java/coil/util/Collections.kt
+++ b/coil-base/src/main/java/coil/util/Collections.kt
@@ -92,7 +92,7 @@ internal inline fun <T> MutableList<T>.removeIfIndices(predicate: (T) -> Boolean
  */
 internal inline fun <K, V, R : Any> Map<K, V>.mapNotNullValues(transform: (Map.Entry<K, V>) -> R?): Map<K, R> {
     val destination = mutableMapOf<K, R>()
-    for (entry in this) {
+    for (entry in entries) {
         val value = transform(entry)
         if (value != null) {
             destination[entry.key] = value

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -24,6 +24,7 @@ import android.widget.ImageView.ScaleType.FIT_START
 import androidx.core.view.ViewCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.ComponentRegistry
+import coil.annotation.ExperimentalCoilApi
 import coil.base.R
 import coil.decode.DataSource
 import coil.map.Mapper
@@ -62,6 +63,7 @@ internal inline val StatFs.blockCountCompat: Long
 internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
 
+@OptIn(ExperimentalCoilApi::class)
 internal fun StrongMemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
     if (key != null) {
         val bitmap = (value as? BitmapDrawable)?.bitmap

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -166,29 +166,8 @@ internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY
 
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()
 
-internal fun assertMainThread() {
-    check(isMainThread()) { "This method can only be called from the main thread." }
-}
-
 internal inline val Any.identityHashCode: Int
     get() = System.identityHashCode(this)
-
-/** Map [data] using the components registered in this [ComponentRegistry]. */
-@Suppress("UNCHECKED_CAST")
-internal inline fun ComponentRegistry.mapData(data: Any, size: (MeasuredMapper<*, *>) -> Size): Any {
-    var mappedData = data
-    measuredMappers.forEachIndices { (type, mapper) ->
-        if (type.isAssignableFrom(mappedData::class.java) && (mapper as MeasuredMapper<Any, *>).handles(mappedData)) {
-            mappedData = mapper.map(mappedData, size(mapper))
-        }
-    }
-    mappers.forEachIndices { (type, mapper) ->
-        if (type.isAssignableFrom(mappedData::class.java) && (mapper as Mapper<Any, *>).handles(mappedData)) {
-            mappedData = mapper.map(mappedData)
-        }
-    }
-    return mappedData
-}
 
 internal inline fun AtomicInteger.loop(action: (Int) -> Unit) {
     while (true) action(get())

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -61,9 +61,7 @@ internal inline val StatFs.blockCountCompat: Long
 internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
 
-internal fun MemoryCache.get(key: MemoryCache.Key?): MemoryCache.Value? = key?.let(::get)
-
-internal fun MemoryCache.put(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
+internal fun MemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
     if (key != null) {
         val bitmap = (value as? BitmapDrawable)?.bitmap
         if (bitmap != null) {
@@ -168,8 +166,29 @@ internal fun Parameters?.orEmpty() = this ?: Parameters.EMPTY
 
 internal fun isMainThread() = Looper.myLooper() == Looper.getMainLooper()
 
+internal fun assertMainThread() {
+    check(isMainThread()) { "This method can only be called from the main thread." }
+}
+
 internal inline val Any.identityHashCode: Int
     get() = System.identityHashCode(this)
+
+/** Map [data] using the components registered in this [ComponentRegistry]. */
+@Suppress("UNCHECKED_CAST")
+internal inline fun ComponentRegistry.mapData(data: Any, size: (MeasuredMapper<*, *>) -> Size): Any {
+    var mappedData = data
+    measuredMappers.forEachIndices { (type, mapper) ->
+        if (type.isAssignableFrom(mappedData::class.java) && (mapper as MeasuredMapper<Any, *>).handles(mappedData)) {
+            mappedData = mapper.map(mappedData, size(mapper))
+        }
+    }
+    mappers.forEachIndices { (type, mapper) ->
+        if (type.isAssignableFrom(mappedData::class.java) && (mapper as Mapper<Any, *>).handles(mappedData)) {
+            mappedData = mapper.map(mappedData)
+        }
+    }
+    return mappedData
+}
 
 internal inline fun AtomicInteger.loop(action: (Int) -> Unit) {
     while (true) action(get())

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -28,7 +28,7 @@ import coil.base.R
 import coil.decode.DataSource
 import coil.map.Mapper
 import coil.map.MeasuredMapper
-import coil.memory.MemoryCache
+import coil.memory.StrongMemoryCache
 import coil.memory.ViewTargetRequestManager
 import coil.request.Parameters
 import coil.size.Scale
@@ -61,7 +61,7 @@ internal inline val StatFs.blockCountCompat: Long
 internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
 
-internal fun MemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
+internal fun StrongMemoryCache.set(key: StrongMemoryCache.Key?, value: Drawable, isSampled: Boolean) {
     if (key != null) {
         val bitmap = (value as? BitmapDrawable)?.bitmap
         if (bitmap != null) {

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -65,13 +65,15 @@ internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
 
 @OptIn(ExperimentalCoilApi::class)
-internal fun StrongMemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
+internal fun StrongMemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean): Boolean {
     if (key != null) {
         val bitmap = (value as? BitmapDrawable)?.bitmap
         if (bitmap != null) {
             set(key, bitmap, isSampled)
+            return true
         }
     }
+    return false
 }
 
 internal inline fun <T> takeIf(take: Boolean, factory: () -> T): T? {

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -35,6 +35,7 @@ import coil.memory.ViewTargetRequestManager
 import coil.request.Parameters
 import coil.size.Scale
 import coil.size.Size
+import coil.transform.Transformation
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
@@ -192,4 +193,32 @@ internal inline fun ComponentRegistry.mapData(data: Any, lazySize: () -> Size): 
         }
     }
     return mappedData
+}
+
+@OptIn(ExperimentalCoilApi::class)
+internal inline operator fun MemoryCache.Key.Companion.invoke(
+    base: String,
+    transformations: List<Transformation>,
+    size: Size,
+    parameters: Parameters
+): MemoryCache.Key {
+    return MemoryCache.Key.Complex(
+        base = base,
+        transformations = transformations.mapIndices { it.key() },
+        size = size,
+        parameters = parameters.cacheKeys()
+    )
+}
+
+@OptIn(ExperimentalCoilApi::class)
+internal inline operator fun MemoryCache.Key.Companion.invoke(
+    base: String,
+    parameters: Parameters
+): MemoryCache.Key {
+    return MemoryCache.Key.Complex(
+        base = base,
+        transformations = emptyList(),
+        size = null,
+        parameters = parameters.cacheKeys()
+    )
 }

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -28,6 +28,7 @@ import coil.base.R
 import coil.decode.DataSource
 import coil.map.Mapper
 import coil.map.MeasuredMapper
+import coil.memory.MemoryCache
 import coil.memory.StrongMemoryCache
 import coil.memory.ViewTargetRequestManager
 import coil.request.Parameters
@@ -61,7 +62,7 @@ internal inline val StatFs.blockCountCompat: Long
 internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
 
-internal fun StrongMemoryCache.set(key: StrongMemoryCache.Key?, value: Drawable, isSampled: Boolean) {
+internal fun StrongMemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean) {
     if (key != null) {
         val bitmap = (value as? BitmapDrawable)?.bitmap
         if (bitmap != null) {

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -63,9 +63,9 @@ class RealImageLoaderBasicTest {
     fun before() {
         context = ApplicationProvider.getApplicationContext()
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
-        val weakMemoryCache = RealWeakMemoryCache()
+        val weakMemoryCache = RealWeakMemoryCache(null)
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        strongMemoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE)
+        strongMemoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -16,9 +16,9 @@ import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.fetch.Fetcher
 import coil.memory.BitmapReferenceCounter
 import coil.memory.EmptyTargetDelegate
+import coil.memory.MemoryCache.Key
 import coil.memory.RealWeakMemoryCache
 import coil.memory.StrongMemoryCache
-import coil.memory.StrongMemoryCache.Key
 import coil.request.ImageRequest
 import coil.request.Parameters
 import coil.size.OriginalSize

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -16,9 +16,9 @@ import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.fetch.Fetcher
 import coil.memory.BitmapReferenceCounter
 import coil.memory.EmptyTargetDelegate
-import coil.memory.MemoryCache
-import coil.memory.MemoryCache.Key
 import coil.memory.RealWeakMemoryCache
+import coil.memory.StrongMemoryCache
+import coil.memory.StrongMemoryCache.Key
 import coil.request.ImageRequest
 import coil.request.Parameters
 import coil.size.OriginalSize
@@ -55,7 +55,7 @@ import kotlin.test.fail
 class RealImageLoaderBasicTest {
 
     private lateinit var context: Context
-    private lateinit var memoryCache: MemoryCache
+    private lateinit var strongMemoryCache: StrongMemoryCache
     private lateinit var imageLoader: RealImageLoader
 
     @Before
@@ -64,13 +64,13 @@ class RealImageLoaderBasicTest {
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
         val weakMemoryCache = RealWeakMemoryCache()
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        memoryCache = MemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
+        strongMemoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
         imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),
             bitmapPool = bitmapPool,
             referenceCounter = referenceCounter,
-            memoryCache = memoryCache,
+            strongMemoryCache = strongMemoryCache,
             weakMemoryCache = weakMemoryCache,
             callFactory = OkHttpClient(),
             eventListenerFactory = EventListener.Factory.NONE,
@@ -283,7 +283,7 @@ class RealImageLoaderBasicTest {
         val options = BitmapFactory.Options().apply { inPreferredConfig = Bitmap.Config.HARDWARE }
         val bitmap = context.decodeBitmapAsset(fileName, options)
         assertEquals(Bitmap.Config.HARDWARE, bitmap.config)
-        memoryCache.set(key, bitmap, false)
+        strongMemoryCache.set(key, bitmap, false)
         return bitmap
     }
 }

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -64,7 +64,7 @@ class RealImageLoaderBasicTest {
         val bitmapPool = BitmapPool(Int.MAX_VALUE)
         val weakMemoryCache = RealWeakMemoryCache()
         val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null)
-        strongMemoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE, null)
+        strongMemoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, Int.MAX_VALUE)
         imageLoader = RealImageLoader(
             context = context,
             defaults = DefaultRequestOptions(),
@@ -94,7 +94,7 @@ class RealImageLoaderBasicTest {
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
                 val request = ImageRequest.Builder(context)
-                    .key(key.baseKey)
+                    .key(key.base)
                     .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                     .size(100, 100)
                     .precision(Precision.INEXACT)
@@ -130,7 +130,7 @@ class RealImageLoaderBasicTest {
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
                 val request = ImageRequest.Builder(context)
-                    .key(key.baseKey)
+                    .key(key.base)
                     .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                     .size(100, 100)
                     .precision(Precision.INEXACT)
@@ -199,7 +199,7 @@ class RealImageLoaderBasicTest {
             imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, transformations, sizeResolver)
         }
 
-        assertEquals(Key("base_key", transformations, size), result)
+        assertEquals(Key("base_key", transformations, size, Parameters.EMPTY), result)
     }
 
     @Test

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -168,14 +168,14 @@ class RealImageLoaderBasicTest {
     }
 
     @Test
-    fun `computeCacheKey - basic key`() {
+    fun `computeCacheKey - simple key`() {
         val fetcher = createFakeFetcher()
         val sizeResolver = createFakeLazySizeResolver()
         val result = runBlocking {
             imageLoader.computeCacheKey(fetcher, Unit, Parameters.EMPTY, emptyList(), sizeResolver)
         }
 
-        assertEquals(Key("base_key"), result)
+        assertEquals(Key("base_key", Parameters.EMPTY), result)
     }
 
     @Test

--- a/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
+++ b/coil-base/src/test/java/coil/RealImageLoaderBasicTest.kt
@@ -29,6 +29,7 @@ import coil.size.SizeResolver
 import coil.transform.Transformation
 import coil.util.createRequest
 import coil.util.decodeBitmapAsset
+import coil.util.invoke
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -94,7 +95,7 @@ class RealImageLoaderBasicTest {
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
                 val request = ImageRequest.Builder(context)
-                    .key(key.base)
+                    .key("fake_key")
                     .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                     .size(100, 100)
                     .precision(Precision.INEXACT)
@@ -130,7 +131,7 @@ class RealImageLoaderBasicTest {
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
                 val request = ImageRequest.Builder(context)
-                    .key(key.base)
+                    .key("fake_key")
                     .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                     .size(100, 100)
                     .precision(Precision.INEXACT)

--- a/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
@@ -1,7 +1,7 @@
 package coil.memory
 
 import coil.bitmappool.BitmapPool
-import coil.memory.MemoryCache.Key
+import coil.memory.StrongMemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.count
 import coil.util.createBitmap

--- a/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
@@ -1,7 +1,7 @@
 package coil.memory
 
 import coil.bitmappool.BitmapPool
-import coil.memory.StrongMemoryCache.Key
+import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.count
 import coil.util.createBitmap

--- a/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
@@ -25,7 +25,7 @@ class BitmapReferenceCounterTest {
 
     @Before
     fun before() {
-        weakMemoryCache = RealWeakMemoryCache()
+        weakMemoryCache = RealWeakMemoryCache(null)
         pool = BitmapPool(DEFAULT_BITMAP_SIZE)
         counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
     }

--- a/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/memory/BitmapReferenceCounterTest.kt
@@ -1,5 +1,6 @@
 package coil.memory
 
+import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
@@ -15,6 +16,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoilApi::class)
 class BitmapReferenceCounterTest {
 
     private lateinit var weakMemoryCache: WeakMemoryCache

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -5,8 +5,8 @@ import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
 import coil.DefaultRequestOptions
 import coil.annotation.ExperimentalCoilApi
-import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
+import coil.memory.StrongMemoryCache.Key
+import coil.memory.StrongMemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.PixelSize
 import coil.size.Precision

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -5,8 +5,8 @@ import android.graphics.Bitmap
 import androidx.test.core.app.ApplicationProvider
 import coil.DefaultRequestOptions
 import coil.annotation.ExperimentalCoilApi
-import coil.memory.StrongMemoryCache.Key
-import coil.memory.StrongMemoryCache.Value
+import coil.memory.MemoryCache.Key
+import coil.memory.MemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.PixelSize
 import coil.size.Precision

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -8,6 +8,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.memory.MemoryCache.Key
 import coil.memory.RealMemoryCache.Value
 import coil.request.ImageRequest
+import coil.request.Parameters
 import coil.size.PixelSize
 import coil.size.Precision
 import coil.size.Scale
@@ -16,6 +17,7 @@ import coil.size.SizeResolver
 import coil.transform.CircleCropTransformation
 import coil.util.createBitmap
 import coil.util.createRequest
+import coil.util.invoke
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -286,7 +288,7 @@ class MemoryCacheServiceTest {
     fun `isCachedValueValid - transformation that reduces size of output bitmap`() {
         val transformations = listOf(CircleCropTransformation())
         val cachedSize = PixelSize(1000, 500) // The size of the previous request.
-        val key = Key("key", transformations, cachedSize)
+        val key = Key("key", transformations, cachedSize, Parameters.EMPTY)
         val value = object : Value {
             override val bitmap = createBitmap(width = 200, height = 200) // The small cached bitmap.
             override val isSampled = true

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -6,7 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import coil.DefaultRequestOptions
 import coil.annotation.ExperimentalCoilApi
 import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
+import coil.memory.RealMemoryCache.Value
 import coil.request.ImageRequest
 import coil.size.PixelSize
 import coil.size.Precision

--- a/coil-base/src/test/java/coil/memory/MemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheTest.kt
@@ -68,7 +68,7 @@ class MemoryCacheTest {
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
-        cache.invalidate(Key("1"))
+        cache.remove(Key("1"))
 
         assertNull(cache.get(Key("1")))
     }

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -1,0 +1,54 @@
+package coil.memory
+
+import coil.annotation.ExperimentalCoilApi
+import coil.bitmappool.FakeBitmapPool
+import coil.util.allocationByteCountCompat
+import coil.util.createBitmap
+import coil.util.isInvalid
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoilApi::class)
+class RealMemoryCacheTest {
+
+    private lateinit var weakCache: WeakMemoryCache
+    private lateinit var counter: BitmapReferenceCounter
+    private lateinit var strongCache: StrongMemoryCache
+    private lateinit var cache: MemoryCache
+
+    @Before
+    fun before() {
+        weakCache = RealWeakMemoryCache(null)
+        counter = BitmapReferenceCounter(weakCache, FakeBitmapPool(), null)
+        strongCache = StrongMemoryCache(weakCache, counter, Int.MAX_VALUE, null)
+        cache = RealMemoryCache(strongCache, weakCache, counter)
+    }
+
+    @Test
+    fun `can retrieve strong cached value`() {
+        val key = MemoryCache.Key("strong")
+        val bitmap = createBitmap()
+        strongCache.set(key, bitmap, false)
+
+        assertFalse(counter.isInvalid(bitmap))
+        assertEquals(bitmap, cache.get(key))
+        assertTrue(counter.isInvalid(bitmap))
+    }
+
+    @Test
+    fun `can retrieve weak cached value`() {
+        val key = MemoryCache.Key("weak")
+        val bitmap = createBitmap()
+        weakCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
+
+        assertFalse(counter.isInvalid(bitmap))
+        assertEquals(bitmap, cache.get(key))
+        assertTrue(counter.isInvalid(bitmap))
+    }
+}

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -2,6 +2,7 @@ package coil.memory
 
 import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.FakeBitmapPool
+import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.allocationByteCountCompat
 import coil.util.createBitmap
 import coil.util.isInvalid
@@ -9,7 +10,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -17,7 +17,6 @@ import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCoilApi::class)
-@Config(sdk = [28])
 class RealMemoryCacheTest {
 
     private lateinit var weakCache: WeakMemoryCache
@@ -74,5 +73,25 @@ class RealMemoryCacheTest {
         assertTrue(cache.remove(key))
         assertNull(strongCache.get(key))
         assertNull(weakCache.get(key))
+    }
+
+    @Test
+    fun `clear clears all values`() {
+        assertEquals(0, cache.size)
+
+        strongCache.set(MemoryCache.Key("a"), createBitmap(), false)
+        strongCache.set(MemoryCache.Key("b"), createBitmap(), false)
+        weakCache.set(MemoryCache.Key("c"), createBitmap(), false, 100)
+        weakCache.set(MemoryCache.Key("d"), createBitmap(), false, 100)
+
+        assertEquals(2 * DEFAULT_BITMAP_SIZE, cache.size)
+
+        cache.clear()
+
+        assertEquals(0, cache.size)
+        assertNull(cache.get(MemoryCache.Key("a")))
+        assertNull(cache.get(MemoryCache.Key("b")))
+        assertNull(cache.get(MemoryCache.Key("c")))
+        assertNull(cache.get(MemoryCache.Key("d")))
     }
 }

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -9,12 +9,15 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCoilApi::class)
+@Config(sdk = [28])
 class RealMemoryCacheTest {
 
     private lateinit var weakCache: WeakMemoryCache
@@ -34,6 +37,9 @@ class RealMemoryCacheTest {
     fun `can retrieve strong cached value`() {
         val key = MemoryCache.Key("strong")
         val bitmap = createBitmap()
+
+        assertNull(cache.get(key))
+
         strongCache.set(key, bitmap, false)
 
         assertFalse(counter.isInvalid(bitmap))
@@ -45,10 +51,28 @@ class RealMemoryCacheTest {
     fun `can retrieve weak cached value`() {
         val key = MemoryCache.Key("weak")
         val bitmap = createBitmap()
+
+        assertNull(cache.get(key))
+
         weakCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
 
         assertFalse(counter.isInvalid(bitmap))
         assertEquals(bitmap, cache.get(key))
         assertTrue(counter.isInvalid(bitmap))
+    }
+
+    @Test
+    fun `remove removes from both caches`() {
+        val key = MemoryCache.Key("key")
+        val bitmap = createBitmap()
+
+        assertNull(cache.get(key))
+
+        strongCache.set(key, bitmap, false)
+        weakCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
+
+        assertTrue(cache.remove(key))
+        assertNull(strongCache.get(key))
+        assertNull(weakCache.get(key))
     }
 }

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -1,7 +1,7 @@
 package coil.memory
 
 import coil.bitmappool.BitmapPool
-import coil.memory.StrongMemoryCache.Key
+import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.createBitmap
 import org.junit.Test

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -18,104 +18,104 @@ class StrongMemoryCacheTest {
 
     @Test
     fun `can retrieve cached value`() {
-        val weakMemoryCache = EmptyWeakMemoryCache
+        val weakCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
-        cache.set(Key("1"), bitmap, false)
+        strongCache.set(Key("1"), bitmap, false)
 
-        assertEquals(bitmap, cache.get(Key("1"))?.bitmap)
+        assertEquals(bitmap, strongCache.get(Key("1"))?.bitmap)
     }
 
     @Test
     fun `least recently used value is evicted`() {
-        val weakMemoryCache = EmptyWeakMemoryCache
+        val weakCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val first = createBitmap()
-        cache.set(Key("1"), first, false)
+        strongCache.set(Key("1"), first, false)
 
         val second = createBitmap()
-        cache.set(Key("2"), second, false)
+        strongCache.set(Key("2"), second, false)
 
         val third = createBitmap()
-        cache.set(Key("3"), third, false)
+        strongCache.set(Key("3"), third, false)
 
-        assertNull(cache.get(Key("1")))
+        assertNull(strongCache.get(Key("1")))
     }
 
     @Test
     fun `maxSize 0 disables memory cache`() {
-        val weakMemoryCache = EmptyWeakMemoryCache
+        val weakCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, 0, null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, 0, null)
 
         val bitmap = createBitmap()
-        cache.set(Key("1"), bitmap, false)
+        strongCache.set(Key("1"), bitmap, false)
 
-        assertNull(cache.get(Key("1")))
+        assertNull(strongCache.get(Key("1")))
     }
 
     @Test
     fun `value is removed after invalidate is called`() {
-        val weakMemoryCache = RealWeakMemoryCache(null)
+        val weakCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
-        cache.set(Key("1"), bitmap, false)
-        cache.remove(Key("1"))
+        strongCache.set(Key("1"), bitmap, false)
+        strongCache.remove(Key("1"))
 
-        assertNull(cache.get(Key("1")))
+        assertNull(strongCache.get(Key("1")))
     }
 
     @Test
     fun `valid evicted item is added to bitmap pool`() {
-        val weakMemoryCache = RealWeakMemoryCache(null)
+        val weakCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
-        cache.set(Key("1"), first, false)
+        strongCache.set(Key("1"), first, false)
 
-        assertNotNull(cache.get(Key("1")))
+        assertNotNull(strongCache.get(Key("1")))
 
         val second = createBitmap()
-        cache.set(Key("2"), second, false)
+        strongCache.set(Key("2"), second, false)
 
-        assertNull(cache.get(Key("1")))
-        assertNull(weakMemoryCache.get(Key("1")))
+        assertNull(strongCache.get(Key("1")))
+        assertNull(weakCache.get(Key("1")))
         assertEquals(first, pool.getDirtyOrNull(first.width, first.height, first.config))
     }
 
     @Test
     fun `invalid evicted item is added to weak memory cache`() {
-        val weakMemoryCache = RealWeakMemoryCache(null)
+        val weakCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
-        val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val counter = BitmapReferenceCounter(weakCache, pool, null)
+        val strongCache = StrongMemoryCache(weakCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
-        cache.set(Key("key"), first, false)
+        strongCache.set(Key("key"), first, false)
 
-        assertNotNull(cache.get(Key("key")))
+        assertNotNull(strongCache.get(Key("key")))
 
         // Invalidate the first bitmap.
         counter.invalidate(first)
 
         // Overwrite the value in the memory cache.
         val second = createBitmap()
-        cache.set(Key("key"), second, false)
+        strongCache.set(Key("key"), second, false)
 
-        assertEquals(second, cache.get(Key("key"))?.bitmap)
-        assertEquals(first, weakMemoryCache.get(Key("key"))?.bitmap)
+        assertEquals(second, strongCache.get(Key("key"))?.bitmap)
+        assertEquals(first, weakCache.get(Key("key"))?.bitmap)
         assertNull(pool.getDirtyOrNull(first.width, first.height, first.config))
     }
 }

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -21,7 +21,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -34,7 +34,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -53,7 +53,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, 0)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, 0, null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -63,10 +63,10 @@ class StrongMemoryCacheTest {
 
     @Test
     fun `value is removed after invalidate is called`() {
-        val weakMemoryCache = RealWeakMemoryCache()
+        val weakMemoryCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -77,10 +77,10 @@ class StrongMemoryCacheTest {
 
     @Test
     fun `valid evicted item is added to bitmap pool`() {
-        val weakMemoryCache = RealWeakMemoryCache()
+        val weakMemoryCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -97,10 +97,10 @@ class StrongMemoryCacheTest {
 
     @Test
     fun `invalid evicted item is added to weak memory cache`() {
-        val weakMemoryCache = RealWeakMemoryCache()
+        val weakMemoryCache = RealWeakMemoryCache(null)
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
         cache.set(Key("key"), first, false)

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -1,5 +1,6 @@
 package coil.memory
 
+import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.BitmapPool
 import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
@@ -12,6 +13,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoilApi::class)
 class StrongMemoryCacheTest {
 
     @Test
@@ -19,7 +21,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -32,7 +34,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -51,7 +53,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, 0, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, 0)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -64,7 +66,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE))
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -78,7 +80,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE)
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -98,7 +100,7 @@ class StrongMemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE)
 
         val first = createBitmap()
         cache.set(Key("key"), first, false)

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -1,7 +1,7 @@
 package coil.memory
 
 import coil.bitmappool.BitmapPool
-import coil.memory.MemoryCache.Key
+import coil.memory.StrongMemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.createBitmap
 import org.junit.Test
@@ -12,14 +12,14 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
-class MemoryCacheTest {
+class StrongMemoryCacheTest {
 
     @Test
     fun `can retrieve cached value`() {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -32,7 +32,7 @@ class MemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -51,7 +51,7 @@ class MemoryCacheTest {
         val weakMemoryCache = EmptyWeakMemoryCache
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, 0, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, 0, null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -64,7 +64,7 @@ class MemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, (2 * DEFAULT_BITMAP_SIZE), null)
 
         val bitmap = createBitmap()
         cache.set(Key("1"), bitmap, false)
@@ -78,7 +78,7 @@ class MemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
         cache.set(Key("1"), first, false)
@@ -98,7 +98,7 @@ class MemoryCacheTest {
         val weakMemoryCache = RealWeakMemoryCache()
         val pool = BitmapPool(Int.MAX_VALUE)
         val counter = BitmapReferenceCounter(weakMemoryCache, pool, null)
-        val cache = MemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
+        val cache = StrongMemoryCache(weakMemoryCache, counter, DEFAULT_BITMAP_SIZE, null)
 
         val first = createBitmap()
         cache.set(Key("key"), first, false)

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -9,9 +9,9 @@ import coil.annotation.ExperimentalCoilApi
 import coil.bitmappool.FakeBitmapPool
 import coil.decode.DataSource
 import coil.request.ErrorResult
+import coil.request.Metadata
 import coil.request.RequestResult
 import coil.request.SuccessResult
-import coil.request.SuccessResult.Metadata
 import coil.target.FakeTarget
 import coil.target.ImageViewTarget
 import coil.transition.Transition

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -11,6 +11,7 @@ import coil.decode.DataSource
 import coil.request.ErrorResult
 import coil.request.RequestResult
 import coil.request.SuccessResult
+import coil.request.SuccessResult.Metadata
 import coil.target.FakeTarget
 import coil.target.ImageViewTarget
 import coil.transition.Transition
@@ -77,7 +78,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            val result = SuccessResult(bitmap.toDrawable(context), DataSource.DISK)
+            val result = SuccessResult(bitmap.toDrawable(context), Metadata(null, DataSource.DISK))
             delegate.success(result, Transition.NONE)
             assertFalse(counter.isInvalid(bitmap))
         }
@@ -90,7 +91,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            val result = SuccessResult(bitmap.toDrawable(context), DataSource.DISK)
+            val result = SuccessResult(bitmap.toDrawable(context), Metadata(null, DataSource.DISK))
             delegate.success(result, Transition.NONE)
             assertTrue(counter.isInvalid(bitmap))
         }
@@ -114,7 +115,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            val result = SuccessResult(bitmap.toDrawable(context), DataSource.DISK)
+            val result = SuccessResult(bitmap.toDrawable(context), Metadata(null, DataSource.DISK))
             delegate.success(result, Transition.NONE)
             assertTrue(target.success)
             assertTrue(counter.isInvalid(bitmap))
@@ -144,7 +145,7 @@ class TargetDelegateTest {
 
         runBlocking {
             val bitmap = createBitmap()
-            val result = SuccessResult(bitmap.toDrawable(context), DataSource.DISK)
+            val result = SuccessResult(bitmap.toDrawable(context), Metadata(null, DataSource.DISK))
             delegate.success(result, Transition.NONE)
             assertFalse(counter.isInvalid(bitmap))
             assertTrue(pool.bitmaps.contains(initialBitmap))
@@ -167,7 +168,7 @@ class TargetDelegateTest {
         runBlocking {
             val bitmap = createBitmap()
             var isRunning = true
-            val result = SuccessResult(bitmap.toDrawable(context), DataSource.DISK)
+            val result = SuccessResult(bitmap.toDrawable(context), Metadata(null, DataSource.DISK))
             val transition = object : Transition {
                 override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
                     assertFalse(pool.bitmaps.contains(initialBitmap))

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -3,6 +3,7 @@ package coil.memory
 import android.content.Context
 import androidx.collection.arraySetOf
 import androidx.test.core.app.ApplicationProvider
+import coil.annotation.ExperimentalCoilApi
 import coil.memory.MemoryCache.Key
 import coil.util.allocationByteCountCompat
 import coil.util.clear
@@ -18,6 +19,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoilApi::class)
 @Config(sdk = [21, 29])
 class WeakMemoryCacheTest {
 

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -75,7 +75,7 @@ class WeakMemoryCacheTest {
         val bitmap = reference(createBitmap())
 
         weakMemoryCache.set(key, bitmap, false, 100)
-        weakMemoryCache.invalidate(bitmap)
+        weakMemoryCache.remove(bitmap)
 
         assertNull(weakMemoryCache.get(key))
     }
@@ -101,28 +101,28 @@ class WeakMemoryCacheTest {
         weakMemoryCache.set(Key("key"), bitmap2, false, 2)
 
         assertEquals(bitmap8, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap8)
+        weakMemoryCache.remove(bitmap8)
 
         assertEquals(bitmap7, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap7)
+        weakMemoryCache.remove(bitmap7)
 
         assertEquals(bitmap6, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap6)
+        weakMemoryCache.remove(bitmap6)
 
         assertEquals(bitmap5, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap5)
+        weakMemoryCache.remove(bitmap5)
 
         assertEquals(bitmap4, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap4)
+        weakMemoryCache.remove(bitmap4)
 
         assertEquals(bitmap3, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap3)
+        weakMemoryCache.remove(bitmap3)
 
         assertEquals(bitmap2, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap2)
+        weakMemoryCache.remove(bitmap2)
 
         assertEquals(bitmap1, weakMemoryCache.get(Key("key"))?.bitmap)
-        weakMemoryCache.invalidate(bitmap1)
+        weakMemoryCache.remove(bitmap1)
 
         // All the values are invalidated.
         assertNull(weakMemoryCache.get(Key("key")))
@@ -161,7 +161,7 @@ class WeakMemoryCacheTest {
         val key = Key("1")
         val bitmap = createBitmap()
         weakMemoryCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
-        weakMemoryCache.invalidate(key)
+        weakMemoryCache.remove(key)
 
         assertNull(weakMemoryCache.get(key))
     }

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -30,7 +30,7 @@ class WeakMemoryCacheTest {
     @Before
     fun before() {
         context = ApplicationProvider.getApplicationContext()
-        weakMemoryCache = RealWeakMemoryCache()
+        weakMemoryCache = RealWeakMemoryCache(null)
         references = arraySetOf()
     }
 

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -3,7 +3,7 @@ package coil.memory
 import android.content.Context
 import androidx.collection.arraySetOf
 import androidx.test.core.app.ApplicationProvider
-import coil.memory.MemoryCache.Key
+import coil.memory.StrongMemoryCache.Key
 import coil.util.allocationByteCountCompat
 import coil.util.clear
 import coil.util.count

--- a/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/WeakMemoryCacheTest.kt
@@ -3,7 +3,7 @@ package coil.memory
 import android.content.Context
 import androidx.collection.arraySetOf
 import androidx.test.core.app.ApplicationProvider
-import coil.memory.StrongMemoryCache.Key
+import coil.memory.MemoryCache.Key
 import coil.util.allocationByteCountCompat
 import coil.util.clear
 import coil.util.count

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -10,8 +10,8 @@ import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.drawable.CrossfadeDrawable
 import coil.request.ErrorResult
+import coil.request.Metadata
 import coil.request.SuccessResult
-import coil.request.SuccessResult.Metadata
 import coil.util.createTestMainDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -11,6 +11,7 @@ import coil.decode.DataSource
 import coil.drawable.CrossfadeDrawable
 import coil.request.ErrorResult
 import coil.request.SuccessResult
+import coil.request.SuccessResult.Metadata
 import coil.util.createTestMainDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -62,7 +63,7 @@ class CrossfadeTransitionTest {
                         assertEquals(drawable, result)
                     }
                 ),
-                result = SuccessResult(drawable, DataSource.MEMORY_CACHE)
+                result = SuccessResult(drawable, Metadata(null, DataSource.MEMORY_CACHE))
             )
         }
 
@@ -88,7 +89,7 @@ class CrossfadeTransitionTest {
                         result.stop()
                     }
                 ),
-                result = SuccessResult(drawable, DataSource.DISK)
+                result = SuccessResult(drawable, Metadata(null, DataSource.DISK))
             )
         }
 
@@ -114,7 +115,7 @@ class CrossfadeTransitionTest {
                         assertFalse(result is CrossfadeDrawable)
                     }
                 ),
-                result = SuccessResult(drawable, DataSource.NETWORK)
+                result = SuccessResult(drawable, Metadata(null, DataSource.NETWORK))
             )
         }
     }

--- a/coil-sample/src/main/java/coil/sample/MainActivity.kt
+++ b/coil-sample/src/main/java/coil/sample/MainActivity.kt
@@ -14,6 +14,7 @@ import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL
+import coil.Coil
 import coil.api.load
 import coil.sample.databinding.ActivityMainBinding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -51,6 +52,12 @@ class MainActivity : AppCompatActivity() {
             setHasFixedSize(true)
             layoutManager = StaggeredGridLayoutManager(listAdapter.numColumns, VERTICAL)
             adapter = listAdapter
+        }
+
+        val imageLoader = Coil.imageLoader(this)
+        imageLoader.apply {
+            imageLoader.memoryCache.clear()
+            imageLoader.bitmapPool.clear()
         }
 
         lifecycleScope.apply {

--- a/coil-sample/src/main/java/coil/sample/MainActivity.kt
+++ b/coil-sample/src/main/java/coil/sample/MainActivity.kt
@@ -14,7 +14,7 @@ import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL
-import coil.Coil
+import coil.ImageLoader
 import coil.api.load
 import coil.sample.databinding.ActivityMainBinding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -54,11 +54,8 @@ class MainActivity : AppCompatActivity() {
             adapter = listAdapter
         }
 
-        val imageLoader = Coil.imageLoader(this)
-        imageLoader.apply {
-            imageLoader.memoryCache.clear()
-            imageLoader.bitmapPool.clear()
-        }
+        val imageLoader = ImageLoader(this)
+        imageLoader.clearMemory()
 
         lifecycleScope.apply {
             launch {

--- a/coil-sample/src/main/java/coil/sample/MainActivity.kt
+++ b/coil-sample/src/main/java/coil/sample/MainActivity.kt
@@ -14,7 +14,6 @@ import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL
-import coil.ImageLoader
 import coil.api.load
 import coil.sample.databinding.ActivityMainBinding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -53,9 +52,6 @@ class MainActivity : AppCompatActivity() {
             layoutManager = StaggeredGridLayoutManager(listAdapter.numColumns, VERTICAL)
             adapter = listAdapter
         }
-
-        val imageLoader = ImageLoader(this)
-        imageLoader.clearMemory()
 
         lifecycleScope.apply {
             launch {

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -6,7 +6,7 @@ Both `ImageLoader` and `LoadRequest` builders accept a `Transition`. Transitions
 
 By default, Coil comes packaged with 2 transitions:
 
-- [`CrossfadeTransition`](../api/coil-base/coil.transition/-crossfade-transition/) which crossfades from the current drawable to the sucess/error drawable.
+- [`CrossfadeTransition`](../api/coil-base/coil.transition/-crossfade-transition/) which crossfades from the current drawable to the success/error drawable.
 - [`Transition.NONE`](../api/coil-base/coil.transition/-transition/-n-o-n-e/) which sets the drawable on the `Target` immediately without animating.
 
 Take a look at the [`CrossfadeTransition` source code](https://github.com/coil-kt/coil/blob/master/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt) for an example of how to write a custom `Transition`.


### PR DESCRIPTION
Adds a public `MemoryCache` interface that can be accessed with `imageLoader.memoryCache`. This allows users to query an `ImageLoader`'s memory cache directly. Spec:

```kotlin
interface MemoryCache {

    /** The current size of the cache in bytes. */
    val size: Int

    /** The maximum size of the cache in bytes. */
    val maxSize: Int

    /** Get the [Bitmap] associated with [key]. */
    operator fun get(key: Key): Bitmap?

    /** Remove the [Bitmap] referenced by [key]. */
    fun remove(key: Key): Boolean

    /** Remove all values from the memory cache. */
    fun clear()
}
```

Currently it's read-only (except `remove`/`clear`), but I may add `operator fun set(key: Key, bitmap: Bitmap)` later (need to make sure `set` wouldn't violate any internal assumptions).

`MemoryCache.Key` comes in two variants:
- Simple, which wraps a `String`.
- Complex, only created by Coil's image pipeline so the semantics can be changed in the future if necessary. Returned as part of `SucessResult` and `ImageRequest.Listener.onSuccess`.

Example usage:

```kotlin
val request = ImageRequest.Builder(context)
    .data("https://www.example.com/image.jpg")
    .target(imageView)
    .listener { request, metadata ->
        // Now or later...
        val bitmap = imageLoader.memoryCache[metadata.key]
    }
    .build()
imageLoader.enqueue(request)
```