### PR TITLE
Add MemoryCache.set().

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -405,6 +405,7 @@ public abstract interface class coil/memory/MemoryCache {
 	public abstract fun getMaxSize ()I
 	public abstract fun getSize ()I
 	public abstract fun remove (Lcoil/memory/MemoryCache$Key;)Z
+	public abstract fun set (Lcoil/memory/MemoryCache$Key;Landroid/graphics/Bitmap;)V
 }
 
 public abstract class coil/memory/MemoryCache$Key {

--- a/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/memory/BitmapReferenceCounter.kt
@@ -45,7 +45,7 @@ internal class BitmapReferenceCounter(
      *
      * If the reference count is now zero, add the [Bitmap] to [bitmapPool].
      *
-     * @return `true` if [bitmap] was added to [bitmapPool] as a result of this decrement operation.
+     * @return True if [bitmap] was added to [bitmapPool] as a result of this decrement operation.
      */
     @Synchronized
     fun decrement(bitmap: Bitmap): Boolean {

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -22,10 +22,13 @@ interface MemoryCache {
     /** Get the [Bitmap] associated with [key]. */
     operator fun get(key: Key): Bitmap?
 
+    /** Set the [Bitmap] associated with [key]. */
+    operator fun set(key: Key, bitmap: Bitmap)
+
     /**
      * Remove the [Bitmap] referenced by [key].
      *
-     * @return `true` if [key] was present in the cache. Else, return `false`.
+     * @return True if [key] was present in the cache. Else, return false.
      */
     fun remove(key: Key): Boolean
 

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -22,7 +22,7 @@ internal class RealMemoryCache(
 
     override fun set(key: Key, bitmap: Bitmap) {
         referenceCounter.invalidate(bitmap)
-        strongMemoryCache.set(key, bitmap, false) // Assume the input is not sampled.
+        strongMemoryCache.set(key, bitmap, false)
         weakMemoryCache.remove(key) // Clear any existing weak values.
     }
 

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -37,12 +37,12 @@ class RealMemoryCacheTest {
         val key = MemoryCache.Key("strong")
         val bitmap = createBitmap()
 
-        assertNull(cache.get(key))
+        assertNull(cache[key])
 
         strongCache.set(key, bitmap, false)
 
         assertFalse(counter.isInvalid(bitmap))
-        assertEquals(bitmap, cache.get(key))
+        assertEquals(bitmap, cache[key])
         assertTrue(counter.isInvalid(bitmap))
     }
 
@@ -51,12 +51,12 @@ class RealMemoryCacheTest {
         val key = MemoryCache.Key("weak")
         val bitmap = createBitmap()
 
-        assertNull(cache.get(key))
+        assertNull(cache[key])
 
         weakCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
 
         assertFalse(counter.isInvalid(bitmap))
-        assertEquals(bitmap, cache.get(key))
+        assertEquals(bitmap, cache[key])
         assertTrue(counter.isInvalid(bitmap))
     }
 
@@ -65,7 +65,7 @@ class RealMemoryCacheTest {
         val key = MemoryCache.Key("key")
         val bitmap = createBitmap()
 
-        assertNull(cache.get(key))
+        assertNull(cache[key])
 
         strongCache.set(key, bitmap, false)
         weakCache.set(key, bitmap, false, bitmap.allocationByteCountCompat)
@@ -89,9 +89,31 @@ class RealMemoryCacheTest {
         cache.clear()
 
         assertEquals(0, cache.size)
-        assertNull(cache.get(MemoryCache.Key("a")))
-        assertNull(cache.get(MemoryCache.Key("b")))
-        assertNull(cache.get(MemoryCache.Key("c")))
-        assertNull(cache.get(MemoryCache.Key("d")))
+        assertNull(cache[MemoryCache.Key("a")])
+        assertNull(cache[MemoryCache.Key("b")])
+        assertNull(cache[MemoryCache.Key("c")])
+        assertNull(cache[MemoryCache.Key("d")])
+    }
+
+    @Test
+    fun `set can be retrieved with get`() {
+        val key = MemoryCache.Key("a")
+        val bitmap = createBitmap()
+        cache[key] = bitmap
+
+        assertEquals(bitmap, cache[key])
+    }
+
+    @Test
+    fun `set replaces strong and weak values`() {
+        val key = MemoryCache.Key("a")
+        val expected = createBitmap()
+
+        strongCache.set(key, createBitmap(), false)
+        weakCache.set(key, createBitmap(), false, 100)
+        cache[key] = expected
+
+        assertEquals(expected, strongCache.get(key)?.bitmap)
+        assertNull(weakCache.get(key))
     }
 }

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -113,6 +113,7 @@ class RealMemoryCacheTest {
         weakCache.set(key, createBitmap(), false, 100)
         cache[key] = expected
 
+        assertTrue(counter.isInvalid(expected))
         assertEquals(expected, strongCache.get(key)?.bitmap)
         assertNull(weakCache.get(key))
     }


### PR DESCRIPTION
Adds the ability to set a bitmap in Coil's memory cache.

After thinking about it for a couple days, I think this should be safe, however the API is marked as experimental to allow further changes.