### PR TITLE
Remove data modifier from several public classes.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -18,20 +18,6 @@ public final class coil/DefaultRequestOptions {
 	public fun <init> ()V
 	public fun <init> (Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
 	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lkotlinx/coroutines/CoroutineDispatcher;
-	public final fun component10 ()Lcoil/request/CachePolicy;
-	public final fun component11 ()Lcoil/request/CachePolicy;
-	public final fun component12 ()Lcoil/request/CachePolicy;
-	public final fun component2 ()Lcoil/transition/Transition;
-	public final fun component3 ()Lcoil/size/Precision;
-	public final fun component4 ()Landroid/graphics/Bitmap$Config;
-	public final fun component5 ()Z
-	public final fun component6 ()Z
-	public final fun component7 ()Landroid/graphics/drawable/Drawable;
-	public final fun component8 ()Landroid/graphics/drawable/Drawable;
-	public final fun component9 ()Landroid/graphics/drawable/Drawable;
-	public final fun copy (Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/DefaultRequestOptions;
-	public static synthetic fun copy$default (Lcoil/DefaultRequestOptions;Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/DefaultRequestOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowHardware ()Z
 	public final fun getAllowRgb565 ()Z
@@ -253,18 +239,6 @@ public final class coil/decode/InterruptibleSourceKt {
 
 public final class coil/decode/Options {
 	public fun <init> (Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public final fun component1 ()Landroid/graphics/Bitmap$Config;
-	public final fun component10 ()Lcoil/request/CachePolicy;
-	public final fun component2 ()Landroid/graphics/ColorSpace;
-	public final fun component3 ()Lcoil/size/Scale;
-	public final fun component4 ()Z
-	public final fun component5 ()Z
-	public final fun component6 ()Lokhttp3/Headers;
-	public final fun component7 ()Lcoil/request/Parameters;
-	public final fun component8 ()Lcoil/request/CachePolicy;
-	public final fun component9 ()Lcoil/request/CachePolicy;
-	public final fun copy (Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
-	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowInexactSize ()Z
 	public final fun getAllowRgb565 ()Z
@@ -550,11 +524,6 @@ public final class coil/request/ImageRequest$Listener$DefaultImpls {
 
 public final class coil/request/Metadata {
 	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)V
-	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
-	public final fun component2 ()Z
-	public final fun component3 ()Lcoil/decode/DataSource;
-	public final fun copy (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)Lcoil/request/Metadata;
-	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataSource ()Lcoil/decode/DataSource;
 	public final fun getKey ()Lcoil/memory/MemoryCache$Key;

--- a/coil-base/src/main/java/coil/DefaultRequestOptions.kt
+++ b/coil-base/src/main/java/coil/DefaultRequestOptions.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalCoilApi::class)
-
 package coil
 
 import android.graphics.Bitmap
@@ -18,7 +16,8 @@ import kotlinx.coroutines.Dispatchers
  *
  * @see ImageLoader.defaults
  */
-data class DefaultRequestOptions(
+@OptIn(ExperimentalCoilApi::class)
+class DefaultRequestOptions(
     val dispatcher: CoroutineDispatcher = Dispatchers.IO,
     val transition: Transition = Transition.NONE,
     val precision: Precision = Precision.AUTOMATIC,
@@ -31,4 +30,45 @@ data class DefaultRequestOptions(
     val memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
     val diskCachePolicy: CachePolicy = CachePolicy.ENABLED,
     val networkCachePolicy: CachePolicy = CachePolicy.ENABLED
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is DefaultRequestOptions &&
+            dispatcher == other.dispatcher &&
+            transition == other.transition &&
+            precision == other.precision &&
+            bitmapConfig == other.bitmapConfig &&
+            allowHardware == other.allowHardware &&
+            allowRgb565 == other.allowRgb565 &&
+            placeholder == other.placeholder &&
+            error == other.error &&
+            fallback == other.fallback &&
+            memoryCachePolicy == other.memoryCachePolicy &&
+            diskCachePolicy == other.diskCachePolicy &&
+            networkCachePolicy == other.networkCachePolicy
+    }
+
+    override fun hashCode(): Int {
+        var result = dispatcher.hashCode()
+        result = 31 * result + transition.hashCode()
+        result = 31 * result + precision.hashCode()
+        result = 31 * result + bitmapConfig.hashCode()
+        result = 31 * result + allowHardware.hashCode()
+        result = 31 * result + allowRgb565.hashCode()
+        result = 31 * result + (placeholder?.hashCode() ?: 0)
+        result = 31 * result + (error?.hashCode() ?: 0)
+        result = 31 * result + (fallback?.hashCode() ?: 0)
+        result = 31 * result + memoryCachePolicy.hashCode()
+        result = 31 * result + diskCachePolicy.hashCode()
+        result = 31 * result + networkCachePolicy.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "DefaultRequestOptions(dispatcher=$dispatcher, transition=$transition, precision=$precision, " +
+            "bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, allowRgb565=$allowRgb565, " +
+            "placeholder=$placeholder, error=$error, fallback=$fallback, memoryCachePolicy=$memoryCachePolicy, " +
+            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy)"
+    }
+}

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -30,6 +30,7 @@ import coil.transition.Transition
 import coil.util.CoilUtils
 import coil.util.Logger
 import coil.util.Utils
+import coil.util.copy
 import coil.util.getDrawableCompat
 import coil.util.lazyCallFactory
 import kotlinx.coroutines.CoroutineDispatcher

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -27,7 +27,7 @@ import okhttp3.Headers
  * @param diskCachePolicy Determines if this request is allowed to read/write from/to disk.
  * @param networkCachePolicy Determines if this request is allowed to read from the network.
  */
-data class Options(
+class Options(
     val config: Bitmap.Config,
     val colorSpace: ColorSpace?,
     val scale: Scale,
@@ -38,4 +38,40 @@ data class Options(
     val memoryCachePolicy: CachePolicy,
     val diskCachePolicy: CachePolicy,
     val networkCachePolicy: CachePolicy
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is Options &&
+            config == other.config &&
+            colorSpace == other.colorSpace &&
+            scale == other.scale &&
+            allowInexactSize == other.allowInexactSize &&
+            allowRgb565 == other.allowRgb565 &&
+            headers == other.headers &&
+            parameters == other.parameters &&
+            memoryCachePolicy == other.memoryCachePolicy &&
+            diskCachePolicy == other.diskCachePolicy &&
+            networkCachePolicy == other.networkCachePolicy
+    }
+
+    override fun hashCode(): Int {
+        var result = config.hashCode()
+        result = 31 * result + (colorSpace?.hashCode() ?: 0)
+        result = 31 * result + scale.hashCode()
+        result = 31 * result + allowInexactSize.hashCode()
+        result = 31 * result + allowRgb565.hashCode()
+        result = 31 * result + headers.hashCode()
+        result = 31 * result + parameters.hashCode()
+        result = 31 * result + memoryCachePolicy.hashCode()
+        result = 31 * result + diskCachePolicy.hashCode()
+        result = 31 * result + networkCachePolicy.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Options(config=$config, colorSpace=$colorSpace, scale=$scale, allowInexactSize=$allowInexactSize, " +
+            "allowRgb565=$allowRgb565, headers=$headers, parameters=$parameters, memoryCachePolicy=$memoryCachePolicy, " +
+            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy)"
+    }
+}

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalCoilApi::class)
-
 package coil.request
 
 import coil.annotation.ExperimentalCoilApi
@@ -14,8 +12,29 @@ import coil.memory.MemoryCache
  * @param isSampled True if [drawable] is sampled (i.e. loaded into memory at less than its original size).
  * @param dataSource The data source that the image was loaded from.
  */
-data class Metadata(
+@OptIn(ExperimentalCoilApi::class)
+class Metadata(
     val key: MemoryCache.Key?,
     val isSampled: Boolean,
     val dataSource: DataSource
-)
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is Metadata &&
+            key == other.key &&
+            isSampled == other.isSampled &&
+            dataSource == other.dataSource
+    }
+
+    override fun hashCode(): Int {
+        var result = key?.hashCode() ?: 0
+        result = 31 * result + isSampled.hashCode()
+        result = 31 * result + dataSource.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Metadata(key=$key, isSampled=$isSampled, dataSource=$dataSource)"
+    }
+}

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -5,6 +5,7 @@ package coil.util
 
 import android.app.ActivityManager
 import android.content.res.Configuration
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
@@ -23,16 +24,21 @@ import android.widget.ImageView.ScaleType.FIT_END
 import android.widget.ImageView.ScaleType.FIT_START
 import androidx.core.view.ViewCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import coil.DefaultRequestOptions
 import coil.annotation.ExperimentalCoilApi
 import coil.base.R
 import coil.decode.DataSource
 import coil.memory.MemoryCache
 import coil.memory.StrongMemoryCache
 import coil.memory.ViewTargetRequestManager
+import coil.request.CachePolicy
 import coil.request.Parameters
+import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
 import coil.transform.Transformation
+import coil.transition.Transition
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import okhttp3.Call
 import okhttp3.Headers
@@ -195,3 +201,20 @@ internal inline operator fun MemoryCache.Key.Companion.invoke(
         parameters = parameters.cacheKeys()
     )
 }
+
+@OptIn(ExperimentalCoilApi::class)
+internal fun DefaultRequestOptions.copy(
+    dispatcher: CoroutineDispatcher = this.dispatcher,
+    transition: Transition = this.transition,
+    precision: Precision = this.precision,
+    bitmapConfig: Bitmap.Config = this.bitmapConfig,
+    allowHardware: Boolean = this.allowHardware,
+    allowRgb565: Boolean = this.allowRgb565,
+    placeholder: Drawable? = this.placeholder,
+    error: Drawable? = this.error,
+    fallback: Drawable? = this.fallback,
+    memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
+    diskCachePolicy: CachePolicy = this.diskCachePolicy,
+    networkCachePolicy: CachePolicy = this.networkCachePolicy
+) = DefaultRequestOptions(dispatcher, transition, precision, bitmapConfig, allowHardware, allowRgb565, placeholder,
+    error, fallback, memoryCachePolicy, diskCachePolicy, networkCachePolicy)


### PR DESCRIPTION
These classes are likely to have attributes added in the future. To be able to change the API safely, they can't be data classes. See: https://jakewharton.com/public-api-challenges-in-kotlin/