### PR TITLE
Make MemoryCache.Key parcelable.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -378,7 +378,7 @@ public abstract interface class coil/memory/MemoryCache {
 	public abstract fun set (Lcoil/memory/MemoryCache$Key;Landroid/graphics/Bitmap;)V
 }
 
-public abstract class coil/memory/MemoryCache$Key {
+public abstract class coil/memory/MemoryCache$Key : android/os/Parcelable {
 	public static final field Companion Lcoil/memory/MemoryCache$Key$Companion;
 	public static final fun create (Ljava/lang/String;)Lcoil/memory/MemoryCache$Key;
 }
@@ -611,21 +611,39 @@ public final class coil/size/DisplaySizeResolver : coil/size/SizeResolver {
 }
 
 public final class coil/size/OriginalSize : coil/size/Size {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field INSTANCE Lcoil/size/OriginalSize;
+	public fun describeContents ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class coil/size/OriginalSize$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class coil/size/PixelSize : coil/size/Size {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (II)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun copy (II)Lcoil/size/PixelSize;
 	public static synthetic fun copy$default (Lcoil/size/PixelSize;IIILjava/lang/Object;)Lcoil/size/PixelSize;
+	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHeight ()I
 	public final fun getWidth ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public class coil/size/PixelSize$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class coil/size/Precision : java/lang/Enum {
@@ -643,7 +661,7 @@ public final class coil/size/Scale : java/lang/Enum {
 	public static fun values ()[Lcoil/size/Scale;
 }
 
-public abstract class coil/size/Size {
+public abstract class coil/size/Size : android/os/Parcelable {
 }
 
 public abstract interface class coil/size/SizeResolver {

--- a/coil-base/build.gradle.kts
+++ b/coil-base/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("com.android.library")
     id("com.vanniktech.maven.publish")
     id("kotlin-android")
+    id("kotlin-android-extensions")
     id("org.jetbrains.dokka")
 }
 
@@ -27,6 +28,11 @@ android {
     testOptions {
         unitTests.isIncludeAndroidResources = true
     }
+}
+
+androidExtensions {
+    isExperimental = true
+    features = setOf("parcelize")
 }
 
 afterEvaluate {

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -1,11 +1,13 @@
 package coil.memory
 
 import android.graphics.Bitmap
+import android.os.Parcelable
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.request.ImageRequest
 import coil.request.SuccessResult
 import coil.size.Size
+import kotlinx.android.parcel.Parcelize
 
 /**
  * An in-memory cache of recently loaded images.
@@ -36,7 +38,7 @@ interface MemoryCache {
     fun clear()
 
     /** The cache key for an image in the memory cache. */
-    sealed class Key {
+    sealed class Key : Parcelable {
 
         companion object {
             /** Create a simple memory cache key. */
@@ -46,6 +48,7 @@ interface MemoryCache {
         }
 
         /** A simple memory cache key that wraps a [String]. Create new instances using [invoke]. */
+        @Parcelize
         internal data class Simple(val value: String) : Key()
 
         /**
@@ -56,6 +59,7 @@ interface MemoryCache {
          *
          * This class is an implementation detail and its fields may change in future releases.
          */
+        @Parcelize
         internal data class Complex(
             val base: String,
             val transformations: List<String>,

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -1,7 +1,9 @@
 package coil.size
 
+import android.os.Parcelable
 import androidx.annotation.Px
 import coil.request.ImageRequest
+import kotlinx.android.parcel.Parcelize
 
 /**
  * Represents the target size of an image request.
@@ -9,14 +11,16 @@ import coil.request.ImageRequest
  * @see ImageRequest.Builder.size
  * @see SizeResolver.size
  */
-sealed class Size
+sealed class Size : Parcelable
 
 /** Represents the width and height of the source image. */
+@Parcelize
 object OriginalSize : Size() {
     override fun toString() = "coil.size.OriginalSize"
 }
 
 /** A positive width and height in pixels. */
+@Parcelize
 data class PixelSize(
     @Px val width: Int,
     @Px val height: Int


### PR DESCRIPTION
It's likely users will want to pass these cache keys to an `Activity` if they're performing shared element transitions.