### PR TITLE
Prefer immutable bitmaps on API 24+.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -78,7 +78,7 @@ public abstract interface class coil/ImageLoader {
 	public static fun create (Landroid/content/Context;)Lcoil/ImageLoader;
 	public abstract fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/RequestDisposable;
 	public abstract fun execute (Lcoil/request/ImageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getBitmapPool ()Lcoil/bitmappool/BitmapPool;
+	public abstract fun getBitmapPool ()Lcoil/bitmap/BitmapPool;
 	public abstract fun getDefaults ()Lcoil/request/DefaultRequestOptions;
 	public abstract fun getMemoryCache ()Lcoil/memory/MemoryCache;
 	public abstract fun invalidate (Ljava/lang/String;)V
@@ -134,10 +134,10 @@ public abstract interface annotation class coil/annotation/ExperimentalCoilApi :
 public abstract interface annotation class coil/annotation/InternalCoilApi : java/lang/annotation/Annotation {
 }
 
-public abstract interface class coil/bitmappool/BitmapPool {
-	public static final field Companion Lcoil/bitmappool/BitmapPool$Companion;
+public abstract interface class coil/bitmap/BitmapPool {
+	public static final field Companion Lcoil/bitmap/BitmapPool$Companion;
 	public abstract fun clear ()V
-	public static fun create (I)Lcoil/bitmappool/BitmapPool;
+	public static fun create (I)Lcoil/bitmap/BitmapPool;
 	public abstract fun get (IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;
 	public abstract fun getDirty (IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;
 	public abstract fun getDirtyOrNull (IILandroid/graphics/Bitmap$Config;)Landroid/graphics/Bitmap;
@@ -146,8 +146,8 @@ public abstract interface class coil/bitmappool/BitmapPool {
 	public abstract fun trimMemory (I)V
 }
 
-public final class coil/bitmappool/BitmapPool$Companion {
-	public final fun create (I)Lcoil/bitmappool/BitmapPool;
+public final class coil/bitmap/BitmapPool$Companion {
+	public final fun create (I)Lcoil/bitmap/BitmapPool;
 }
 
 public final class coil/collection/SparseIntArraySet {
@@ -213,7 +213,7 @@ public final class coil/decode/DecodeUtils {
 }
 
 public abstract interface class coil/decode/Decoder {
-	public abstract fun decode (Lcoil/bitmappool/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
 }
 
@@ -321,7 +321,7 @@ public abstract class coil/fetch/FetchResult {
 }
 
 public abstract interface class coil/fetch/Fetcher {
-	public abstract fun fetch (Lcoil/bitmappool/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun fetch (Lcoil/bitmap/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun handles (Ljava/lang/Object;)Z
 	public abstract fun key (Ljava/lang/Object;)Ljava/lang/String;
 }
@@ -830,7 +830,7 @@ public final class coil/transform/BlurTransformation : coil/transform/Transforma
 	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
-	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transform/CircleCropTransformation : coil/transform/Transformation {
@@ -839,7 +839,7 @@ public final class coil/transform/CircleCropTransformation : coil/transform/Tran
 	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
-	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transform/GrayscaleTransformation : coil/transform/Transformation {
@@ -848,7 +848,7 @@ public final class coil/transform/GrayscaleTransformation : coil/transform/Trans
 	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
-	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transform/RoundedCornersTransformation : coil/transform/Transformation {
@@ -860,12 +860,12 @@ public final class coil/transform/RoundedCornersTransformation : coil/transform/
 	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
-	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transform (Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class coil/transform/Transformation {
 	public abstract fun key ()Ljava/lang/String;
-	public abstract fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun transform (Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transition/CrossfadeTransition : coil/transition/Transition {

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -7,7 +7,7 @@ import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
 import coil.base.test.R
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
@@ -15,7 +15,7 @@ import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
 import coil.base.test.R
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.BitmapFactoryDecoder
 import coil.decode.DecodeResult
 import coil.decode.Decoder

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
@@ -16,12 +16,12 @@ import androidx.test.core.app.ApplicationProvider
 import coil.annotation.ExperimentalCoilApi
 import coil.base.test.R
 import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
 import coil.decode.BitmapFactoryDecoder
 import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
 import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
-import coil.memory.BitmapReferenceCounter
 import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
 import coil.memory.StrongMemoryCache

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -159,8 +159,7 @@ class BitmapFactoryDecoderTest {
         )
         assertEquals(PixelSize(1080, 1350), result.size)
 
-        // BitmapFactoryDecoder does not use pooled bitmaps on API 24+.
-        // Instead, we create immutable bitmaps.
+        // BitmapFactoryDecoder creates immutable bitmaps instead of using pooled bitmaps on API 24+.
         if (SDK_INT >= 24) {
             assertNotSame(pooledBitmap, result)
             assertFalse(result.isMutable)
@@ -186,8 +185,7 @@ class BitmapFactoryDecoderTest {
         )
         assertEquals(PixelSize(500, 625), result.size)
 
-        // BitmapFactoryDecoder does not use pooled bitmaps on API 24+.
-        // Instead, we create immutable bitmaps.
+        // BitmapFactoryDecoder creates immutable bitmaps instead of using pooled bitmaps on API 24+.
         when {
             SDK_INT >= 24 -> {
                 assertNotSame(pooledBitmap, result)

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -22,6 +22,9 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class BitmapFactoryDecoderTest {
@@ -155,7 +158,16 @@ class BitmapFactoryDecoderTest {
             )
         )
         assertEquals(PixelSize(1080, 1350), result.size)
-        assertEquals(pooledBitmap, result)
+
+        // BitmapFactoryDecoder does not use pooled bitmaps on API 24+.
+        // Instead, we create immutable bitmaps.
+        if (SDK_INT >= 24) {
+            assertNotSame(pooledBitmap, result)
+            assertFalse(result.isMutable)
+        } else {
+            assertSame(pooledBitmap, result)
+            assertTrue(result.isMutable)
+        }
     }
 
     @Test
@@ -173,8 +185,23 @@ class BitmapFactoryDecoderTest {
             )
         )
         assertEquals(PixelSize(500, 625), result.size)
-        // The bitmap should not be re-used on pre-API 19.
-        assertEquals(pooledBitmap === result, SDK_INT >= 19)
+
+        // BitmapFactoryDecoder does not use pooled bitmaps on API 24+.
+        // Instead, we create immutable bitmaps.
+        when {
+            SDK_INT >= 24 -> {
+                assertNotSame(pooledBitmap, result)
+                assertFalse(result.isMutable)
+            }
+            SDK_INT >= 19 -> {
+                assertSame(pooledBitmap, result)
+                assertTrue(result.isMutable)
+            }
+            else -> {
+                assertNotSame(pooledBitmap, result)
+                assertTrue(result.isMutable)
+            }
+        }
     }
 
     @Test

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -6,7 +6,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.createBitmap
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Scale

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -171,7 +171,7 @@ class BitmapFactoryDecoderTest {
 
     @Test
     fun pooledBitmap_inexactSize() {
-        val pooledBitmap = createBitmap(1080, 1350, Bitmap.Config.ARGB_8888)
+        val pooledBitmap = createBitmap(900, 850, Bitmap.Config.ARGB_8888)
         pool.put(pooledBitmap)
 
         val result = decodeBitmap(

--- a/coil-base/src/androidTest/java/coil/fetch/AssetUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/AssetUriFetcherTest.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.size.PixelSize
 import coil.util.createOptions

--- a/coil-base/src/androidTest/java/coil/fetch/ContentUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ContentUriFetcherTest.kt
@@ -18,7 +18,7 @@ import android.provider.ContactsContract.RawContacts
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.GrantPermissionRule
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.util.createOptions
 import kotlinx.coroutines.runBlocking

--- a/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
@@ -2,7 +2,7 @@ package coil.fetch
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.util.copyAssetToFile
 import coil.util.createOptions

--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -7,7 +7,7 @@ import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import coil.base.test.R
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DrawableDecoderService
 import coil.map.ResourceUriMapper
 import coil.size.PixelSize

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -8,7 +8,7 @@ import android.widget.ImageView
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.fetch.AssetUriFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.size.Size
 import coil.transform.Transformation

--- a/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
@@ -2,7 +2,7 @@ package coil.transform
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.util.decodeBitmapAsset
 import coil.util.isSimilarTo

--- a/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/GrayscaleTransformationTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.util.decodeBitmapAsset
 import coil.util.getPixels

--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -11,8 +11,8 @@ import coil.EventListener
 import coil.ImageLoader
 import coil.RealImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
-import coil.memory.BitmapReferenceCounter
+import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
 import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
 import coil.memory.StrongMemoryCache

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -204,9 +204,9 @@ interface ImageLoader {
          *
          * Default: [Utils.getDefaultAvailableMemoryPercentage]
          */
-        fun availableMemoryPercentage(@FloatRange(from = 0.0, to = 1.0) multiplier: Double) = apply {
-            require(multiplier in 0.0..1.0) { "Multiplier must be within the range [0.0, 1.0]." }
-            this.availableMemoryPercentage = multiplier
+        fun availableMemoryPercentage(@FloatRange(from = 0.0, to = 1.0) percent: Double) = apply {
+            require(percent in 0.0..1.0) { "Percent must be in the range [0.0, 1.0]." }
+            this.availableMemoryPercentage = percent
         }
 
         /**
@@ -219,9 +219,9 @@ interface ImageLoader {
          *
          * Default: [Utils.getDefaultBitmapPoolPercentage]
          */
-        fun bitmapPoolPercentage(@FloatRange(from = 0.0, to = 1.0) multiplier: Double) = apply {
-            require(multiplier in 0.0..1.0) { "Multiplier must be within the range [0.0, 1.0]." }
-            this.bitmapPoolPercentage = multiplier
+        fun bitmapPoolPercentage(@FloatRange(from = 0.0, to = 1.0) percent: Double) = apply {
+            require(percent in 0.0..1.0) { "Percent must be in the range [0.0, 1.0]." }
+            this.bitmapPoolPercentage = percent
         }
 
         /**
@@ -416,8 +416,7 @@ interface ImageLoader {
 
             val bitmapPool = RealBitmapPool(bitmapPoolSize, logger = logger)
             val weakMemoryCache = if (trackWeakReferences) RealWeakMemoryCache(logger) else EmptyWeakMemoryCache
-            val referenceCounter =
-                BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
+            val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
             val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize, logger)
 
             return RealImageLoader(

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -9,10 +9,10 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.annotation.FloatRange
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
-import coil.bitmappool.RealBitmapPool
+import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
+import coil.bitmap.RealBitmapPool
 import coil.drawable.CrossfadeDrawable
-import coil.memory.BitmapReferenceCounter
 import coil.memory.EmptyWeakMemoryCache
 import coil.memory.MemoryCache
 import coil.memory.RealWeakMemoryCache
@@ -416,7 +416,8 @@ interface ImageLoader {
 
             val bitmapPool = RealBitmapPool(bitmapPoolSize, logger = logger)
             val weakMemoryCache = if (trackWeakReferences) RealWeakMemoryCache(logger) else EmptyWeakMemoryCache
-            val referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
+            val referenceCounter =
+                BitmapReferenceCounter(weakMemoryCache, bitmapPool, logger)
             val memoryCache = StrongMemoryCache(weakMemoryCache, referenceCounter, memoryCacheSize, logger)
 
             return RealImageLoader(

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -4,7 +4,8 @@ import android.content.Context
 import android.util.Log
 import androidx.annotation.MainThread
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
 import coil.decode.BitmapFactoryDecoder
 import coil.decode.DrawableDecoderService
 import coil.fetch.AssetUriFetcher
@@ -21,7 +22,6 @@ import coil.map.HttpUriMapper
 import coil.map.ResourceIntMapper
 import coil.map.ResourceUriMapper
 import coil.map.StringMapper
-import coil.memory.BitmapReferenceCounter
 import coil.memory.DelegateService
 import coil.memory.RealMemoryCache
 import coil.memory.RequestService

--- a/coil-base/src/main/java/coil/bitmap/BitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/BitmapPool.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.content.ComponentCallbacks2
 import android.graphics.Bitmap

--- a/coil-base/src/main/java/coil/bitmap/BitmapPoolStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmap/BitmapPoolStrategy.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.graphics.Bitmap
 import android.os.Build.VERSION.SDK_INT

--- a/coil-base/src/main/java/coil/bitmap/BitmapPoolStrategy.kt
+++ b/coil-base/src/main/java/coil/bitmap/BitmapPoolStrategy.kt
@@ -95,7 +95,7 @@ internal class SizeStrategy : BitmapPoolStrategy {
     override fun toString() = "SizeStrategy: entries=$entries, sizes=$sizes"
 
     companion object {
-        private const val MAX_SIZE_MULTIPLE = 8
+        private const val MAX_SIZE_MULTIPLE = 4
     }
 }
 

--- a/coil-base/src/main/java/coil/bitmap/BitmapReferenceCounter.kt
+++ b/coil-base/src/main/java/coil/bitmap/BitmapReferenceCounter.kt
@@ -1,13 +1,13 @@
-package coil.memory
+package coil.bitmap
 
 import android.graphics.Bitmap
 import android.util.Log
 import android.util.SparseIntArray
 import androidx.annotation.VisibleForTesting
 import androidx.core.util.set
-import coil.bitmappool.BitmapPool
 import coil.collection.SparseIntArraySet
 import coil.collection.plusAssign
+import coil.memory.WeakMemoryCache
 import coil.util.Logger
 import coil.util.identityHashCode
 import coil.util.log

--- a/coil-base/src/main/java/coil/bitmap/Deprecated.kt
+++ b/coil-base/src/main/java/coil/bitmap/Deprecated.kt
@@ -1,0 +1,12 @@
+@file:JvmName("-Deprecated")
+@file:Suppress("PackageDirectoryMismatch", "unused")
+
+package coil.bitmappool
+
+import coil.bitmap.BitmapPool
+
+@Deprecated(
+    message = "BitmapPool moved to a different package.",
+    replaceWith = ReplaceWith("BitmapPool", "coil.bitmap.BitmapPool")
+)
+typealias BitmapPool = BitmapPool

--- a/coil-base/src/main/java/coil/bitmap/Deprecated.kt
+++ b/coil-base/src/main/java/coil/bitmap/Deprecated.kt
@@ -1,3 +1,4 @@
+// ktlint-disable filename
 @file:JvmName("-Deprecated")
 @file:Suppress("PackageDirectoryMismatch", "unused")
 

--- a/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW

--- a/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
@@ -11,7 +11,6 @@ import androidx.annotation.Px
 import androidx.core.graphics.createBitmap
 import coil.util.Logger
 import coil.util.allocationByteCountCompat
-import coil.util.identityHashCode
 import coil.util.isHardware
 import coil.util.log
 
@@ -45,7 +44,7 @@ internal class RealBitmapPool(
     override fun put(bitmap: Bitmap) {
         if (bitmap.isRecycled) {
             logger?.log(TAG, Log.ERROR) {
-                "Rejecting recycled bitmap from pool; bitmap: ${bitmap.identityHashCode}"
+                "Rejecting recycled bitmap from pool; bitmap: $bitmap"
             }
             return
         }

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -10,7 +10,7 @@ import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.applyCanvas
 import androidx.exifinterface.media.ExifInterface
 import coil.annotation.InternalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.size.Size
 import coil.util.toDrawable

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -79,7 +79,8 @@ internal class BitmapFactoryDecoder(private val context: Context) : Decoder {
             inPreferredColorSpace = options.colorSpace
         }
 
-        inMutable = SDK_INT < 26 || inPreferredConfig != Bitmap.Config.HARDWARE
+        // Create immutable bitmaps on API 24 and above.
+        inMutable = SDK_INT < 24
         inScaled = false
 
         when {

--- a/coil-base/src/main/java/coil/decode/DataSource.kt
+++ b/coil-base/src/main/java/coil/decode/DataSource.kt
@@ -18,7 +18,7 @@ import java.nio.ByteBuffer
 enum class DataSource {
 
     /**
-     * Represents an [ImageLoader]'s internal memory cache.
+     * Represents an [ImageLoader]'s memory cache.
      *
      * This is a special data source as it means the request was
      * short circuited and skipped the full image pipeline.

--- a/coil-base/src/main/java/coil/decode/Decoder.kt
+++ b/coil-base/src/main/java/coil/decode/Decoder.kt
@@ -2,7 +2,7 @@ package coil.decode
 
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import okio.BufferedSource
 

--- a/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
+++ b/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
@@ -9,7 +9,7 @@ import androidx.core.graphics.component1
 import androidx.core.graphics.component2
 import androidx.core.graphics.component3
 import androidx.core.graphics.component4
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.size.Scale
 import coil.size.Size

--- a/coil-base/src/main/java/coil/decode/EmptyDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/EmptyDecoder.kt
@@ -2,7 +2,7 @@ package coil.decode
 
 import android.graphics.drawable.ColorDrawable
 import coil.ComponentRegistry
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import okio.BufferedSource
 import okio.blackholeSink

--- a/coil-base/src/main/java/coil/fetch/AssetUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/AssetUriFetcher.kt
@@ -4,7 +4,7 @@ import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.webkit.MimeTypeMap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
 import coil.size.Size

--- a/coil-base/src/main/java/coil/fetch/BitmapFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/BitmapFetcher.kt
@@ -2,7 +2,7 @@ package coil.fetch
 
 import android.content.Context
 import android.graphics.Bitmap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
 import coil.size.Size

--- a/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
@@ -6,7 +6,7 @@ import android.net.Uri
 import android.provider.ContactsContract
 import android.provider.ContactsContract.Contacts
 import androidx.annotation.VisibleForTesting
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
 import coil.size.Size

--- a/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
@@ -2,7 +2,7 @@ package coil.fetch
 
 import android.content.Context
 import android.graphics.drawable.Drawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.DrawableDecoderService
 import coil.decode.Options

--- a/coil-base/src/main/java/coil/fetch/Fetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/Fetcher.kt
@@ -4,7 +4,7 @@ package coil.fetch
 
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.Options
 import coil.memory.StrongMemoryCache
 import coil.size.Size

--- a/coil-base/src/main/java/coil/fetch/FileFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/FileFetcher.kt
@@ -1,7 +1,7 @@
 package coil.fetch
 
 import android.webkit.MimeTypeMap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
 import coil.size.Size

--- a/coil-base/src/main/java/coil/fetch/HttpUrlFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/HttpUrlFetcher.kt
@@ -1,7 +1,7 @@
 package coil.fetch
 
 import android.webkit.MimeTypeMap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
 import coil.network.HttpException

--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.TypedValue
 import android.webkit.MimeTypeMap
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.DrawableDecoderService
 import coil.decode.Options

--- a/coil-base/src/main/java/coil/interceptor/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/interceptor/EngineInterceptor.kt
@@ -7,7 +7,7 @@ import androidx.annotation.VisibleForTesting
 import coil.ComponentRegistry
 import coil.EventListener
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.DecodeUtils
 import coil.decode.DrawableDecoderService

--- a/coil-base/src/main/java/coil/memory/DelegateService.kt
+++ b/coil-base/src/main/java/coil/memory/DelegateService.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.LifecycleObserver
 import coil.EventListener
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
+import coil.bitmap.BitmapReferenceCounter
 import coil.request.ImageRequest
 import coil.target.PoolableViewTarget
 import coil.target.Target

--- a/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/RealMemoryCache.kt
@@ -1,6 +1,7 @@
 package coil.memory
 
 import android.graphics.Bitmap
+import coil.bitmap.BitmapReferenceCounter
 import coil.memory.MemoryCache.Key
 
 internal class RealMemoryCache(

--- a/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
@@ -7,6 +7,7 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.collection.LruCache
+import coil.bitmap.BitmapReferenceCounter
 import coil.memory.MemoryCache.Key
 import coil.memory.RealMemoryCache.Value
 import coil.util.Logger

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -11,6 +11,7 @@ import androidx.annotation.MainThread
 import coil.EventListener
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
+import coil.bitmap.BitmapReferenceCounter
 import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.RequestResult

--- a/coil-base/src/main/java/coil/request/DefinedRequestOptions.kt
+++ b/coil-base/src/main/java/coil/request/DefinedRequestOptions.kt
@@ -12,7 +12,8 @@ import coil.transition.Transition
 import kotlinx.coroutines.CoroutineDispatcher
 
 /**
- * Tracks which values have been set (instead of computed automatically using a default) when building an [ImageRequest].
+ * Tracks which values have been set (instead of computed automatically using a default)
+ * when building an [ImageRequest].
  *
  * @see ImageRequest.defined
  */

--- a/coil-base/src/main/java/coil/request/NullRequestDataException.kt
+++ b/coil-base/src/main/java/coil/request/NullRequestDataException.kt
@@ -1,9 +1,8 @@
 package coil.request
 
 import coil.ImageLoader
-import kotlin.coroutines.CoroutineContext
 
 /**
- * Exception thrown by [ImageLoader.execute] (inside the [CoroutineContext]) when [ImageRequest.data] is null.
+ * Exception thrown when an [ImageRequest] with empty/null data is executed by an [ImageLoader].
  */
 class NullRequestDataException : RuntimeException("The request's data is null.")

--- a/coil-base/src/main/java/coil/transform/BlurTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/BlurTransformation.kt
@@ -11,7 +11,7 @@ import android.renderscript.RenderScript
 import android.renderscript.ScriptIntrinsicBlur
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.applyCanvas
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.util.safeConfig
 

--- a/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
@@ -7,7 +7,7 @@ import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import androidx.core.graphics.applyCanvas
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.util.safeConfig
 import kotlin.math.min

--- a/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
@@ -7,7 +7,7 @@ import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import androidx.core.graphics.applyCanvas
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.Size
 import coil.util.safeConfig
 

--- a/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
@@ -13,7 +13,7 @@ import android.graphics.RectF
 import android.graphics.Shader
 import androidx.annotation.Px
 import androidx.core.graphics.applyCanvas
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DecodeUtils
 import coil.size.OriginalSize
 import coil.size.PixelSize

--- a/coil-base/src/main/java/coil/transform/Transformation.kt
+++ b/coil-base/src/main/java/coil/transform/Transformation.kt
@@ -2,7 +2,7 @@ package coil.transform
 
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DecodeResult
 import coil.fetch.DrawableResult
 import coil.request.ImageRequest

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -63,12 +63,12 @@ internal object Utils {
 
     fun getDefaultBitmapPoolPercentage(): Double {
         return when {
-            // We strongly prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
-            // Maintain a small pool for transformations
+            // We prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
+            // Maintain a small pool for cases where we need to draw on a canvas.
             SDK_INT >= 24 -> 0.1
-            // Bitmap pooling is most effective for API 19-24.
+            // Bitmap pooling is most effective for APIs 19 to 23.
             SDK_INT >= 19 -> 0.5
-            // The requirements for bitmap reuse are quite strict below API 19.
+            // The requirements for bitmap reuse are strict below API 19.
             else -> 0.25
         }
     }

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -63,9 +63,8 @@ internal object Utils {
 
     fun getDefaultBitmapPoolPercentage(): Double {
         return when {
-            // We prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
-            // Maintain a small pool for cases where we need to draw on a canvas.
-            SDK_INT >= 24 -> 0.1
+            // Prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
+            SDK_INT >= 24 -> 0.0
             // Bitmap pooling is most effective for APIs 19 to 23.
             SDK_INT >= 19 -> 0.5
             // The requirements for bitmap reuse are strict below API 19.

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -62,10 +62,14 @@ internal object Utils {
     }
 
     fun getDefaultBitmapPoolPercentage(): Double {
-        // Allocate less memory for bitmap pooling on API 18 and below as the requirements
-        // for bitmap reuse are quite strict.
-        // Allocate less memory for bitmap pooling on API 26 and above since we default to
-        // hardware bitmaps, which cannot be reused.
-        return if (SDK_INT in 19..25) 0.5 else 0.25
+        return when {
+            // We strongly prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
+            // Maintain a small pool for transformations
+            SDK_INT >= 24 -> 0.1
+            // Bitmap pooling is most effective for API 19-24.
+            SDK_INT >= 19 -> 0.5
+            // The requirements for bitmap reuse are quite strict below API 19.
+            else -> 0.25
+        }
     }
 }

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -65,7 +65,7 @@ internal object Utils {
         return when {
             // Prefer immutable bitmaps (which cannot be pooled) on API 24 and greater.
             SDK_INT >= 24 -> 0.0
-            // Bitmap pooling is most effective for APIs 19 to 23.
+            // Bitmap pooling is most effective on APIs 19 to 23.
             SDK_INT >= 19 -> 0.5
             // The requirements for bitmap reuse are strict below API 19.
             else -> 0.25

--- a/coil-base/src/test/java/coil/bitmap/AttributeStrategyTest.kt
+++ b/coil-base/src/test/java/coil/bitmap/AttributeStrategyTest.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.graphics.Bitmap
 import coil.util.createBitmap
@@ -9,13 +9,13 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
-class SizeStrategyTest {
+class AttributeStrategyTest {
 
-    private lateinit var strategy: SizeStrategy
+    private lateinit var strategy: AttributeStrategy
 
     @Before
     fun before() {
-        strategy = SizeStrategy()
+        strategy = AttributeStrategy()
     }
 
     @Test
@@ -35,20 +35,18 @@ class SizeStrategyTest {
     }
 
     @Test
-    fun `large enough bitmap with different config is reused`() {
+    fun `large enough bitmap with different config is not reused`() {
         val bitmap = createBitmap(width = 250, height = 250, config = Bitmap.Config.RGB_565)
         strategy.put(bitmap)
 
-        assertEquals(bitmap, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
+        assertEquals(null, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
     }
 
     @Test
-    fun `only puts are factored into ceilingKey`() {
-        strategy.put(createBitmap(100, 100, Bitmap.Config.ARGB_8888))
-        strategy.get(200, 100, Bitmap.Config.ARGB_8888)
-        val expected = createBitmap(300, 100, Bitmap.Config.ARGB_8888)
-        strategy.put(expected)
+    fun `large enough bitmap with different size is not reused`() {
+        val bitmap = createBitmap(width = 150, height = 150)
+        strategy.put(bitmap)
 
-        assertEquals(expected, strategy.get(200, 100, Bitmap.Config.ARGB_8888))
+        assertEquals(null, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
     }
 }

--- a/coil-base/src/test/java/coil/bitmap/BitmapReferenceCounterTest.kt
+++ b/coil-base/src/test/java/coil/bitmap/BitmapReferenceCounterTest.kt
@@ -1,7 +1,8 @@
-package coil.memory
+package coil.bitmap
 
-import coil.bitmappool.BitmapPool
 import coil.memory.MemoryCache.Key
+import coil.memory.RealWeakMemoryCache
+import coil.memory.WeakMemoryCache
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.count
 import coil.util.createBitmap

--- a/coil-base/src/test/java/coil/bitmap/FakeBitmapPool.kt
+++ b/coil-base/src/test/java/coil/bitmap/FakeBitmapPool.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.graphics.Bitmap
 import android.os.Build.VERSION.SDK_INT

--- a/coil-base/src/test/java/coil/bitmap/FakeBitmapPoolStrategy.kt
+++ b/coil-base/src/test/java/coil/bitmap/FakeBitmapPoolStrategy.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.graphics.Bitmap
 import java.util.ArrayDeque

--- a/coil-base/src/test/java/coil/bitmap/RealBitmapPoolTest.kt
+++ b/coil-base/src/test/java/coil/bitmap/RealBitmapPoolTest.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
 import android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE

--- a/coil-base/src/test/java/coil/bitmap/SizeStrategyTest.kt
+++ b/coil-base/src/test/java/coil/bitmap/SizeStrategyTest.kt
@@ -1,4 +1,4 @@
-package coil.bitmappool
+package coil.bitmap
 
 import android.graphics.Bitmap
 import coil.util.createBitmap
@@ -9,13 +9,13 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
-class AttributeStrategyTest {
+class SizeStrategyTest {
 
-    private lateinit var strategy: AttributeStrategy
+    private lateinit var strategy: SizeStrategy
 
     @Before
     fun before() {
-        strategy = AttributeStrategy()
+        strategy = SizeStrategy()
     }
 
     @Test
@@ -35,18 +35,20 @@ class AttributeStrategyTest {
     }
 
     @Test
-    fun `large enough bitmap with different config is not reused`() {
+    fun `large enough bitmap with different config is reused`() {
         val bitmap = createBitmap(width = 250, height = 250, config = Bitmap.Config.RGB_565)
         strategy.put(bitmap)
 
-        assertEquals(null, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
+        assertEquals(bitmap, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
     }
 
     @Test
-    fun `large enough bitmap with different size is not reused`() {
-        val bitmap = createBitmap(width = 150, height = 150)
-        strategy.put(bitmap)
+    fun `only puts are factored into ceilingKey`() {
+        strategy.put(createBitmap(100, 100, Bitmap.Config.ARGB_8888))
+        strategy.get(200, 100, Bitmap.Config.ARGB_8888)
+        val expected = createBitmap(300, 100, Bitmap.Config.ARGB_8888)
+        strategy.put(expected)
 
-        assertEquals(null, strategy.get(100, 100, Bitmap.Config.ARGB_8888))
+        assertEquals(expected, strategy.get(200, 100, Bitmap.Config.ARGB_8888))
     }
 }

--- a/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
+++ b/coil-base/src/test/java/coil/decode/DrawableDecoderServiceTest.kt
@@ -2,7 +2,7 @@ package coil.decode
 
 import android.graphics.Bitmap
 import android.graphics.drawable.VectorDrawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.size.Scale
 import coil.util.size

--- a/coil-base/src/test/java/coil/fetch/HttpUrlFetcherTest.kt
+++ b/coil-base/src/test/java/coil/fetch/HttpUrlFetcherTest.kt
@@ -2,7 +2,7 @@ package coil.fetch
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.util.createMockWebServer
 import coil.util.createOptions

--- a/coil-base/src/test/java/coil/interceptor/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/interceptor/EngineInterceptorTest.kt
@@ -11,13 +11,13 @@ import coil.EventListener
 import coil.ImageLoader
 import coil.RealImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
 import coil.decode.DataSource
 import coil.decode.DrawableDecoderService
 import coil.decode.Options
 import coil.fetch.DrawableResult
 import coil.fetch.Fetcher
-import coil.memory.BitmapReferenceCounter
 import coil.memory.MemoryCache.Key
 import coil.memory.RealMemoryCache
 import coil.memory.RealWeakMemoryCache

--- a/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/RealMemoryCacheTest.kt
@@ -1,6 +1,7 @@
 package coil.memory
 
-import coil.bitmappool.FakeBitmapPool
+import coil.bitmap.BitmapReferenceCounter
+import coil.bitmap.FakeBitmapPool
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.allocationByteCountCompat
 import coil.util.createBitmap

--- a/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
+++ b/coil-base/src/test/java/coil/memory/StrongMemoryCacheTest.kt
@@ -1,6 +1,7 @@
 package coil.memory
 
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
+import coil.bitmap.BitmapReferenceCounter
 import coil.memory.MemoryCache.Key
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.createBitmap

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -6,7 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import coil.EventListener
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
-import coil.bitmappool.FakeBitmapPool
+import coil.bitmap.BitmapReferenceCounter
+import coil.bitmap.FakeBitmapPool
 import coil.decode.DataSource
 import coil.request.ErrorResult
 import coil.request.Metadata

--- a/coil-base/src/test/java/coil/util/TestExtensions.kt
+++ b/coil-base/src/test/java/coil/util/TestExtensions.kt
@@ -2,7 +2,7 @@ package coil.util
 
 import android.graphics.Bitmap
 import androidx.annotation.VisibleForTesting
-import coil.memory.BitmapReferenceCounter
+import coil.bitmap.BitmapReferenceCounter
 import coil.memory.RealWeakMemoryCache
 
 /** Return the current reference count for [bitmap]. */

--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -2,7 +2,7 @@ public final class coil/decode/GifDecoder : coil/decode/Decoder {
 	public static final field Companion Lcoil/decode/GifDecoder$Companion;
 	public static final field REPEAT_COUNT_KEY Ljava/lang/String;
 	public fun <init> ()V
-	public fun decode (Lcoil/bitmappool/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
 }
 
@@ -13,7 +13,7 @@ public final class coil/decode/ImageDecoderDecoder : coil/decode/Decoder {
 	public static final field Companion Lcoil/decode/ImageDecoderDecoder$Companion;
 	public static final field REPEAT_COUNT_KEY Ljava/lang/String;
 	public fun <init> ()V
-	public fun decode (Lcoil/bitmappool/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
 }
 
@@ -23,10 +23,10 @@ public final class coil/decode/ImageDecoderDecoder$Companion {
 public final class coil/drawable/MovieDrawable : android/graphics/drawable/Drawable, androidx/vectordrawable/graphics/drawable/Animatable2Compat {
 	public static final field Companion Lcoil/drawable/MovieDrawable$Companion;
 	public static final field REPEAT_INFINITE I
-	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmappool/BitmapPool;)V
-	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap$Config;)V
-	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap$Config;Lcoil/size/Scale;)V
-	public synthetic fun <init> (Landroid/graphics/Movie;Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap$Config;Lcoil/size/Scale;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;)V
+	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap$Config;)V
+	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap$Config;Lcoil/size/Scale;)V
+	public synthetic fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap$Config;Lcoil/size/Scale;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearAnimationCallbacks ()V
 	public fun draw (Landroid/graphics/Canvas;)V
 	public final fun getConfig ()Landroid/graphics/Bitmap$Config;

--- a/coil-gif/src/main/java/coil/decode/GifDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/GifDecoder.kt
@@ -6,7 +6,7 @@ import android.graphics.Bitmap
 import android.graphics.Movie
 import android.os.Build.VERSION.SDK_INT
 import coil.annotation.InternalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.drawable.MovieDrawable
 import coil.request.repeatCount
 import coil.size.Size

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -11,7 +11,7 @@ import androidx.core.graphics.decodeDrawable
 import androidx.core.util.component1
 import androidx.core.util.component2
 import coil.annotation.InternalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.drawable.ScaleDrawable
 import coil.request.repeatCount
 import coil.size.PixelSize

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -17,7 +17,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.os.SystemClock
 import androidx.core.graphics.withSave
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DecodeUtils
 import coil.decode.ImageDecoderDecoder
 import coil.size.Scale

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -21,6 +21,7 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
 
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
+            .allowHardware(false)
             .availableMemoryPercentage(0.25) // Use 25% of the application's available memory.
             .crossfade(false) // Show a short crossfade when loading images from network or disk.
             .componentRegistry {

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -21,7 +21,6 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
 
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
-            .allowHardware(false)
             .availableMemoryPercentage(0.25) // Use 25% of the application's available memory.
             .crossfade(false) // Show a short crossfade when loading images from network or disk.
             .componentRegistry {

--- a/coil-svg/api/coil-svg.api
+++ b/coil-svg/api/coil-svg.api
@@ -1,7 +1,7 @@
 public final class coil/decode/SvgDecoder : coil/decode/Decoder {
 	public static final field Companion Lcoil/decode/SvgDecoder$Companion;
 	public fun <init> (Landroid/content/Context;)V
-	public fun decode (Lcoil/bitmappool/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
 }
 

--- a/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
+++ b/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
@@ -3,7 +3,7 @@ package coil.decode
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.PixelSize
 import coil.size.Scale
 import coil.util.createOptions

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -8,7 +8,7 @@ import android.graphics.Canvas
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.drawable.toDrawable
 import coil.annotation.InternalCoilApi
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -11,7 +11,7 @@ public abstract class coil/fetch/VideoFrameFetcher : coil/fetch/Fetcher {
 	public static final field VIDEO_FRAME_MICROS_KEY Ljava/lang/String;
 	public static final field VIDEO_FRAME_OPTION_KEY Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;)V
-	public fun fetch (Lcoil/bitmappool/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun fetch (Lcoil/bitmap/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Ljava/lang/Object;)Z
 	protected abstract fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
 }

--- a/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
+++ b/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
@@ -6,7 +6,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.fetch.VideoFrameFetcher.Companion.ASSET_FILE_PATH_ROOT
 import coil.fetch.VideoFrameFetcher.Companion.VIDEO_FRAME_MICROS_KEY
 import coil.request.Parameters

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -14,7 +14,7 @@ import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.drawable.toDrawable
-import coil.bitmappool.BitmapPool
+import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.DecodeUtils
 import coil.decode.Decoder


### PR DESCRIPTION
Talked with a member of the Android graphics team and they recommended preferring immutable bitmaps on Android N+ as [this change](https://cs.android.com/android/_/android/platform/frameworks/base/+/775873a66a946fae2b0535abb51df9817bd1b20c) makes bitmap pooling much less important. Immutable software bitmaps also "don't need to stay pinned in the GPU texture cache like mutable ones do, since we know we're free to re-upload whenever we want/need."

This disables bitmap reuse on N+, however we still call `Bitmap.recycle()` to eagerly free memory when a bitmap's reference count reaches zero. Disabling bitmap reuse doesn't affect decode performance, but will result in creating more bitmaps - though each bitmap will be the exact minimum required size (and they're much cheaper on N+). Overall, I'm following the recommendation of the graphics team here.

Bitmap pool size can still be set manually by consumers using `ImageLoader.Builder.bitmapPoolPercentage` - this PR just changes the default.

This also moves common bitmap pooling-related classes to the `coil.bitmap` package for consistency.