### PR TITLE
Add equals/hashCode/toString implementations.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -683,7 +683,10 @@ public final class coil/request/SuccessResult : coil/request/RequestResult {
 
 public final class coil/size/DisplaySizeResolver : coil/size/SizeResolver {
 	public fun <init> (Landroid/content/Context;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun size (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class coil/size/OriginalSize : coil/size/Size {
@@ -770,9 +773,11 @@ public final class coil/size/ViewSizeResolver$DefaultImpls {
 
 public class coil/target/ImageViewTarget : androidx/lifecycle/DefaultLifecycleObserver, coil/target/PoolableViewTarget, coil/transition/TransitionTarget {
 	public fun <init> (Landroid/widget/ImageView;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getDrawable ()Landroid/graphics/drawable/Drawable;
 	public synthetic fun getView ()Landroid/view/View;
 	public fun getView ()Landroid/widget/ImageView;
+	public fun hashCode ()I
 	public fun onClear ()V
 	public fun onError (Landroid/graphics/drawable/Drawable;)V
 	public fun onStart (Landroid/graphics/drawable/Drawable;)V
@@ -780,6 +785,7 @@ public class coil/target/ImageViewTarget : androidx/lifecycle/DefaultLifecycleOb
 	public fun onStop (Landroidx/lifecycle/LifecycleOwner;)V
 	public fun onSuccess (Landroid/graphics/drawable/Drawable;)V
 	protected fun setDrawable (Landroid/graphics/drawable/Drawable;)V
+	public fun toString ()Ljava/lang/String;
 	protected fun updateAnimation ()V
 }
 
@@ -820,19 +826,28 @@ public final class coil/transform/BlurTransformation : coil/transform/Transforma
 	public fun <init> (Landroid/content/Context;F)V
 	public fun <init> (Landroid/content/Context;FF)V
 	public synthetic fun <init> (Landroid/content/Context;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transform/CircleCropTransformation : coil/transform/Transformation {
 	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transform/GrayscaleTransformation : coil/transform/Transformation {
 	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -841,7 +856,10 @@ public final class coil/transform/RoundedCornersTransformation : coil/transform/
 	public fun <init> (F)V
 	public fun <init> (FFFF)V
 	public synthetic fun <init> (FFFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
 	public fun key ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
 	public fun transform (Lcoil/bitmappool/BitmapPool;Landroid/graphics/Bitmap;Lcoil/size/Size;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -854,7 +872,10 @@ public final class coil/transition/CrossfadeTransition : coil/transition/Transit
 	public fun <init> ()V
 	public fun <init> (I)V
 	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDurationMillis ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/RequestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -53,9 +53,7 @@ class Parameters private constructor(
     }
 
     override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        return other is Parameters &&
-            map == other.map
+        return (this === other) || (other is Parameters && map == other.map)
     }
 
     override fun hashCode() = map.hashCode()

--- a/coil-base/src/main/java/coil/size/DisplaySizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/DisplaySizeResolver.kt
@@ -14,4 +14,12 @@ class DisplaySizeResolver(private val context: Context) : SizeResolver {
     override suspend fun size(): Size {
         return context.resources.displayMetrics.run { PixelSize(widthPixels, heightPixels) }
     }
+
+    override fun equals(other: Any?): Boolean {
+        return (this === other) || (other is DisplaySizeResolver && context == other.context)
+    }
+
+    override fun hashCode() = context.hashCode()
+
+    override fun toString() = "DisplaySizeResolver(context=$context)"
 }

--- a/coil-base/src/main/java/coil/size/RealSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/RealSizeResolver.kt
@@ -1,0 +1,14 @@
+package coil.size
+
+internal class RealSizeResolver(val size: Size) : SizeResolver {
+
+    override suspend fun size() = size
+
+    override fun equals(other: Any?): Boolean {
+        return (this === other) || (other is RealSizeResolver && size == other.size)
+    }
+
+    override fun hashCode() = size.hashCode()
+
+    override fun toString() = "RealSizeResolver(size=$size)"
+}

--- a/coil-base/src/main/java/coil/size/RealViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/RealViewSizeResolver.kt
@@ -1,0 +1,22 @@
+package coil.size
+
+import android.view.View
+
+internal class RealViewSizeResolver<T : View>(
+    override val view: T,
+    override val subtractPadding: Boolean
+) : ViewSizeResolver<T> {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is RealViewSizeResolver<*> &&
+            view == other.view &&
+            subtractPadding == other.subtractPadding
+    }
+
+    override fun hashCode(): Int {
+        var result = view.hashCode()
+        result = 31 * result + subtractPadding.hashCode()
+        return result
+    }
+}

--- a/coil-base/src/main/java/coil/size/RealViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/RealViewSizeResolver.kt
@@ -19,4 +19,8 @@ internal class RealViewSizeResolver<T : View>(
         result = 31 * result + subtractPadding.hashCode()
         return result
     }
+
+    override fun toString(): String {
+        return "RealViewSizeResolver(view=$view, subtractPadding=$subtractPadding)"
+    }
 }

--- a/coil-base/src/main/java/coil/size/SizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/SizeResolver.kt
@@ -14,11 +14,7 @@ interface SizeResolver {
         /** Create a [SizeResolver] with a fixed [size]. */
         @JvmStatic
         @JvmName("create")
-        operator fun invoke(size: Size): SizeResolver {
-            return object : SizeResolver {
-                override suspend fun size() = size
-            }
-        }
+        operator fun invoke(size: Size): SizeResolver = RealSizeResolver(size)
     }
 
     /** Return the [Size] that the image should be loaded at. */

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -19,12 +19,10 @@ interface ViewSizeResolver<T : View> : SizeResolver {
         @JvmStatic
         // @JvmOverloads https://youtrack.jetbrains.com/issue/KT-35716
         @JvmName("create")
-        operator fun <T : View> invoke(view: T, subtractPadding: Boolean = true): ViewSizeResolver<T> {
-            return object : ViewSizeResolver<T> {
-                override val view = view
-                override val subtractPadding = subtractPadding
-            }
-        }
+        operator fun <T : View> invoke(
+            view: T,
+            subtractPadding: Boolean = true
+        ): ViewSizeResolver<T> = RealViewSizeResolver(view, subtractPadding)
     }
 
     /** The [View] to measure. This field should be immutable. */

--- a/coil-base/src/main/java/coil/target/ImageViewTarget.kt
+++ b/coil-base/src/main/java/coil/target/ImageViewTarget.kt
@@ -49,4 +49,12 @@ open class ImageViewTarget(
         val animatable = view.drawable as? Animatable ?: return
         if (isStarted) animatable.start() else animatable.stop()
     }
+
+    override fun equals(other: Any?): Boolean {
+        return (this === other) || (other is ImageViewTarget && view == other.view)
+    }
+
+    override fun hashCode() = view.hashCode()
+
+    override fun toString() = "ImageViewTarget(view=$view)"
 }

--- a/coil-base/src/main/java/coil/transform/BlurTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/BlurTransformation.kt
@@ -72,6 +72,25 @@ class BlurTransformation @JvmOverloads constructor(
         return output
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is BlurTransformation &&
+            context == other.context &&
+            radius == other.radius &&
+            sampling == other.sampling
+    }
+
+    override fun hashCode(): Int {
+        var result = context.hashCode()
+        result = 31 * result + radius.hashCode()
+        result = 31 * result + sampling.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "BlurTransformation(context=$context, radius=$radius, sampling=$sampling)"
+    }
+
     private companion object {
         private const val DEFAULT_RADIUS = 10f
         private const val DEFAULT_SAMPLING = 1f

--- a/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/CircleCropTransformation.kt
@@ -35,6 +35,12 @@ class CircleCropTransformation : Transformation {
         return output
     }
 
+    override fun equals(other: Any?) = other is CircleCropTransformation
+
+    override fun hashCode() = javaClass.hashCode()
+
+    override fun toString() = "CircleCropTransformation()"
+
     private companion object {
         val XFERMODE = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
     }

--- a/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/GrayscaleTransformation.kt
@@ -31,6 +31,12 @@ class GrayscaleTransformation : Transformation {
         return output
     }
 
+    override fun equals(other: Any?) = other is GrayscaleTransformation
+
+    override fun hashCode() = javaClass.hashCode()
+
+    override fun toString() = "GrayscaleTransformation()"
+
     private companion object {
         val COLOR_FILTER = ColorMatrixColorFilter(ColorMatrix().apply { setSaturation(0f) })
     }

--- a/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
@@ -87,4 +87,26 @@ class RoundedCornersTransformation(
 
         return output
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is RoundedCornersTransformation &&
+            topLeft == other.topLeft &&
+            topRight == other.topRight &&
+            bottomLeft == other.bottomLeft &&
+            bottomRight == other.bottomRight
+    }
+
+    override fun hashCode(): Int {
+        var result = topLeft.hashCode()
+        result = 31 * result + topRight.hashCode()
+        result = 31 * result + bottomLeft.hashCode()
+        result = 31 * result + bottomRight.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "RoundedCornersTransformation(topLeft=$topLeft, topRight=$topRight, " +
+            "bottomLeft=$bottomLeft, bottomRight=$bottomRight)"
+    }
 }

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -70,4 +70,12 @@ class CrossfadeTransition @JvmOverloads constructor(
             throw throwable
         }
     }
+
+    override fun equals(other: Any?): Boolean {
+        return (this === other) || (other is CrossfadeTransition && durationMillis == other.durationMillis)
+    }
+
+    override fun hashCode() = durationMillis.hashCode()
+
+    override fun toString() = "CrossfadeTransition(durationMillis=$durationMillis)"
 }

--- a/coil-base/src/main/java/coil/transition/NoneTransition.kt
+++ b/coil-base/src/main/java/coil/transition/NoneTransition.kt
@@ -8,8 +8,8 @@ import coil.request.SuccessResult
 /**
  * A transition that applies the [RequestResult] on the [TransitionTarget] without animating.
  */
-@OptIn(ExperimentalCoilApi::class)
-internal object EmptyTransition : Transition {
+@ExperimentalCoilApi
+internal object NoneTransition : Transition {
 
     override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
         when (result) {
@@ -17,4 +17,6 @@ internal object EmptyTransition : Transition {
             is ErrorResult -> target.onError(result.drawable)
         }
     }
+
+    override fun toString() = "coil.transition.NoneTransition"
 }

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -31,6 +31,6 @@ interface Transition {
     suspend fun transition(target: TransitionTarget<*>, result: RequestResult)
 
     companion object {
-        @JvmField val NONE: Transition = EmptyTransition
+        @JvmField val NONE: Transition = NoneTransition
     }
 }

--- a/coil-base/src/test/java/coil/request/ImageRequestTest.kt
+++ b/coil-base/src/test/java/coil/request/ImageRequestTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -144,5 +145,28 @@ class ImageRequestTest {
         assertSame(defaults.dispatcher, request.dispatcher)
         assertSame(defaults.transition, request.transition)
         assertSame(defaults.precision, request.precision)
+    }
+
+    @Test
+    fun `test equality`() {
+        val imageView = ImageView(context)
+        val request1 = ImageRequest.Builder(context)
+            .data("https://www.example.com/image.jpg")
+            .target(imageView)
+            .allowHardware(true)
+            .build()
+        val request2 = ImageRequest.Builder(context)
+            .data("https://www.example.com/image.jpg")
+            .target(imageView)
+            .allowHardware(true)
+            .build()
+
+        assertEquals(request1, request2)
+
+        val request3 = request2.newBuilder()
+            .allowHardware(false)
+            .build()
+
+        assertNotEquals(request1, request3)
     }
 }


### PR DESCRIPTION
Adds equals/hashCode/toString implementations to all classes that can be part of an `ImageRequest`. This works toward fixing #405.