### PR TITLE
Rename RequestResult and RequestDisposable.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -597,6 +597,8 @@ public abstract class coil/request/ImageResult {
 
 public final class coil/request/Metadata {
 	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)V
+	public final fun copy (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)Lcoil/request/Metadata;
+	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataSource ()Lcoil/decode/DataSource;
 	public final fun getKey ()Lcoil/memory/MemoryCache$Key;

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -597,6 +597,9 @@ public abstract class coil/request/ImageResult {
 
 public final class coil/request/Metadata {
 	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)V
+	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcoil/decode/DataSource;
 	public final fun copy (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)Lcoil/request/Metadata;
 	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
 	public fun equals (Ljava/lang/Object;)Z

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -76,7 +76,7 @@ public abstract interface class coil/ImageLoader {
 	public static final field Companion Lcoil/ImageLoader$Companion;
 	public abstract fun clearMemory ()V
 	public static fun create (Landroid/content/Context;)Lcoil/ImageLoader;
-	public abstract fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/RequestDisposable;
+	public abstract fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/Disposable;
 	public abstract fun execute (Lcoil/request/ImageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getBitmapPool ()Lcoil/bitmap/BitmapPool;
 	public abstract fun getDefaults ()Lcoil/request/DefaultRequestOptions;
@@ -457,7 +457,13 @@ public final class coil/request/DefinedRequestOptions {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class coil/request/ErrorResult : coil/request/RequestResult {
+public abstract interface class coil/request/Disposable {
+	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun dispose ()V
+	public abstract fun isDisposed ()Z
+}
+
+public final class coil/request/ErrorResult : coil/request/ImageResult {
 	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Lcoil/request/ImageRequest;
@@ -584,6 +590,11 @@ public final class coil/request/ImageRequest$Listener$DefaultImpls {
 	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
 }
 
+public abstract class coil/request/ImageResult {
+	public abstract fun getDrawable ()Landroid/graphics/drawable/Drawable;
+	public abstract fun getRequest ()Lcoil/request/ImageRequest;
+}
+
 public final class coil/request/Metadata {
 	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -654,18 +665,7 @@ public final class coil/request/ParametersKt {
 	public static final fun isNotEmpty (Lcoil/request/Parameters;)Z
 }
 
-public abstract interface class coil/request/RequestDisposable {
-	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun dispose ()V
-	public abstract fun isDisposed ()Z
-}
-
-public abstract class coil/request/RequestResult {
-	public abstract fun getDrawable ()Landroid/graphics/drawable/Drawable;
-	public abstract fun getRequest ()Lcoil/request/ImageRequest;
-}
-
-public final class coil/request/SuccessResult : coil/request/RequestResult {
+public final class coil/request/SuccessResult : coil/request/ImageResult {
 	public fun <init> (Landroid/graphics/drawable/Drawable;Lcoil/request/ImageRequest;Lcoil/request/Metadata;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Lcoil/request/ImageRequest;
@@ -876,13 +876,13 @@ public final class coil/transition/CrossfadeTransition : coil/transition/Transit
 	public final fun getDurationMillis ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-	public fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/RequestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/ImageResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class coil/transition/Transition {
 	public static final field Companion Lcoil/transition/Transition$Companion;
 	public static final field NONE Lcoil/transition/Transition;
-	public abstract fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/RequestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/ImageResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/transition/Transition$Companion {

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -15,8 +15,8 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.request.ErrorResult
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.request.Metadata
-import coil.request.RequestResult
 import coil.request.SuccessResult
 import coil.size.Size
 import coil.transform.Transformation
@@ -118,7 +118,7 @@ class EventListenerTest {
             imageLoader.testEnqueue {
                 data("$SCHEME_ANDROID_RESOURCE://${context.packageName}/${R.drawable.normal}")
                 transition(object : Transition {
-                    override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
+                    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
                         transitionIsCalled = true
                         when (result) {
                             is SuccessResult -> target.onSuccess(result.drawable)

--- a/coil-base/src/androidTest/java/coil/request/DisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/DisposableTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoilApi::class, ExperimentalCoroutinesApi::class, FlowPreview::class)
-class RequestDisposableTest {
+class DisposableTest {
 
     private lateinit var context: Context
     private lateinit var imageLoader: ImageLoader

--- a/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
+++ b/coil-base/src/androidTest/java/coil/request/RequestDisposableTest.kt
@@ -56,7 +56,7 @@ class RequestDisposableTest {
             .build()
         val disposable = imageLoader.enqueue(request)
 
-        assertTrue(disposable is BaseTargetRequestDisposable)
+        assertTrue(disposable is BaseTargetDisposable)
         assertFalse(disposable.isDisposed)
         disposable.dispose()
         assertTrue(disposable.isDisposed)
@@ -74,7 +74,7 @@ class RequestDisposableTest {
             .build()
         val disposable = imageLoader.enqueue(request)
 
-        assertTrue(disposable is BaseTargetRequestDisposable)
+        assertTrue(disposable is BaseTargetDisposable)
         assertNull(result)
         transformation.open()
         disposable.await()
@@ -93,7 +93,7 @@ class RequestDisposableTest {
             .build()
         val disposable = imageLoader.enqueue(request)
 
-        assertTrue(disposable is ViewTargetRequestDisposable)
+        assertTrue(disposable is ViewTargetDisposable)
         assertFalse(disposable.isDisposed)
         disposable.dispose()
         assertTrue(disposable.isDisposed)
@@ -112,7 +112,7 @@ class RequestDisposableTest {
             .build()
         val disposable = imageLoader.enqueue(request)
 
-        assertTrue(disposable is ViewTargetRequestDisposable)
+        assertTrue(disposable is ViewTargetDisposable)
         assertNull(imageView.drawable)
         transformation.open()
         disposable.await()
@@ -132,7 +132,7 @@ class RequestDisposableTest {
             .build()
         val disposable = imageLoader.enqueue(request)
 
-        assertTrue(disposable is ViewTargetRequestDisposable)
+        assertTrue(disposable is ViewTargetDisposable)
         assertFalse(disposable.isDisposed)
 
         transformation.open()
@@ -153,7 +153,7 @@ class RequestDisposableTest {
     fun viewTargetRequestDisposable_replace() = runBlockingTest {
         val imageView = ImageView(context)
 
-        fun launchNewRequest(): RequestDisposable {
+        fun launchNewRequest(): Disposable {
             val request = ImageRequest.Builder(context)
                 .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/normal.jpg")
                 // Set a fixed size so we don't suspend indefinitely waiting for the view to be measured.

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -127,7 +127,7 @@ interface ImageLoader {
         private var eventListenerFactory: EventListener.Factory? = null
         private var registry: ComponentRegistry? = null
         private var logger: Logger? = null
-        private var defaults = DefaultRequestOptions()
+        private var defaults = DefaultRequestOptions.INSTANCE
 
         private var availableMemoryPercentage = Utils.getDefaultAvailableMemoryPercentage(applicationContext)
         private var bitmapPoolPercentage = Utils.getDefaultBitmapPoolPercentage()

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -444,6 +444,6 @@ interface ImageLoader {
         /** Create a new [ImageLoader] without configuration. */
         @JvmStatic
         @JvmName("create")
-        inline operator fun invoke(context: Context) = Builder(context).build()
+        operator fun invoke(context: Context) = Builder(context).build()
     }
 }

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -19,10 +19,10 @@ import coil.memory.RealWeakMemoryCache
 import coil.memory.StrongMemoryCache
 import coil.request.CachePolicy
 import coil.request.DefaultRequestOptions
+import coil.request.Disposable
 import coil.request.ErrorResult
 import coil.request.ImageRequest
-import coil.request.RequestDisposable
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.request.SuccessResult
 import coil.size.Precision
 import coil.target.ViewTarget
@@ -69,9 +69,9 @@ interface ImageLoader {
      * Enqueue the [request] to be executed asynchronously.
      *
      * @param request The request to execute.
-     * @return A [RequestDisposable] which can be used to cancel or check the status of the request.
+     * @return A [Disposable] which can be used to cancel or check the status of the request.
      */
-    fun enqueue(request: ImageRequest): RequestDisposable
+    fun enqueue(request: ImageRequest): Disposable
 
     /**
      * Execute the [request] in the current coroutine scope.
@@ -82,7 +82,7 @@ interface ImageLoader {
      * @param request The request to execute.
      * @return A [SuccessResult] if the request completes successfully. Else, returns an [ErrorResult].
      */
-    suspend fun execute(request: ImageRequest): RequestResult
+    suspend fun execute(request: ImageRequest): ImageResult
 
     /**
      * Shutdown this image loader.

--- a/coil-base/src/main/java/coil/interceptor/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/interceptor/EngineInterceptor.kt
@@ -22,8 +22,8 @@ import coil.memory.RequestService
 import coil.memory.StrongMemoryCache
 import coil.memory.WeakMemoryCache
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.request.Metadata
-import coil.request.RequestResult
 import coil.request.SuccessResult
 import coil.size.OriginalSize
 import coil.size.PixelSize
@@ -63,7 +63,7 @@ internal class EngineInterceptor(
     private val logger: Logger?
 ) : Interceptor {
 
-    override suspend fun intercept(chain: Interceptor.Chain): RequestResult {
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
         try {
             // This interceptor uses some internal APIs.
             check(chain is RealInterceptorChain)

--- a/coil-base/src/main/java/coil/interceptor/Interceptor.kt
+++ b/coil-base/src/main/java/coil/interceptor/Interceptor.kt
@@ -3,7 +3,7 @@ package coil.interceptor
 import coil.ImageLoader
 import coil.annotation.ExperimentalCoilApi
 import coil.request.ImageRequest
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.size.Size
 
 /**
@@ -12,7 +12,7 @@ import coil.size.Size
 @ExperimentalCoilApi
 interface Interceptor {
 
-    suspend fun intercept(chain: Chain): RequestResult
+    suspend fun intercept(chain: Chain): ImageResult
 
     interface Chain {
 
@@ -32,6 +32,6 @@ interface Interceptor {
          *
          * @param request The request to proceed with.
          */
-        suspend fun proceed(request: ImageRequest): RequestResult
+        suspend fun proceed(request: ImageRequest): ImageResult
     }
 }

--- a/coil-base/src/main/java/coil/interceptor/RealInterceptorChain.kt
+++ b/coil-base/src/main/java/coil/interceptor/RealInterceptorChain.kt
@@ -3,8 +3,8 @@ package coil.interceptor
 import coil.EventListener
 import coil.annotation.ExperimentalCoilApi
 import coil.request.ImageRequest
+import coil.request.ImageResult
 import coil.request.NullRequestData
-import coil.request.RequestResult
 import coil.size.Size
 
 @OptIn(ExperimentalCoilApi::class)
@@ -20,7 +20,7 @@ internal class RealInterceptorChain(
 
     override fun withSize(size: Size) = copy(size = size)
 
-    override suspend fun proceed(request: ImageRequest): RequestResult {
+    override suspend fun proceed(request: ImageRequest): ImageResult {
         if (index > 0) checkRequest(request, interceptors[index - 1])
         val interceptor = interceptors[index]
         val next = copy(index = index + 1, request = request)

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -14,7 +14,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.bitmap.BitmapReferenceCounter
 import coil.request.ErrorResult
 import coil.request.ImageRequest
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.request.SuccessResult
 import coil.target.PoolableViewTarget
 import coil.target.Target
@@ -145,7 +145,7 @@ private interface Poolable {
     }
 }
 
-private inline val RequestResult.bitmap: Bitmap?
+private inline val ImageResult.bitmap: Bitmap?
     get() = (drawable as? BitmapDrawable)?.bitmap
 
 private inline fun Poolable.instrument(bitmap: Bitmap?, update: PoolableViewTarget<*>.() -> Unit) {

--- a/coil-base/src/main/java/coil/request/Deprecated.kt
+++ b/coil-base/src/main/java/coil/request/Deprecated.kt
@@ -32,3 +32,15 @@ typealias GetRequestBuilder = ImageRequest.Builder
     replaceWith = ReplaceWith("ImageRequest", "coil.request.ImageRequest")
 )
 typealias Request = ImageRequest
+
+@Deprecated(
+    message = "Replace with Disposable.",
+    replaceWith = ReplaceWith("Disposable", "coil.request.Disposable")
+)
+typealias RequestDisposable = Disposable
+
+@Deprecated(
+    message = "Replace with ImageResult.",
+    replaceWith = ReplaceWith("ImageResult", "coil.request.ImageResult")
+)
+typealias RequestResult = ImageResult

--- a/coil-base/src/main/java/coil/request/Disposable.kt
+++ b/coil-base/src/main/java/coil/request/Disposable.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 /**
  * Represents the work of an executed [ImageRequest].
  */
-interface RequestDisposable {
+interface Disposable {
 
     /**
      * Returns true if the request is complete or cancelling.
@@ -32,7 +32,7 @@ interface RequestDisposable {
 /**
  * A disposable for one-shot image requests.
  */
-internal class BaseTargetRequestDisposable(private val job: Job) : RequestDisposable {
+internal class BaseTargetDisposable(private val job: Job) : Disposable {
 
     override val isDisposed
         get() = !job.isActive
@@ -52,14 +52,14 @@ internal class BaseTargetRequestDisposable(private val job: Job) : RequestDispos
 /**
  * A disposable for requests that are attached to a [View].
  *
- * [ViewTargetRequestDisposable] is not disposed until its request is detached from the view.
+ * [ViewTargetDisposable] is not disposed until its request is detached from the view.
  * This is because requests are automatically cancelled in [View.onDetachedFromWindow] and are
  * restarted in [View.onAttachedToWindow].
  */
-internal class ViewTargetRequestDisposable(
+internal class ViewTargetDisposable(
     private val requestId: UUID,
     private val target: ViewTarget<*>
-) : RequestDisposable {
+) : Disposable {
 
     override val isDisposed
         get() = target.view.requestManager.currentRequestId != requestId

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -230,8 +230,8 @@ class ImageRequest private constructor(
             "placeholderKey=$placeholderKey, colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, " +
             "transformations=$transformations, headers=$headers, parameters=$parameters, lifecycle=$lifecycle, " +
             "sizeResolver=$sizeResolver, scale=$scale, dispatcher=$dispatcher, transition=$transition, " +
-            "precision=$precision, bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, allowRgb565=$allowRgb565, " +
-            "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
+            "precision=$precision, bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, " +
+            "allowRgb565=$allowRgb565, memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
             "networkCachePolicy=$networkCachePolicy, placeholderResId=$placeholderResId, " +
             "placeholderDrawable=$placeholderDrawable, errorResId=$errorResId, errorDrawable=$errorDrawable, " +
             "fallbackResId=$fallbackResId, fallbackDrawable=$fallbackDrawable, defined=$defined, defaults=$defaults)"

--- a/coil-base/src/main/java/coil/request/ImageResult.kt
+++ b/coil-base/src/main/java/coil/request/ImageResult.kt
@@ -9,7 +9,7 @@ import coil.decode.DataSource
  *
  * @see ImageLoader.execute
  */
-sealed class RequestResult {
+sealed class ImageResult {
     abstract val drawable: Drawable?
     abstract val request: ImageRequest
 }
@@ -18,13 +18,14 @@ sealed class RequestResult {
  * Indicates that the request completed successfully.
  *
  * @param drawable The result drawable.
+ * @param request The request that was executed to create this result.
  * @param metadata Metadata about the request that created this response.
  */
 data class SuccessResult(
     override val drawable: Drawable,
     override val request: ImageRequest,
     val metadata: Metadata
-) : RequestResult() {
+) : ImageResult() {
 
     @Deprecated(
         message = "Moved to Metadata.",
@@ -37,10 +38,11 @@ data class SuccessResult(
  * Indicates that an error occurred while executing the request.
  *
  * @param drawable The error drawable.
+ * @param request The request that was executed to create this result.
  * @param throwable The error that failed the request.
  */
 data class ErrorResult(
     override val drawable: Drawable?,
     override val request: ImageRequest,
     val throwable: Throwable
-) : RequestResult()
+) : ImageResult()

--- a/coil-base/src/main/java/coil/request/ImageResult.kt
+++ b/coil-base/src/main/java/coil/request/ImageResult.kt
@@ -17,7 +17,7 @@ sealed class ImageResult {
 /**
  * Indicates that the request completed successfully.
  *
- * @param drawable The result drawable.
+ * @param drawable The success drawable.
  * @param request The request that was executed to create this result.
  * @param metadata Metadata about the request that created this response.
  */

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -11,34 +11,8 @@ import coil.memory.MemoryCache
  * @param isSampled True if [drawable] is sampled (i.e. loaded into memory at less than its original size).
  * @param dataSource The data source that the image was loaded from.
  */
-class Metadata(
+data class Metadata(
     val key: MemoryCache.Key?,
     val isSampled: Boolean,
     val dataSource: DataSource
-) {
-
-    fun copy(
-        key: MemoryCache.Key? = this.key,
-        isSampled: Boolean = this.isSampled,
-        dataSource: DataSource = this.dataSource
-    ) = Metadata(key, isSampled, dataSource)
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        return other is Metadata &&
-            key == other.key &&
-            isSampled == other.isSampled &&
-            dataSource == other.dataSource
-    }
-
-    override fun hashCode(): Int {
-        var result = key?.hashCode() ?: 0
-        result = 31 * result + isSampled.hashCode()
-        result = 31 * result + dataSource.hashCode()
-        return result
-    }
-
-    override fun toString(): String {
-        return "Metadata(key=$key, isSampled=$isSampled, dataSource=$dataSource)"
-    }
-}
+)

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -1,8 +1,5 @@
-@file:OptIn(ExperimentalCoilApi::class)
-
 package coil.request
 
-import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.memory.MemoryCache
 
@@ -19,6 +16,12 @@ class Metadata(
     val isSampled: Boolean,
     val dataSource: DataSource
 ) {
+
+    fun copy(
+        key: MemoryCache.Key? = this.key,
+        isSampled: Boolean = this.isSampled,
+        dataSource: DataSource = this.dataSource
+    ) = Metadata(key, isSampled, dataSource)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -8,7 +8,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
 import coil.drawable.CrossfadeDrawable
 import coil.request.ErrorResult
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.request.SuccessResult
 import coil.size.Scale
 import coil.util.scale
@@ -25,7 +25,7 @@ class CrossfadeTransition @JvmOverloads constructor(
         require(durationMillis > 0) { "durationMillis must be > 0." }
     }
 
-    override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
+    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
         // Don't animate if the request was fulfilled by the memory cache.
         if (result is SuccessResult && result.metadata.dataSource == DataSource.MEMORY_CACHE) {
             target.onSuccess(result.drawable)

--- a/coil-base/src/main/java/coil/transition/NoneTransition.kt
+++ b/coil-base/src/main/java/coil/transition/NoneTransition.kt
@@ -2,16 +2,16 @@ package coil.transition
 
 import coil.annotation.ExperimentalCoilApi
 import coil.request.ErrorResult
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.request.SuccessResult
 
 /**
- * A transition that applies the [RequestResult] on the [TransitionTarget] without animating.
+ * A transition that applies the [ImageResult] on the [TransitionTarget] without animating.
  */
 @ExperimentalCoilApi
 internal object NoneTransition : Transition {
 
-    override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
+    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
         when (result) {
             is SuccessResult -> target.onSuccess(result.drawable)
             is ErrorResult -> target.onError(result.drawable)

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -3,7 +3,7 @@ package coil.transition
 import android.graphics.Bitmap
 import androidx.annotation.MainThread
 import coil.annotation.ExperimentalCoilApi
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.target.Target
 
 /**
@@ -28,7 +28,7 @@ interface Transition {
      * @param result The result of the image request.
      */
     @MainThread
-    suspend fun transition(target: TransitionTarget<*>, result: RequestResult)
+    suspend fun transition(target: TransitionTarget<*>, result: ImageResult)
 
     companion object {
         @JvmField val NONE: Transition = NoneTransition

--- a/coil-base/src/main/java/coil/util/CoilUtils.kt
+++ b/coil-base/src/main/java/coil/util/CoilUtils.kt
@@ -2,8 +2,8 @@ package coil.util
 
 import android.content.Context
 import android.view.View
+import coil.request.Disposable
 import coil.request.Metadata
-import coil.request.RequestDisposable
 import okhttp3.Cache
 
 /** Public utility methods for Coil. */
@@ -20,7 +20,7 @@ object CoilUtils {
     /**
      * Cancel any in progress requests attached to [view] and clear any associated resources.
      *
-     * NOTE: Typically you should use [RequestDisposable.dispose] to clear any associated resources,
+     * NOTE: Typically you should use [Disposable.dispose] to clear any associated resources,
      * however this method is provided for convenience.
      */
     @JvmStatic

--- a/coil-base/src/test/java/coil/interceptor/FakeInterceptor.kt
+++ b/coil-base/src/test/java/coil/interceptor/FakeInterceptor.kt
@@ -3,14 +3,14 @@ package coil.interceptor
 import android.graphics.drawable.ColorDrawable
 import coil.annotation.ExperimentalCoilApi
 import coil.decode.DataSource
+import coil.request.ImageResult
 import coil.request.Metadata
-import coil.request.RequestResult
 import coil.request.SuccessResult
 
 @OptIn(ExperimentalCoilApi::class)
 class FakeInterceptor : Interceptor {
 
-    override suspend fun intercept(chain: Interceptor.Chain): RequestResult {
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
         return SuccessResult(
             drawable = ColorDrawable(),
             request = chain.request,

--- a/coil-base/src/test/java/coil/interceptor/RealInterceptorChainTest.kt
+++ b/coil-base/src/test/java/coil/interceptor/RealInterceptorChainTest.kt
@@ -11,7 +11,7 @@ import coil.annotation.ExperimentalCoilApi
 import coil.lifecycle.FakeLifecycle
 import coil.memory.MemoryCache
 import coil.request.ImageRequest
-import coil.request.RequestResult
+import coil.request.ImageResult
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size
@@ -141,7 +141,7 @@ class RealInterceptorChainTest {
         assertSame(request, result.request)
     }
 
-    private fun testChain(request: ImageRequest, interceptors: List<Interceptor>): RequestResult {
+    private fun testChain(request: ImageRequest, interceptors: List<Interceptor>): ImageResult {
         val chain = RealInterceptorChain(
             initialRequest = request,
             requestType = REQUEST_TYPE_ENQUEUE,
@@ -154,7 +154,7 @@ class RealInterceptorChainTest {
         return runBlocking { chain.proceed(request) }
     }
 
-    private inline fun Interceptor(crossinline block: suspend (Interceptor.Chain) -> RequestResult): Interceptor {
+    private inline fun Interceptor(crossinline block: suspend (Interceptor.Chain) -> ImageResult): Interceptor {
         return object : Interceptor {
             override suspend fun intercept(chain: Interceptor.Chain) = block(chain)
         }

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -10,8 +10,8 @@ import coil.bitmap.BitmapReferenceCounter
 import coil.bitmap.FakeBitmapPool
 import coil.decode.DataSource
 import coil.request.ErrorResult
+import coil.request.ImageResult
 import coil.request.Metadata
-import coil.request.RequestResult
 import coil.request.SuccessResult
 import coil.target.FakeTarget
 import coil.target.ImageViewTarget
@@ -190,7 +190,7 @@ class TargetDelegateTest {
             val bitmap = createBitmap()
             var isRunning = true
             val transition = object : Transition {
-                override suspend fun transition(target: TransitionTarget<*>, result: RequestResult) {
+                override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
                     assertFalse(initialBitmap in pool.bitmaps)
                     delay(100) // Simulate an animation.
                     assertFalse(initialBitmap in pool.bitmaps)

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -22,7 +22,7 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
             .availableMemoryPercentage(0.25) // Use 25% of the application's available memory.
-            .crossfade(false) // Show a short crossfade when loading images from network or disk.
+            .crossfade(true) // Show a short crossfade when loading images from network or disk.
             .componentRegistry {
                 // Fetchers
                 add(VideoFrameFileFetcher(this@Application))

--- a/coil-singleton/api/coil-singleton.api
+++ b/coil-singleton/api/coil-singleton.api
@@ -1,6 +1,6 @@
 public final class coil/Coil {
 	public static final field INSTANCE Lcoil/Coil;
-	public static final fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/RequestDisposable;
+	public static final fun enqueue (Lcoil/request/ImageRequest;)Lcoil/request/Disposable;
 	public static final fun execute (Lcoil/request/ImageRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun imageLoader (Landroid/content/Context;)Lcoil/ImageLoader;
 	public static final fun setImageLoader (Lcoil/ImageLoader;)V
@@ -13,42 +13,42 @@ public abstract interface class coil/ImageLoaderFactory {
 
 public final class coil/ImageViews {
 	public static final fun clear (Landroid/widget/ImageView;)V
-	public static final synthetic fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static synthetic fun loadAny$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static final synthetic fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static synthetic fun loadAny$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
 	public static final fun metadata (Landroid/widget/ImageView;)Lcoil/request/Metadata;
 }
 
 public final class coil/api/ImageViews {
 	public static final fun clear (Landroid/widget/ImageView;)V
-	public static final synthetic fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static synthetic fun load$default (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
-	public static final synthetic fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/RequestDisposable;
-	public static synthetic fun loadAny$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/RequestDisposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static final synthetic fun load (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;ILcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/Bitmap;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/graphics/drawable/Drawable;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Landroid/net/Uri;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/io/File;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/String;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static synthetic fun load$default (Landroid/widget/ImageView;Lokhttp3/HttpUrl;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
+	public static final synthetic fun loadAny (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
+	public static synthetic fun loadAny$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;
 }
 

--- a/coil-singleton/src/main/java/coil/Coil.kt
+++ b/coil-singleton/src/main/java/coil/Coil.kt
@@ -5,9 +5,9 @@ package coil
 import android.app.Application
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import coil.request.Disposable
 import coil.request.ImageRequest
-import coil.request.RequestDisposable
-import coil.request.RequestResult
+import coil.request.ImageResult
 
 /**
  * A singleton that holds the default [ImageLoader] instance.
@@ -29,7 +29,7 @@ object Coil {
      * @see ImageLoader.enqueue
      */
     @JvmStatic
-    inline fun enqueue(request: ImageRequest): RequestDisposable {
+    inline fun enqueue(request: ImageRequest): Disposable {
         return imageLoader(request.context).enqueue(request)
     }
 
@@ -39,7 +39,7 @@ object Coil {
      * @see ImageLoader.execute
      */
     @JvmStatic
-    suspend inline fun execute(request: ImageRequest): RequestResult {
+    suspend inline fun execute(request: ImageRequest): ImageResult {
         return imageLoader(request.context).execute(request)
     }
 

--- a/coil-singleton/src/main/java/coil/Deprecated.kt
+++ b/coil-singleton/src/main/java/coil/Deprecated.kt
@@ -10,8 +10,8 @@ import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import coil.Coil
 import coil.ImageLoader
+import coil.request.Disposable
 import coil.request.ImageRequest
-import coil.request.RequestDisposable
 import okhttp3.HttpUrl
 import java.io.File
 import coil.clear as _clear
@@ -24,7 +24,7 @@ inline fun ImageView.load(
     uri: String?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(uri, imageLoader, builder)
+): Disposable = _load(uri, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -32,7 +32,7 @@ inline fun ImageView.load(
     url: HttpUrl?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(url, imageLoader, builder)
+): Disposable = _load(url, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -40,7 +40,7 @@ inline fun ImageView.load(
     uri: Uri?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(uri, imageLoader, builder)
+): Disposable = _load(uri, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -48,7 +48,7 @@ inline fun ImageView.load(
     file: File?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(file, imageLoader, builder)
+): Disposable = _load(file, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -56,7 +56,7 @@ inline fun ImageView.load(
     @DrawableRes drawableResId: Int,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(drawableResId, imageLoader, builder)
+): Disposable = _load(drawableResId, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -64,7 +64,7 @@ inline fun ImageView.load(
     drawable: Drawable?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(drawable, imageLoader, builder)
+): Disposable = _load(drawable, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -72,7 +72,7 @@ inline fun ImageView.load(
     bitmap: Bitmap?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _load(bitmap, imageLoader, builder)
+): Disposable = _load(bitmap, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.load` with `coil.load`.")
 @JvmSynthetic
@@ -80,7 +80,7 @@ inline fun ImageView.loadAny(
     data: Any?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = _loadAny(data, imageLoader, builder)
+): Disposable = _loadAny(data, imageLoader, builder)
 
 @Deprecated("Replace `coil.api.clear` with `coil.clear`.")
 fun ImageView.clear() = _clear()

--- a/coil-singleton/src/main/java/coil/ImageViews.kt
+++ b/coil-singleton/src/main/java/coil/ImageViews.kt
@@ -8,9 +8,9 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
+import coil.request.Disposable
 import coil.request.ImageRequest
 import coil.request.Metadata
-import coil.request.RequestDisposable
 import coil.util.CoilUtils
 import okhttp3.HttpUrl
 import java.io.File
@@ -21,7 +21,7 @@ inline fun ImageView.load(
     uri: String?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(uri, imageLoader, builder)
+): Disposable = loadAny(uri, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -29,7 +29,7 @@ inline fun ImageView.load(
     url: HttpUrl?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(url, imageLoader, builder)
+): Disposable = loadAny(url, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -37,7 +37,7 @@ inline fun ImageView.load(
     uri: Uri?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(uri, imageLoader, builder)
+): Disposable = loadAny(uri, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -45,7 +45,7 @@ inline fun ImageView.load(
     file: File?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(file, imageLoader, builder)
+): Disposable = loadAny(file, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -53,7 +53,7 @@ inline fun ImageView.load(
     @DrawableRes drawableResId: Int,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(drawableResId, imageLoader, builder)
+): Disposable = loadAny(drawableResId, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -61,7 +61,7 @@ inline fun ImageView.load(
     drawable: Drawable?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(drawable, imageLoader, builder)
+): Disposable = loadAny(drawable, imageLoader, builder)
 
 /** @see ImageView.loadAny */
 @JvmSynthetic
@@ -69,7 +69,7 @@ inline fun ImageView.load(
     bitmap: Bitmap?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable = loadAny(bitmap, imageLoader, builder)
+): Disposable = loadAny(bitmap, imageLoader, builder)
 
 /**
  * Load the image referenced by [data] and set it on this [ImageView].
@@ -93,7 +93,7 @@ inline fun ImageView.loadAny(
     data: Any?,
     imageLoader: ImageLoader = Coil.imageLoader(context),
     builder: ImageRequest.Builder.() -> Unit = {}
-): RequestDisposable {
+): Disposable {
     val request = ImageRequest.Builder(context)
         .data(data)
         .target(this)


### PR DESCRIPTION
Rename:

`RequestResult` -> `ImageResult`
`RequestDisposable` -> `Disposable`.

`Disposable` is also used by RxJava, however I think it should be ok. Curious what you think!

Also converts `Metadata` to be a data class again. This locks the parameter order, but generating `component` functions for this data type should be ok (property order isn't likely to change).