### PR TITLE
Use standard crossfade if drawables are not the same image.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -254,13 +254,14 @@ public final class coil/drawable/CrossfadeDrawable : android/graphics/drawable/D
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;I)V
-	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZ)V
+	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearAnimationCallbacks ()V
 	public fun draw (Landroid/graphics/Canvas;)V
 	public fun getAlpha ()I
 	public fun getColorFilter ()Landroid/graphics/ColorFilter;
 	public final fun getDurationMillis ()I
-	public final fun getEnd ()Landroid/graphics/drawable/Drawable;
+	public final fun getFadeStart ()Z
 	public fun getIntrinsicHeight ()I
 	public fun getIntrinsicWidth ()I
 	public fun getOpacity ()I
@@ -496,14 +497,14 @@ public final class coil/request/ImageRequest {
 	public final fun getFallback ()Landroid/graphics/drawable/Drawable;
 	public final fun getFetcher ()Lkotlin/Pair;
 	public final fun getHeaders ()Lokhttp3/Headers;
-	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
 	public final fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
 	public final fun getListener ()Lcoil/request/ImageRequest$Listener;
+	public final fun getMemoryCacheKey ()Lcoil/memory/MemoryCache$Key;
 	public final fun getMemoryCachePolicy ()Lcoil/request/CachePolicy;
 	public final fun getNetworkCachePolicy ()Lcoil/request/CachePolicy;
 	public final fun getParameters ()Lcoil/request/Parameters;
 	public final fun getPlaceholder ()Landroid/graphics/drawable/Drawable;
-	public final fun getPlaceholderKey ()Lcoil/memory/MemoryCache$Key;
+	public final fun getPlaceholderMemoryCacheKey ()Lcoil/memory/MemoryCache$Key;
 	public final fun getPrecision ()Lcoil/size/Precision;
 	public final fun getScale ()Lcoil/size/Scale;
 	public final fun getSizeResolver ()Lcoil/size/SizeResolver;
@@ -542,19 +543,20 @@ public final class coil/request/ImageRequest$Builder {
 	public final fun fetcher (Lcoil/fetch/Fetcher;Ljava/lang/Class;)Lcoil/request/ImageRequest$Builder;
 	public final fun fetcher (Ljava/lang/Class;Lcoil/fetch/Fetcher;)Lcoil/request/ImageRequest$Builder;
 	public final fun headers (Lokhttp3/Headers;)Lcoil/request/ImageRequest$Builder;
-	public final fun key (Lcoil/memory/MemoryCache$Key;)Lcoil/request/ImageRequest$Builder;
 	public final fun key (Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
 	public final fun lifecycle (Landroidx/lifecycle/Lifecycle;)Lcoil/request/ImageRequest$Builder;
 	public final fun lifecycle (Landroidx/lifecycle/LifecycleOwner;)Lcoil/request/ImageRequest$Builder;
 	public final fun listener (Lcoil/request/ImageRequest$Listener;)Lcoil/request/ImageRequest$Builder;
 	public final fun listener (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)Lcoil/request/ImageRequest$Builder;
 	public static synthetic fun listener$default (Lcoil/request/ImageRequest$Builder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lcoil/request/ImageRequest$Builder;
+	public final fun memoryCacheKey (Lcoil/memory/MemoryCache$Key;)Lcoil/request/ImageRequest$Builder;
+	public final fun memoryCacheKey (Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
 	public final fun memoryCachePolicy (Lcoil/request/CachePolicy;)Lcoil/request/ImageRequest$Builder;
 	public final fun networkCachePolicy (Lcoil/request/CachePolicy;)Lcoil/request/ImageRequest$Builder;
 	public final fun parameters (Lcoil/request/Parameters;)Lcoil/request/ImageRequest$Builder;
 	public final fun placeholder (I)Lcoil/request/ImageRequest$Builder;
 	public final fun placeholder (Landroid/graphics/drawable/Drawable;)Lcoil/request/ImageRequest$Builder;
-	public final fun placeholderKey (Lcoil/memory/MemoryCache$Key;)Lcoil/request/ImageRequest$Builder;
+	public final fun placeholderMemoryCacheKey (Lcoil/memory/MemoryCache$Key;)Lcoil/request/ImageRequest$Builder;
 	public final fun precision (Lcoil/size/Precision;)Lcoil/request/ImageRequest$Builder;
 	public final fun removeHeader (Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
 	public final fun removeParameter (Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
@@ -596,16 +598,18 @@ public abstract class coil/request/ImageResult {
 }
 
 public final class coil/request/Metadata {
-	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)V
+	public fun <init> (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;Z)V
 	public final fun component1 ()Lcoil/memory/MemoryCache$Key;
 	public final fun component2 ()Z
 	public final fun component3 ()Lcoil/decode/DataSource;
-	public final fun copy (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;)Lcoil/request/Metadata;
-	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/request/Metadata;
+	public final fun component4 ()Z
+	public final fun copy (Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;Z)Lcoil/request/Metadata;
+	public static synthetic fun copy$default (Lcoil/request/Metadata;Lcoil/memory/MemoryCache$Key;ZLcoil/decode/DataSource;ZILjava/lang/Object;)Lcoil/request/Metadata;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDataSource ()Lcoil/decode/DataSource;
-	public final fun getKey ()Lcoil/memory/MemoryCache$Key;
+	public final fun getMemoryCacheKey ()Lcoil/memory/MemoryCache$Key;
 	public fun hashCode ()I
+	public final fun isPlaceholderMemoryCacheKeyPresent ()Z
 	public final fun isSampled ()Z
 	public fun toString ()Ljava/lang/String;
 }

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderTest.kt
@@ -357,7 +357,7 @@ class RealImageLoaderTest {
         assertTrue(result is SuccessResult)
         val bitmap = (result.drawable as BitmapDrawable).bitmap
         assertNotNull(bitmap)
-        assertEquals(bitmap, imageLoader.memoryCache[result.metadata.key!!])
+        assertEquals(bitmap, imageLoader.memoryCache[result.metadata.memoryCacheKey!!])
     }
 
     @Test
@@ -369,8 +369,8 @@ class RealImageLoaderTest {
         runBlocking {
             suspendCancellableCoroutine<Unit> { continuation ->
                 val request = ImageRequest.Builder(context)
-                    .key(key)
-                    .placeholderKey(key)
+                    .memoryCacheKey(key)
+                    .placeholderMemoryCacheKey(key)
                     .data("$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/$fileName")
                     .size(100, 100)
                     .precision(Precision.INEXACT)

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -160,7 +160,7 @@ internal class RealImageLoader(
             if (type == REQUEST_TYPE_ENQUEUE) request.lifecycle.awaitStarted()
 
             // Set the placeholder on the target.
-            val cached = request.placeholderKey
+            val cached = request.placeholderMemoryCacheKey
                 ?.let { strongMemoryCache.get(it) ?: weakMemoryCache.get(it) }
                 ?.bitmap?.toDrawable(request.context)
             targetDelegate.metadata = null
@@ -174,7 +174,7 @@ internal class RealImageLoader(
             eventListener.resolveSizeEnd(request, size)
 
             // Execute the interceptor chain.
-            val result = executeChain(request, type, size, eventListener)
+            val result = executeChain(request, type, size, eventListener, cached != null)
 
             // Set the result on the target.
             when (result) {
@@ -219,9 +219,11 @@ internal class RealImageLoader(
         request: ImageRequest,
         type: Int,
         size: Size,
-        eventListener: EventListener
+        eventListener: EventListener,
+        isPlaceholderMemoryCacheKeyPresent: Boolean
     ): ImageResult = withContext(request.dispatcher) {
-        RealInterceptorChain(request, type, interceptors, 0, request, size, eventListener).proceed(request)
+        RealInterceptorChain(request, type, interceptors, 0, request, size, eventListener,
+            isPlaceholderMemoryCacheKeyPresent).proceed(request)
     }
 
     private suspend inline fun onSuccess(

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -1,6 +1,7 @@
 package coil
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.util.Log
 import androidx.annotation.MainThread
 import coil.annotation.ExperimentalCoilApi
@@ -174,7 +175,7 @@ internal class RealImageLoader(
             eventListener.resolveSizeEnd(request, size)
 
             // Execute the interceptor chain.
-            val result = executeChain(request, type, size, eventListener, cached != null)
+            val result = executeChain(request, type, size, cached, eventListener)
 
             // Set the result on the target.
             when (result) {
@@ -219,11 +220,10 @@ internal class RealImageLoader(
         request: ImageRequest,
         type: Int,
         size: Size,
-        eventListener: EventListener,
-        isPlaceholderMemoryCacheKeyPresent: Boolean
+        cached: Drawable?,
+        eventListener: EventListener
     ): ImageResult = withContext(request.dispatcher) {
-        RealInterceptorChain(request, type, interceptors, 0, request, size, eventListener,
-            isPlaceholderMemoryCacheKeyPresent).proceed(request)
+        RealInterceptorChain(request, type, interceptors, 0, request, size, cached, eventListener).proceed(request)
     }
 
     private suspend inline fun onSuccess(

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -28,12 +28,14 @@ import kotlin.math.roundToInt
  * @param end The [Drawable] to crossfade to.
  * @param scale The scaling algorithm for [start] and [end].
  * @param durationMillis The duration of the crossfade animation.
+ * @param fadeStart If false, the start drawable will not fade out while the end drawable fades in.
  */
 class CrossfadeDrawable @JvmOverloads constructor(
     private var start: Drawable?,
-    val end: Drawable?,
+    private val end: Drawable?,
     val scale: Scale = Scale.FIT,
-    val durationMillis: Int = DEFAULT_DURATION
+    val durationMillis: Int = DEFAULT_DURATION,
+    val fadeStart: Boolean = true
 ) : Drawable(), Drawable.Callback, Animatable2Compat {
 
     private val callbacks = mutableListOf<Animatable2Compat.AnimationCallback>()
@@ -70,19 +72,21 @@ class CrossfadeDrawable @JvmOverloads constructor(
         }
 
         val percent = (SystemClock.uptimeMillis() - startTimeMillis) / durationMillis.toDouble()
+        val endAlpha = (percent.coerceIn(0.0, 1.0) * maxAlpha).toInt()
+        val startAlpha = if (fadeStart) maxAlpha - endAlpha else maxAlpha
         val isDone = percent >= 1.0
 
-        // Draw the start Drawable.
+        // Draw the start drawable.
         if (!isDone) {
             start?.apply {
-                alpha = maxAlpha
+                alpha = startAlpha
                 draw(canvas)
             }
         }
 
-        // Draw the end Drawable.
+        // Draw the end drawable.
         end?.apply {
-            alpha = (percent.coerceIn(0.0, 1.0) * maxAlpha).toInt()
+            alpha = endAlpha
             draw(canvas)
         }
 

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -81,7 +81,7 @@ internal class EngineInterceptor(
 
             // Check the memory cache.
             val fetcher = request.fetcher(mappedData) ?: registry.requireFetcher(mappedData)
-            val key = request.key ?: computeKey(request, mappedData, fetcher, size)
+            val key = request.memoryCacheKey ?: computeKey(request, mappedData, fetcher, size)
             val value = takeIf(request.memoryCachePolicy.readEnabled) {
                 key?.let { strongMemoryCache.get(it) ?: weakMemoryCache.get(it) }
             }
@@ -96,7 +96,12 @@ internal class EngineInterceptor(
                 return SuccessResult(
                     drawable = value.bitmap.toDrawable(context),
                     request = request,
-                    metadata = Metadata(key, value.isSampled, DataSource.MEMORY_CACHE)
+                    metadata = Metadata(
+                        memoryCacheKey = key,
+                        isSampled = value.isSampled,
+                        dataSource = DataSource.MEMORY_CACHE,
+                        isPlaceholderMemoryCacheKeyPresent = chain.isPlaceholderMemoryCacheKeyPresent
+                    )
                 )
             }
 
@@ -109,7 +114,12 @@ internal class EngineInterceptor(
             return SuccessResult(
                 drawable = drawable,
                 request = request,
-                metadata = Metadata(key.takeIf { isCached }, isSampled, dataSource)
+                metadata = Metadata(
+                    memoryCacheKey = key.takeIf { isCached },
+                    isSampled = isSampled,
+                    dataSource = dataSource,
+                    isPlaceholderMemoryCacheKeyPresent = chain.isPlaceholderMemoryCacheKeyPresent
+                )
             )
         } catch (throwable: Throwable) {
             if (throwable is CancellationException) {

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -100,7 +100,7 @@ internal class EngineInterceptor(
                         memoryCacheKey = key,
                         isSampled = value.isSampled,
                         dataSource = DataSource.MEMORY_CACHE,
-                        isPlaceholderMemoryCacheKeyPresent = chain.isPlaceholderMemoryCacheKeyPresent
+                        isPlaceholderMemoryCacheKeyPresent = chain.cached != null
                     )
                 )
             }
@@ -118,7 +118,7 @@ internal class EngineInterceptor(
                     memoryCacheKey = key.takeIf { isCached },
                     isSampled = isSampled,
                     dataSource = dataSource,
-                    isPlaceholderMemoryCacheKeyPresent = chain.isPlaceholderMemoryCacheKeyPresent
+                    isPlaceholderMemoryCacheKeyPresent = chain.cached != null
                 )
             )
         } catch (throwable: Throwable) {

--- a/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
+++ b/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
@@ -15,7 +15,8 @@ internal class RealInterceptorChain(
     val index: Int,
     override val request: ImageRequest,
     override val size: Size,
-    val eventListener: EventListener
+    val eventListener: EventListener,
+    val isPlaceholderMemoryCacheKeyPresent: Boolean
 ) : Interceptor.Chain {
 
     override fun withSize(size: Size) = copy(size = size)
@@ -51,5 +52,6 @@ internal class RealInterceptorChain(
         index: Int = this.index,
         request: ImageRequest = this.request,
         size: Size = this.size
-    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size, eventListener)
+    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size,
+        eventListener, isPlaceholderMemoryCacheKeyPresent)
 }

--- a/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
+++ b/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
@@ -1,5 +1,6 @@
 package coil.intercept
 
+import android.graphics.drawable.Drawable
 import coil.EventListener
 import coil.annotation.ExperimentalCoilApi
 import coil.request.ImageRequest
@@ -15,8 +16,8 @@ internal class RealInterceptorChain(
     val index: Int,
     override val request: ImageRequest,
     override val size: Size,
-    val eventListener: EventListener,
-    val isPlaceholderMemoryCacheKeyPresent: Boolean
+    val cached: Drawable?,
+    val eventListener: EventListener
 ) : Interceptor.Chain {
 
     override fun withSize(size: Size) = copy(size = size)
@@ -52,6 +53,5 @@ internal class RealInterceptorChain(
         index: Int = this.index,
         request: ImageRequest = this.request,
         size: Size = this.size
-    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size,
-        eventListener, isPlaceholderMemoryCacheKeyPresent)
+    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size, cached, eventListener)
 }

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -226,12 +226,13 @@ class ImageRequest private constructor(
     }
 
     override fun toString(): String {
-        return "ImageRequest(context=$context, data=$data, target=$target, listener=$listener, key=$memoryCacheKey, " +
-            "placeholderKey=$placeholderMemoryCacheKey, colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, " +
-            "transformations=$transformations, headers=$headers, parameters=$parameters, lifecycle=$lifecycle, " +
-            "sizeResolver=$sizeResolver, scale=$scale, dispatcher=$dispatcher, transition=$transition, " +
-            "precision=$precision, bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, " +
-            "allowRgb565=$allowRgb565, memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
+        return "ImageRequest(context=$context, data=$data, target=$target, listener=$listener, " +
+            "memoryCacheKey=$memoryCacheKey, placeholderMemoryCacheKey=$placeholderMemoryCacheKey, " +
+            "colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, transformations=$transformations, " +
+            "headers=$headers, parameters=$parameters, lifecycle=$lifecycle, sizeResolver=$sizeResolver, " +
+            "scale=$scale, dispatcher=$dispatcher, transition=$transition, precision=$precision, " +
+            "bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, allowRgb565=$allowRgb565, " +
+            "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
             "networkCachePolicy=$networkCachePolicy, placeholderResId=$placeholderResId, " +
             "placeholderDrawable=$placeholderDrawable, errorResId=$errorResId, errorDrawable=$errorDrawable, " +
             "fallbackResId=$fallbackResId, fallbackDrawable=$fallbackDrawable, defined=$defined, defaults=$defaults)"

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -409,7 +409,7 @@ class ImageRequest private constructor(
             this.data = data
         }
 
-        @Deprecated("Replaced by memoryCacheKey(key).", ReplaceWith("memoryCacheKey(key)"))
+        @Deprecated("Replace with `memoryCacheKey(key)`.", ReplaceWith("memoryCacheKey(key)"))
         fun key(key: String?) = memoryCacheKey(key)
 
         /**

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -66,11 +66,11 @@ class ImageRequest private constructor(
     /** @see Builder.listener */
     val listener: Listener?,
 
-    /** @see Builder.key */
-    val key: MemoryCache.Key?,
+    /** @see Builder.memoryCacheKey */
+    val memoryCacheKey: MemoryCache.Key?,
 
-    /** @see Builder.placeholderKey */
-    val placeholderKey: MemoryCache.Key?,
+    /** @see Builder.placeholderMemoryCacheKey */
+    val placeholderMemoryCacheKey: MemoryCache.Key?,
 
     /** @see Builder.colorSpace */
     val colorSpace: ColorSpace?,
@@ -159,8 +159,8 @@ class ImageRequest private constructor(
             data == other.data &&
             target == other.target &&
             listener == other.listener &&
-            key == other.key &&
-            placeholderKey == other.placeholderKey &&
+            memoryCacheKey == other.memoryCacheKey &&
+            placeholderMemoryCacheKey == other.placeholderMemoryCacheKey &&
             colorSpace == other.colorSpace &&
             fetcher == other.fetcher &&
             decoder == other.decoder &&
@@ -194,8 +194,8 @@ class ImageRequest private constructor(
         result = 31 * result + data.hashCode()
         result = 31 * result + (target?.hashCode() ?: 0)
         result = 31 * result + (listener?.hashCode() ?: 0)
-        result = 31 * result + (key?.hashCode() ?: 0)
-        result = 31 * result + (placeholderKey?.hashCode() ?: 0)
+        result = 31 * result + (memoryCacheKey?.hashCode() ?: 0)
+        result = 31 * result + (placeholderMemoryCacheKey?.hashCode() ?: 0)
         result = 31 * result + (colorSpace?.hashCode() ?: 0)
         result = 31 * result + (fetcher?.hashCode() ?: 0)
         result = 31 * result + (decoder?.hashCode() ?: 0)
@@ -226,8 +226,8 @@ class ImageRequest private constructor(
     }
 
     override fun toString(): String {
-        return "ImageRequest(context=$context, data=$data, target=$target, listener=$listener, key=$key, " +
-            "placeholderKey=$placeholderKey, colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, " +
+        return "ImageRequest(context=$context, data=$data, target=$target, listener=$listener, key=$memoryCacheKey, " +
+            "placeholderKey=$placeholderMemoryCacheKey, colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, " +
             "transformations=$transformations, headers=$headers, parameters=$parameters, lifecycle=$lifecycle, " +
             "sizeResolver=$sizeResolver, scale=$scale, dispatcher=$dispatcher, transition=$transition, " +
             "precision=$precision, bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, " +
@@ -275,8 +275,8 @@ class ImageRequest private constructor(
 
         private var target: Target?
         private var listener: Listener?
-        private var key: MemoryCache.Key?
-        private var placeholderKey: MemoryCache.Key?
+        private var memoryCacheKey: MemoryCache.Key?
+        private var placeholderMemoryCacheKey: MemoryCache.Key?
         private var colorSpace: ColorSpace? = null
         private var fetcher: Pair<Fetcher<*>, Class<*>>?
         private var decoder: Decoder?
@@ -316,8 +316,8 @@ class ImageRequest private constructor(
             data = null
             target = null
             listener = null
-            key = null
-            placeholderKey = null
+            memoryCacheKey = null
+            placeholderMemoryCacheKey = null
             if (SDK_INT >= 26) colorSpace = null
             fetcher = null
             decoder = null
@@ -354,8 +354,8 @@ class ImageRequest private constructor(
             data = request.data
             target = request.target
             listener = request.listener
-            key = request.key
-            placeholderKey = request.placeholderKey
+            memoryCacheKey = request.memoryCacheKey
+            placeholderMemoryCacheKey = request.placeholderMemoryCacheKey
             if (SDK_INT >= 26) colorSpace = request.colorSpace
             fetcher = request.fetcher
             decoder = request.decoder
@@ -409,20 +409,23 @@ class ImageRequest private constructor(
             this.data = data
         }
 
-        /**
-         * Set the memory cache key for this request.
-         *
-         * If this is null or is not set the [ImageLoader] will compute a memory cache key.
-         */
-        fun key(key: String?) = key(key?.let { MemoryCache.Key(it) })
+        @Deprecated("Replaced by memoryCacheKey(key).", ReplaceWith("memoryCacheKey(key)"))
+        fun key(key: String?) = memoryCacheKey(key)
 
         /**
          * Set the memory cache key for this request.
          *
          * If this is null or is not set the [ImageLoader] will compute a memory cache key.
          */
-        fun key(key: MemoryCache.Key?) = apply {
-            this.key = key
+        fun memoryCacheKey(key: String?) = memoryCacheKey(key?.let { MemoryCache.Key(it) })
+
+        /**
+         * Set the memory cache key for this request.
+         *
+         * If this is null or is not set the [ImageLoader] will compute a memory cache key.
+         */
+        fun memoryCacheKey(key: MemoryCache.Key?) = apply {
+            this.memoryCacheKey = key
         }
 
         /**
@@ -666,8 +669,8 @@ class ImageRequest private constructor(
          *
          * If there is no value in the memory cache for [key], fall back to [placeholder].
          */
-        fun placeholderKey(key: MemoryCache.Key?) = apply {
-            this.placeholderKey = key
+        fun placeholderMemoryCacheKey(key: MemoryCache.Key?) = apply {
+            this.placeholderMemoryCacheKey = key
         }
 
         /**
@@ -798,8 +801,8 @@ class ImageRequest private constructor(
                 data = data ?: NullRequestData,
                 target = target,
                 listener = listener,
-                key = key,
-                placeholderKey = placeholderKey,
+                memoryCacheKey = memoryCacheKey,
+                placeholderMemoryCacheKey = placeholderMemoryCacheKey,
                 colorSpace = colorSpace,
                 fetcher = fetcher,
                 decoder = decoder,

--- a/coil-base/src/main/java/coil/request/Metadata.kt
+++ b/coil-base/src/main/java/coil/request/Metadata.kt
@@ -6,13 +6,16 @@ import coil.memory.MemoryCache
 /**
  * Supplemental information about a successful image request.
  *
- * @param key The cache key for the image in the memory cache.
+ * @param memoryCacheKey The cache key for the image in the memory cache.
  *  It is null if the image was not written to the memory cache.
  * @param isSampled True if [drawable] is sampled (i.e. loaded into memory at less than its original size).
  * @param dataSource The data source that the image was loaded from.
+ * @param isPlaceholderMemoryCacheKeyPresent True if the request's [ImageRequest.placeholderMemoryCacheKey] was
+ *  present in the memory cache and was set as the placeholder.
  */
 data class Metadata(
-    val key: MemoryCache.Key?,
+    val memoryCacheKey: MemoryCache.Key?,
     val isSampled: Boolean,
-    val dataSource: DataSource
+    val dataSource: DataSource,
+    val isPlaceholderMemoryCacheKeyPresent: Boolean
 )

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -50,7 +50,8 @@ class CrossfadeTransition @JvmOverloads constructor(
                     start = target.drawable,
                     end = result.drawable,
                     scale = (target.view as? ImageView)?.scale ?: Scale.FILL,
-                    durationMillis = durationMillis
+                    durationMillis = durationMillis,
+                    fadeStart = result !is SuccessResult || !result.metadata.isPlaceholderMemoryCacheKeyPresent
                 )
                 outerCrossfade = crossfade
                 crossfade.registerAnimationCallback(object : Animatable2Compat.AnimationCallback() {

--- a/coil-base/src/test/java/coil/intercept/FakeInterceptor.kt
+++ b/coil-base/src/test/java/coil/intercept/FakeInterceptor.kt
@@ -15,9 +15,10 @@ class FakeInterceptor : Interceptor {
             drawable = ColorDrawable(),
             request = chain.request,
             metadata = Metadata(
-                key = null,
+                memoryCacheKey = null,
                 isSampled = false,
-                dataSource = DataSource.MEMORY
+                dataSource = DataSource.MEMORY,
+                isPlaceholderMemoryCacheKeyPresent = true
             )
         )
     }

--- a/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
+++ b/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
@@ -149,8 +149,8 @@ class RealInterceptorChainTest {
             index = 0,
             request = request,
             size = PixelSize(100, 100),
-            eventListener = EventListener.NONE,
-            isPlaceholderMemoryCacheKeyPresent = false
+            cached = null,
+            eventListener = EventListener.NONE
         )
         return runBlocking { chain.proceed(request) }
     }

--- a/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
+++ b/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
@@ -95,7 +95,7 @@ class RealInterceptorChainTest {
         var request = initialRequest
         val interceptor1 = Interceptor { chain ->
             assertSame(request, chain.request)
-            request = chain.request.newBuilder().key(MemoryCache.Key("test")).build()
+            request = chain.request.newBuilder().memoryCacheKey(MemoryCache.Key("test")).build()
             chain.proceed(request)
         }
         val interceptor2 = Interceptor { chain ->
@@ -149,7 +149,8 @@ class RealInterceptorChainTest {
             index = 0,
             request = request,
             size = PixelSize(100, 100),
-            eventListener = EventListener.NONE
+            eventListener = EventListener.NONE,
+            isPlaceholderMemoryCacheKeyPresent = false
         )
         return runBlocking { chain.proceed(request) }
     }

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -82,7 +82,12 @@ class TargetDelegateTest {
             val result = SuccessResult(
                 drawable = bitmap.toDrawable(context),
                 request = request,
-                metadata = Metadata(null, false, DataSource.DISK)
+                metadata = Metadata(
+                    memoryCacheKey = null,
+                    isSampled = false,
+                    dataSource = DataSource.DISK,
+                    isPlaceholderMemoryCacheKeyPresent = false
+                )
             )
             delegate.success(result)
             assertFalse(counter.isInvalid(bitmap))
@@ -99,7 +104,12 @@ class TargetDelegateTest {
             val result = SuccessResult(
                 drawable = bitmap.toDrawable(context),
                 request = request,
-                metadata = Metadata(null, false, DataSource.DISK)
+                metadata = Metadata(
+                    memoryCacheKey = null,
+                    isSampled = false,
+                    dataSource = DataSource.DISK,
+                    isPlaceholderMemoryCacheKeyPresent = false
+                )
             )
             delegate.success(result)
             assertTrue(counter.isInvalid(bitmap))
@@ -127,7 +137,12 @@ class TargetDelegateTest {
             val result = SuccessResult(
                 drawable = bitmap.toDrawable(context),
                 request = request,
-                metadata = Metadata(null, false, DataSource.DISK)
+                metadata = Metadata(
+                    memoryCacheKey = null,
+                    isSampled = false,
+                    dataSource = DataSource.DISK,
+                    isPlaceholderMemoryCacheKeyPresent = false
+                )
             )
             delegate.success(result)
             assertTrue(target.success)
@@ -165,7 +180,12 @@ class TargetDelegateTest {
             val result = SuccessResult(
                 drawable = bitmap.toDrawable(context),
                 request = request,
-                metadata = Metadata(null, false, DataSource.DISK)
+                metadata = Metadata(
+                    memoryCacheKey = null,
+                    isSampled = false,
+                    dataSource = DataSource.DISK,
+                    isPlaceholderMemoryCacheKeyPresent = false
+                )
             )
             delegate.success(result)
             assertFalse(counter.isInvalid(bitmap))
@@ -200,7 +220,12 @@ class TargetDelegateTest {
             val result = SuccessResult(
                 drawable = bitmap.toDrawable(context),
                 request = request.newBuilder().transition(transition).build(),
-                metadata = Metadata(null, false, DataSource.DISK)
+                metadata = Metadata(
+                    memoryCacheKey = null,
+                    isSampled = false,
+                    dataSource = DataSource.DISK,
+                    isPlaceholderMemoryCacheKeyPresent = false
+                )
             )
             delegate.success(result)
 

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -67,7 +67,12 @@ class CrossfadeTransitionTest {
                 result = SuccessResult(
                     drawable = drawable,
                     request = createRequest(context),
-                    metadata = Metadata(null, false, DataSource.MEMORY_CACHE)
+                    metadata = Metadata(
+                        memoryCacheKey = null,
+                        isSampled = false,
+                        dataSource = DataSource.MEMORY_CACHE,
+                        isPlaceholderMemoryCacheKeyPresent = false
+                    )
                 )
             )
         }
@@ -88,7 +93,6 @@ class CrossfadeTransitionTest {
                         onSuccessCalled = true
 
                         assertTrue(result is CrossfadeDrawable)
-                        assertEquals(drawable, result.end)
 
                         // Stop the transition early to simulate the end of the animation.
                         result.stop()
@@ -97,7 +101,12 @@ class CrossfadeTransitionTest {
                 result = SuccessResult(
                     drawable = drawable,
                     request = createRequest(context),
-                    metadata = Metadata(null, false, DataSource.DISK)
+                    metadata = Metadata(
+                        memoryCacheKey = null,
+                        isSampled = false,
+                        dataSource = DataSource.DISK,
+                        isPlaceholderMemoryCacheKeyPresent = false
+                    )
                 )
             )
         }
@@ -127,7 +136,12 @@ class CrossfadeTransitionTest {
                 result = SuccessResult(
                     drawable = drawable,
                     request = createRequest(context),
-                    metadata = Metadata(null, false, DataSource.NETWORK)
+                    metadata = Metadata(
+                        memoryCacheKey = null,
+                        isSampled = false,
+                        dataSource = DataSource.NETWORK,
+                        isPlaceholderMemoryCacheKeyPresent = false
+                    )
                 )
             )
         }
@@ -146,7 +160,6 @@ class CrossfadeTransitionTest {
                         onSuccessCalled = true
 
                         assertTrue(error is CrossfadeDrawable)
-                        assertEquals(drawable, error.end)
 
                         // Stop the animation early to simulate the end of the animation.
                         error.stop()

--- a/coil-sample/src/main/java/coil/sample/ImageListAdapter.kt
+++ b/coil-sample/src/main/java/coil/sample/ImageListAdapter.kt
@@ -45,7 +45,7 @@ class ImageListAdapter(
             }
 
             setOnClickListener {
-                setScreen(Screen.Detail(item, metadata?.key))
+                setScreen(Screen.Detail(item, metadata?.memoryCacheKey))
             }
         }
     }

--- a/coil-sample/src/main/java/coil/sample/MainActivity.kt
+++ b/coil-sample/src/main/java/coil/sample/MainActivity.kt
@@ -75,7 +75,7 @@ class MainActivity : AppCompatActivity() {
                 binding.list.isVisible = false
                 binding.detail.isVisible = true
                 binding.detail.load(screen.image.uri) {
-                    placeholderKey(screen.placeholderKey)
+                    placeholderMemoryCacheKey(screen.placeholder)
                     parameters(screen.image.parameters)
                 }
             }

--- a/coil-sample/src/main/java/coil/sample/Screen.kt
+++ b/coil-sample/src/main/java/coil/sample/Screen.kt
@@ -6,5 +6,5 @@ sealed class Screen {
 
     object List : Screen()
 
-    data class Detail(val image: Image, val placeholderKey: MemoryCache.Key?) : Screen()
+    data class Detail(val image: Image, val placeholder: MemoryCache.Key?) : Screen()
 }


### PR DESCRIPTION
Also renames `key` references to `memoryCacheKey` to be explicit.