### PR TITLE
Remove TransitionTarget generic parameter.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -897,8 +897,9 @@ public abstract interface class coil/transition/Transition {
 public final class coil/transition/Transition$Companion {
 }
 
-public abstract interface class coil/transition/TransitionTarget : coil/target/ViewTarget {
+public abstract interface class coil/transition/TransitionTarget : coil/target/Target {
 	public abstract fun getDrawable ()Landroid/graphics/drawable/Drawable;
+	public abstract fun getView ()Landroid/view/View;
 }
 
 public final class coil/transition/TransitionTarget$DefaultImpls {

--- a/coil-base/src/androidTest/java/coil/EventListenerTest.kt
+++ b/coil-base/src/androidTest/java/coil/EventListenerTest.kt
@@ -118,7 +118,7 @@ class EventListenerTest {
             imageLoader.testEnqueue {
                 data("$SCHEME_ANDROID_RESOURCE://${context.packageName}/${R.drawable.normal}")
                 transition(object : Transition {
-                    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
+                    override suspend fun transition(target: TransitionTarget, result: ImageResult) {
                         transitionIsCalled = true
                         when (result) {
                             is SuccessResult -> target.onSuccess(result.drawable)

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -166,7 +166,7 @@ private suspend inline fun Target.onSuccess(
         return
     }
 
-    if (this !is TransitionTarget<*>) {
+    if (this !is TransitionTarget) {
         logger?.log(TAG, Log.DEBUG) {
             "Ignoring '$transition' as '$this' does not implement coil.transition.TransitionTarget."
         }
@@ -191,7 +191,7 @@ private suspend inline fun Target.onError(
         return
     }
 
-    if (this !is TransitionTarget<*>) {
+    if (this !is TransitionTarget) {
         logger?.log(TAG, Log.DEBUG) {
             "Ignoring '$transition' as '$this' does not implement coil.transition.TransitionTarget."
         }

--- a/coil-base/src/main/java/coil/target/ImageViewTarget.kt
+++ b/coil-base/src/main/java/coil/target/ImageViewTarget.kt
@@ -13,7 +13,7 @@ import coil.transition.TransitionTarget
 /** A [Target] that handles setting images on an [ImageView]. */
 open class ImageViewTarget(
     override val view: ImageView
-) : PoolableViewTarget<ImageView>, TransitionTarget<ImageView>, DefaultLifecycleObserver {
+) : PoolableViewTarget<ImageView>, TransitionTarget, DefaultLifecycleObserver {
 
     private var isStarted = false
 

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -25,7 +25,7 @@ class CrossfadeTransition @JvmOverloads constructor(
         require(durationMillis > 0) { "durationMillis must be > 0." }
     }
 
-    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
+    override suspend fun transition(target: TransitionTarget, result: ImageResult) {
         // Don't animate if the request was fulfilled by the memory cache.
         if (result is SuccessResult && result.metadata.dataSource == DataSource.MEMORY_CACHE) {
             target.onSuccess(result.drawable)

--- a/coil-base/src/main/java/coil/transition/NoneTransition.kt
+++ b/coil-base/src/main/java/coil/transition/NoneTransition.kt
@@ -11,7 +11,7 @@ import coil.request.SuccessResult
 @ExperimentalCoilApi
 internal object NoneTransition : Transition {
 
-    override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
+    override suspend fun transition(target: TransitionTarget, result: ImageResult) {
         when (result) {
             is SuccessResult -> target.onSuccess(result.drawable)
             is ErrorResult -> target.onError(result.drawable)

--- a/coil-base/src/main/java/coil/transition/Transition.kt
+++ b/coil-base/src/main/java/coil/transition/Transition.kt
@@ -28,7 +28,7 @@ interface Transition {
      * @param result The result of the image request.
      */
     @MainThread
-    suspend fun transition(target: TransitionTarget<*>, result: ImageResult)
+    suspend fun transition(target: TransitionTarget, result: ImageResult)
 
     companion object {
         @JvmField val NONE: Transition = NoneTransition

--- a/coil-base/src/main/java/coil/transition/TransitionTarget.kt
+++ b/coil-base/src/main/java/coil/transition/TransitionTarget.kt
@@ -4,13 +4,17 @@ import android.graphics.drawable.Drawable
 import android.view.View
 import coil.annotation.ExperimentalCoilApi
 import coil.target.Target
-import coil.target.ViewTarget
 
 /**
  * A [Target] that supports applying [Transition]s.
  */
 @ExperimentalCoilApi
-interface TransitionTarget<T : View> : ViewTarget<T> {
+interface TransitionTarget : Target {
+
+    /**
+     * The [View] used by this [Target].
+     */
+    val view: View
 
     /**
      * The [view]'s current [Drawable].

--- a/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
+++ b/coil-base/src/test/java/coil/memory/TargetDelegateTest.kt
@@ -210,7 +210,7 @@ class TargetDelegateTest {
             val bitmap = createBitmap()
             var isRunning = true
             val transition = object : Transition {
-                override suspend fun transition(target: TransitionTarget<*>, result: ImageResult) {
+                override suspend fun transition(target: TransitionTarget, result: ImageResult) {
                     assertFalse(initialBitmap in pool.bitmaps)
                     delay(100) // Simulate an animation.
                     assertFalse(initialBitmap in pool.bitmaps)

--- a/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
+++ b/coil-base/src/test/java/coil/transition/CrossfadeTransitionTest.kt
@@ -181,11 +181,10 @@ class CrossfadeTransitionTest {
         crossinline onStart: (placeholder: Drawable?) -> Unit = { fail() },
         crossinline onError: (error: Drawable?) -> Unit = { fail() },
         crossinline onSuccess: (result: Drawable) -> Unit = { fail() }
-    ): TransitionTarget<*> {
-        return object : TransitionTarget<ImageView> {
+    ): TransitionTarget {
+        return object : TransitionTarget {
             override val view = imageView
-            override val drawable: Drawable?
-                get() = imageView.drawable
+            override val drawable: Drawable? get() = imageView.drawable
             override fun onStart(placeholder: Drawable?) = onStart(placeholder)
             override fun onError(error: Drawable?) = onError(error)
             override fun onSuccess(result: Drawable) = onSuccess(result)


### PR DESCRIPTION
The generic parameter is unused and was only added to work around JVM [type erasure](https://stackoverflow.com/questions/55456496/type-parameter-of-sub-interface-has-inconsistent-values). This requires that `TransitionTarget` not implement `ViewTarget` - implementations like `ImageViewTarget` should depend on both `ViewTarget` and `TransitionTarget` separately.