### PR TITLE
Invalidate bitmap before adding it to the memory cache.

### DIFF
--- a/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
+++ b/coil-base/src/main/java/coil/intercept/RealInterceptorChain.kt
@@ -17,6 +17,7 @@ internal class RealInterceptorChain(
     override val request: ImageRequest,
     override val size: Size,
     val cached: Drawable?,
+    val invalidate: Boolean,
     val eventListener: EventListener
 ) : Interceptor.Chain {
 
@@ -53,5 +54,5 @@ internal class RealInterceptorChain(
         index: Int = this.index,
         request: ImageRequest = this.request,
         size: Size = this.size
-    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size, cached, eventListener)
+    ) = RealInterceptorChain(initialRequest, requestType, interceptors, index, request, size, cached, invalidate, eventListener)
 }

--- a/coil-base/src/main/java/coil/memory/TargetDelegate.kt
+++ b/coil-base/src/main/java/coil/memory/TargetDelegate.kt
@@ -33,6 +33,8 @@ internal sealed class TargetDelegate {
 
     open val target: Target? get() = null
 
+    open val invalidate: Boolean get() = true
+
     @MainThread
     open fun start(cached: BitmapDrawable?, placeholder: Drawable?) {}
 
@@ -54,7 +56,7 @@ internal object EmptyTargetDelegate : TargetDelegate()
 /**
  * Only invalidate the success bitmaps.
  *
- * Used if [ImageRequest.target] is null and the success [Drawable] is leaked.
+ * Used if [ImageRequest.target] is null and the success [Drawable] is exposed.
  *
  * @see ImageLoader.execute
  */
@@ -101,6 +103,8 @@ internal class PoolableTargetDelegate(
     private val eventListener: EventListener,
     private val logger: Logger?
 ) : TargetDelegate(), Poolable {
+
+    override val invalidate get() = false
 
     override fun start(cached: BitmapDrawable?, placeholder: Drawable?) {
         instrument(cached?.bitmap) { onStart(placeholder) }

--- a/coil-base/src/main/java/coil/util/Extensions.kt
+++ b/coil-base/src/main/java/coil/util/Extensions.kt
@@ -24,7 +24,6 @@ import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.base.R
 import coil.decode.DataSource
 import coil.memory.MemoryCache
-import coil.memory.StrongMemoryCache
 import coil.memory.TargetDelegate
 import coil.memory.ViewTargetRequestManager
 import coil.request.ImageResult
@@ -50,17 +49,6 @@ internal inline val StatFs.blockCountCompat: Long
 @Suppress("DEPRECATION")
 internal inline val StatFs.blockSizeCompat: Long
     get() = if (SDK_INT > 18) blockSizeLong else blockSize.toLong()
-
-internal fun StrongMemoryCache.set(key: MemoryCache.Key?, value: Drawable, isSampled: Boolean): Boolean {
-    if (key != null) {
-        val bitmap = (value as? BitmapDrawable)?.bitmap
-        if (bitmap != null) {
-            set(key, bitmap, isSampled)
-            return true
-        }
-    }
-    return false
-}
 
 internal inline fun <T> takeIf(take: Boolean, factory: () -> T): T? {
     return if (take) factory() else null

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -68,6 +68,7 @@ class EngineInterceptorTest {
         interceptor = EngineInterceptor(
             registry = ComponentRegistry(),
             bitmapPool = bitmapPool,
+            referenceCounter = BitmapReferenceCounter(weakMemoryCache, bitmapPool, null),
             strongMemoryCache = strongMemoryCache,
             weakMemoryCache = weakMemoryCache,
             requestService = RequestService(null),
@@ -78,31 +79,31 @@ class EngineInterceptorTest {
     }
 
     @Test
-    fun `computeKey - null key`() {
+    fun `computeMemoryCacheKey - null key`() {
         val request = createRequest(context)
         val fetcher = createFakeFetcher(key = null)
         val size = OriginalSize
         val key = runBlocking {
-            interceptor.computeKey(request, Unit, fetcher, size)
+            interceptor.computeMemoryCacheKey(request, Unit, fetcher, size)
         }
 
         assertNull(key)
     }
 
     @Test
-    fun `computeKey - simple key`() {
+    fun `computeMemoryCacheKey - simple key`() {
         val request = createRequest(context)
         val fetcher = createFakeFetcher()
         val size = OriginalSize
         val result = runBlocking {
-            interceptor.computeKey(request, Unit, fetcher, size)
+            interceptor.computeMemoryCacheKey(request, Unit, fetcher, size)
         }
 
         assertEquals(Key("base_key", Parameters.EMPTY), result)
     }
 
     @Test
-    fun `computeKey - params only`() {
+    fun `computeMemoryCacheKey - params only`() {
         val parameters = createFakeParameters()
         val request = createRequest(context) {
             parameters(parameters)
@@ -110,14 +111,14 @@ class EngineInterceptorTest {
         val fetcher = createFakeFetcher()
         val size = OriginalSize
         val result = runBlocking {
-            interceptor.computeKey(request, Unit, fetcher, size)
+            interceptor.computeMemoryCacheKey(request, Unit, fetcher, size)
         }
 
         assertEquals(Key("base_key", parameters), result)
     }
 
     @Test
-    fun `computeKey - transformations only`() {
+    fun `computeMemoryCacheKey - transformations only`() {
         val transformations = createFakeTransformations()
         val request = createRequest(context) {
             transformations(transformations)
@@ -125,14 +126,14 @@ class EngineInterceptorTest {
         val fetcher = createFakeFetcher()
         val size = PixelSize(123, 332)
         val result = runBlocking {
-            interceptor.computeKey(request, Unit, fetcher, size)
+            interceptor.computeMemoryCacheKey(request, Unit, fetcher, size)
         }
 
         assertEquals(Key("base_key", transformations, size, Parameters.EMPTY), result)
     }
 
     @Test
-    fun `computeKey - complex key`() {
+    fun `computeMemoryCacheKey - complex key`() {
         val parameters = createFakeParameters()
         val transformations = createFakeTransformations()
         val request = createRequest(context) {
@@ -142,7 +143,7 @@ class EngineInterceptorTest {
         val fetcher = createFakeFetcher()
         val size = OriginalSize
         val result = runBlocking {
-            interceptor.computeKey(request, Unit, fetcher, size)
+            interceptor.computeMemoryCacheKey(request, Unit, fetcher, size)
         }
 
         assertEquals(Key("base_key", transformations, size, parameters), result)

--- a/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
+++ b/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
@@ -150,6 +150,7 @@ class RealInterceptorChainTest {
             request = request,
             size = PixelSize(100, 100),
             cached = null,
+            invalidate = false,
             eventListener = EventListener.NONE
         )
         return runBlocking { chain.proceed(request) }


### PR DESCRIPTION
This fixes a race condition (not in 0.11.0) where a bitmap could be recycled when being evicted from the memory cache before it has a chance to be marked as invalid.