### PR TITLE
Start InterruptibleSource in UNINTERRUPTIBLE state.

### DIFF
--- a/coil-base/src/main/java/coil/decode/InterruptibleSource.kt
+++ b/coil-base/src/main/java/coil/decode/InterruptibleSource.kt
@@ -54,7 +54,7 @@ internal class InterruptibleSource(
     delegate: Source
 ) : ForwardingSource(delegate), CompletionHandler {
 
-    private val _state = AtomicInteger(WORKING)
+    private val _state = AtomicInteger(UNINTERRUPTIBLE)
     private val targetThread = Thread.currentThread()
 
     init {
@@ -64,8 +64,8 @@ internal class InterruptibleSource(
         run {
             _state.loop { state ->
                 when (state) {
-                    WORKING -> if (_state.compareAndSet(state, WORKING)) return@run
-                    INTERRUPTING, INTERRUPTED -> return@run
+                    UNINTERRUPTIBLE -> if (_state.compareAndSet(state, UNINTERRUPTIBLE)) return@run
+                    PENDING, INTERRUPTING, INTERRUPTED -> return@run
                     else -> invalidState(state)
                 }
             }


### PR DESCRIPTION
This fixes a race condition where it's possible to interrupt the thread during the TLS handshake. If this happens subsequent requests won't be saved to the disk cache.