### PR TITLE
Use ImageRequest.context to load resource URIs.

### DIFF
--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -91,6 +91,9 @@ fun DependencyHandler.addAndroidTestDependencies(kotlinVersion: String, includeT
     androidTestImplementation(Library.JUNIT)
     androidTestImplementation(kotlin("test-junit", kotlinVersion))
 
+    androidTestImplementation(Library.ANDROIDX_APPCOMPAT)
+    androidTestImplementation(Library.MATERIAL)
+
     androidTestImplementation(Library.ANDROIDX_TEST_CORE)
     androidTestImplementation(Library.ANDROIDX_TEST_JUNIT)
     androidTestImplementation(Library.ANDROIDX_TEST_RULES)

--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -23,6 +23,7 @@ object Library {
 
     private const val LIFECYCLE_VERSION = "2.2.0"
     const val ANDROIDX_LIFECYCLE_COMMON = "androidx.lifecycle:lifecycle-common-java8:$LIFECYCLE_VERSION"
+    const val ANDROIDX_LIFECYCLE_RUNTIME = "androidx.lifecycle:lifecycle-runtime:$LIFECYCLE_VERSION"
     const val ANDROIDX_LIFECYCLE_VIEW_MODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:$LIFECYCLE_VERSION"
 
     const val MATERIAL = "com.google.android.material:material:1.2.0"

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -207,14 +207,15 @@ public final class coil/decode/InterruptibleSourceKt {
 }
 
 public final class coil/decode/Options {
-	public fun <init> (Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public final fun copy (Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
-	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
+	public fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
+	public final fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
+	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowInexactSize ()Z
 	public final fun getAllowRgb565 ()Z
 	public final fun getColorSpace ()Landroid/graphics/ColorSpace;
 	public final fun getConfig ()Landroid/graphics/Bitmap$Config;
+	public final fun getContext ()Landroid/content/Context;
 	public final fun getDiskCachePolicy ()Lcoil/request/CachePolicy;
 	public final fun getHeaders ()Lokhttp3/Headers;
 	public final fun getMemoryCachePolicy ()Lcoil/request/CachePolicy;

--- a/coil-base/build.gradle.kts
+++ b/coil-base/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(Library.ANDROIDX_EXIF_INTERFACE)
 
     api(Library.ANDROIDX_LIFECYCLE_COMMON)
+    implementation(Library.ANDROIDX_LIFECYCLE_RUNTIME)
 
     api(Library.OKHTTP)
     api(Library.OKIO)

--- a/coil-base/src/androidTest/AndroidManifest.xml
+++ b/coil-base/src/androidTest/AndroidManifest.xml
@@ -9,6 +9,10 @@
     <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
 
     <application android:usesCleartextTraffic="true">
+        <activity
+            android:name="coil.fetch.ResourceUriFetcherTest$TestActivity"
+            android:theme="@style/Theme.TestActivity"/>
+
         <provider
             android:name="coil.util.AssetContentProvider"
             android:authorities="coil"

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -106,7 +106,11 @@ class BitmapFactoryDecoderTest {
         val result = decodeBitmap(
             assetName = "normal.jpg",
             size = PixelSize(1500, 1500),
-            options = createOptions(scale = Scale.FIT, allowInexactSize = true)
+            options = createOptions(
+                context = context,
+                scale = Scale.FIT,
+                allowInexactSize = true
+            )
         )
         assertEquals(PixelSize(1080, 1350), result.size)
     }
@@ -116,7 +120,11 @@ class BitmapFactoryDecoderTest {
         val result = decodeBitmap(
             assetName = "normal.jpg",
             size = PixelSize(1500, 1500),
-            options = createOptions(scale = Scale.FIT, allowInexactSize = false)
+            options = createOptions(
+                context = context,
+                scale = Scale.FIT,
+                allowInexactSize = false
+            )
         )
         assertEquals(PixelSize(1200, 1500), result.size)
     }
@@ -126,7 +134,10 @@ class BitmapFactoryDecoderTest {
         val result = decodeBitmap(
             assetName = "normal.jpg",
             size = PixelSize(500, 500),
-            options = createOptions(allowRgb565 = true)
+            options = createOptions(
+                context = context,
+                allowRgb565 = true
+            )
         )
         assertEquals(PixelSize(500, 625), result.size)
         assertEquals(Bitmap.Config.RGB_565, result.config)
@@ -137,7 +148,10 @@ class BitmapFactoryDecoderTest {
         val result = decodeBitmap(
             assetName = "normal.jpg",
             size = PixelSize(500, 500),
-            options = createOptions(allowRgb565 = false)
+            options = createOptions(
+                context = context,
+                allowRgb565 = false
+            )
         )
         assertEquals(PixelSize(500, 625), result.size)
         assertEquals(Bitmap.Config.ARGB_8888, result.config)
@@ -152,6 +166,7 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             size = PixelSize(1080, 1350),
             options = createOptions(
+                context = context,
                 config = Bitmap.Config.ARGB_8888,
                 scale = Scale.FIT,
                 allowInexactSize = false
@@ -178,6 +193,7 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             size = PixelSize(500, 500),
             options = createOptions(
+                context = context,
                 config = Bitmap.Config.ARGB_8888,
                 scale = Scale.FILL,
                 allowInexactSize = false
@@ -260,7 +276,7 @@ class BitmapFactoryDecoderTest {
     private fun decode(
         assetName: String,
         size: Size,
-        options: Options = createOptions()
+        options: Options = createOptions(context)
     ): DecodeResult = runBlocking {
         val source = context.assets.open(assetName).source().buffer()
         val result = service.decode(
@@ -280,6 +296,6 @@ class BitmapFactoryDecoderTest {
     private fun decodeBitmap(
         assetName: String,
         size: Size,
-        options: Options = createOptions()
+        options: Options = createOptions(context)
     ): Bitmap = (decode(assetName, size, options).drawable as BitmapDrawable).bitmap
 }

--- a/coil-base/src/androidTest/java/coil/fetch/AssetUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/AssetUriFetcherTest.kt
@@ -47,7 +47,7 @@ class AssetUriFetcherTest {
 
     private fun assertUriFetchesCorrectly(uri: Uri) {
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)

--- a/coil-base/src/androidTest/java/coil/fetch/ContentUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ContentUriFetcherTest.kt
@@ -79,7 +79,7 @@ class ContentUriFetcherTest {
         assertTrue(fetcher.handles(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)

--- a/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
@@ -34,7 +34,7 @@ class FileFetcherTest {
 
         val size = PixelSize(100, 100)
         val result = runBlocking {
-            fetcher.fetch(pool, file, size, createOptions())
+            fetcher.fetch(pool, file, size, createOptions(context))
         }
 
         assertTrue(result is SourceResult)

--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -4,14 +4,22 @@ import android.content.ContentResolver.SCHEME_ANDROID_RESOURCE
 import android.content.Context
 import android.graphics.drawable.BitmapDrawable
 import android.os.Build.VERSION.SDK_INT
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.core.app.launchActivity
 import coil.base.test.R
 import coil.bitmap.BitmapPool
 import coil.decode.DrawableDecoderService
+import coil.map.ResourceIntMapper
 import coil.map.ResourceUriMapper
+import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.util.createOptions
+import coil.util.getDrawableCompat
+import coil.util.isSimilarTo
 import kotlinx.coroutines.runBlocking
 import org.junit.Assume.assumeTrue
 import org.junit.Before
@@ -42,7 +50,7 @@ class ResourceUriFetcherTest {
         assertTrue(fetcher.handles(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)
@@ -57,7 +65,7 @@ class ResourceUriFetcherTest {
         assertTrue(fetcher.handles(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is DrawableResult)
@@ -75,7 +83,7 @@ class ResourceUriFetcherTest {
         assertTrue(fetcher.handles(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)
@@ -95,11 +103,31 @@ class ResourceUriFetcherTest {
         assertTrue(fetcher.handles(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is DrawableResult)
         assertTrue(result.drawable is BitmapDrawable)
         assertTrue(result.isSampled)
     }
+
+    /** Regression test: https://github.com/coil-kt/coil/issues/469 */
+    @Test
+    fun colorAttributeIsApplied() {
+        val scenario = launchActivity<TestActivity>()
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity { activity ->
+            runBlocking {
+                val result = runBlocking {
+                    val uri = ResourceIntMapper(context).map(R.drawable.ic_tinted_vector)
+                    fetcher.fetch(pool, uri, OriginalSize, createOptions(activity))
+                }
+                val expected = activity.getDrawableCompat(R.drawable.ic_tinted_vector).toBitmap()
+                val actual = (result as DrawableResult).drawable.toBitmap()
+                assertTrue(actual.isSimilarTo(expected))
+            }
+        }
+    }
+
+    class TestActivity : AppCompatActivity()
 }

--- a/coil-base/src/androidTest/res/drawable/ic_tinted_vector.xml
+++ b/coil-base/src/androidTest/res/drawable/ic_tinted_vector.xml
@@ -1,0 +1,12 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?colorPrimary"
+    android:tintMode="src_in">
+    <path
+        android:fillColor="#00FF00"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+</vector>

--- a/coil-base/src/androidTest/res/values/styles.xml
+++ b/coil-base/src/androidTest/res/values/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.TestActivity" parent="@style/Theme.MaterialComponents.Light">
+        <item name="colorPrimary">#FF0000</item>
+    </style>
+</resources>

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -104,8 +104,8 @@ internal class RealImageLoader(
         .add(AssetUriFetcher(context))
         .add(ContentUriFetcher(context))
         .add(ResourceUriFetcher(context, drawableDecoder))
-        .add(DrawableFetcher(context, drawableDecoder))
-        .add(BitmapFetcher(context))
+        .add(DrawableFetcher(drawableDecoder))
+        .add(BitmapFetcher())
         // Decoders
         .add(BitmapFactoryDecoder(context))
         .build()

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -1,5 +1,6 @@
 package coil.decode
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.ColorSpace
 import coil.fetch.Fetcher
@@ -13,6 +14,7 @@ import okhttp3.Headers
  *
  * [Fetcher]s and [Decoder]s should respect these options as best as possible.
  *
+ * @param context The [Context] used to execute this request.
  * @param config The requested config for any [Bitmap]s.
  * @param colorSpace The preferred color space for any [Bitmap]s.
  *  If null, components should typically default to [ColorSpace.Rgb].
@@ -28,6 +30,7 @@ import okhttp3.Headers
  * @param networkCachePolicy Determines if this request is allowed to read from the network.
  */
 class Options(
+    val context: Context,
     val config: Bitmap.Config,
     val colorSpace: ColorSpace?,
     val scale: Scale,
@@ -41,6 +44,7 @@ class Options(
 ) {
 
     fun copy(
+        context: Context = this.context,
         config: Bitmap.Config = this.config,
         colorSpace: ColorSpace? = this.colorSpace,
         scale: Scale = this.scale,
@@ -51,12 +55,13 @@ class Options(
         memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
         diskCachePolicy: CachePolicy = this.diskCachePolicy,
         networkCachePolicy: CachePolicy = this.networkCachePolicy
-    ) = Options(config, colorSpace, scale, allowInexactSize, allowRgb565, headers, parameters, memoryCachePolicy,
-        diskCachePolicy, networkCachePolicy)
+    ) = Options(context, config, colorSpace, scale, allowInexactSize, allowRgb565, headers, parameters,
+        memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         return other is Options &&
+            context == other.context &&
             config == other.config &&
             colorSpace == other.colorSpace &&
             scale == other.scale &&
@@ -70,7 +75,8 @@ class Options(
     }
 
     override fun hashCode(): Int {
-        var result = config.hashCode()
+        var result = context.hashCode()
+        result = 31 * result + config.hashCode()
         result = 31 * result + (colorSpace?.hashCode() ?: 0)
         result = 31 * result + scale.hashCode()
         result = 31 * result + allowInexactSize.hashCode()
@@ -84,8 +90,9 @@ class Options(
     }
 
     override fun toString(): String {
-        return "Options(config=$config, colorSpace=$colorSpace, scale=$scale, allowInexactSize=$allowInexactSize, " +
-            "allowRgb565=$allowRgb565, headers=$headers, parameters=$parameters, memoryCachePolicy=$memoryCachePolicy, " +
-            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy)"
+        return "Options(context=$context, config=$config, colorSpace=$colorSpace, scale=$scale, " +
+            "allowInexactSize=$allowInexactSize, allowRgb565=$allowRgb565, headers=$headers, " +
+            "parameters=$parameters, memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
+            "networkCachePolicy=$networkCachePolicy)"
     }
 }

--- a/coil-base/src/main/java/coil/fetch/BitmapFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/BitmapFetcher.kt
@@ -1,6 +1,5 @@
 package coil.fetch
 
-import android.content.Context
 import android.graphics.Bitmap
 import coil.bitmap.BitmapPool
 import coil.decode.DataSource
@@ -8,7 +7,7 @@ import coil.decode.Options
 import coil.size.Size
 import coil.util.toDrawable
 
-internal class BitmapFetcher(private val context: Context) : Fetcher<Bitmap> {
+internal class BitmapFetcher : Fetcher<Bitmap> {
 
     override fun key(data: Bitmap): String? = null
 
@@ -19,7 +18,7 @@ internal class BitmapFetcher(private val context: Context) : Fetcher<Bitmap> {
         options: Options
     ): FetchResult {
         return DrawableResult(
-            drawable = data.toDrawable(context),
+            drawable = data.toDrawable(options.context),
             isSampled = false,
             dataSource = DataSource.MEMORY
         )

--- a/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/DrawableFetcher.kt
@@ -1,6 +1,5 @@
 package coil.fetch
 
-import android.content.Context
 import android.graphics.drawable.Drawable
 import coil.bitmap.BitmapPool
 import coil.decode.DataSource
@@ -10,10 +9,7 @@ import coil.size.Size
 import coil.util.isVector
 import coil.util.toDrawable
 
-internal class DrawableFetcher(
-    private val context: Context,
-    private val drawableDecoder: DrawableDecoderService
-) : Fetcher<Drawable> {
+internal class DrawableFetcher(private val drawableDecoder: DrawableDecoderService) : Fetcher<Drawable> {
 
     override fun key(data: Drawable): String? = null
 
@@ -32,7 +28,7 @@ internal class DrawableFetcher(
                     size = size,
                     scale = options.scale,
                     allowInexactSize = options.allowInexactSize
-                ).toDrawable(context)
+                ).toDrawable(options.context)
             } else {
                 data
             },

--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -38,6 +38,7 @@ internal class ResourceUriFetcher(
         val packageName = data.authority?.takeIf { it.isNotBlank() } ?: throwInvalidUriException(data)
         val resId = data.pathSegments.lastOrNull()?.toIntOrNull() ?: throwInvalidUriException(data)
 
+        val context = options.context
         val resources = context.packageManager.getResourcesForApplication(packageName)
         val path = TypedValue().apply { resources.getValue(resId, this, true) }.string
         val entryName = path.substring(path.lastIndexOf('/'))

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -48,6 +48,7 @@ internal class RequestService(private val logger: Logger?) {
         val allowRgb565 = request.allowRgb565 && request.transformations.isEmpty() && config != Bitmap.Config.ALPHA_8
 
         return Options(
+            context = request.context,
             config = config,
             colorSpace = request.colorSpace,
             scale = request.scale,

--- a/coil-base/src/test/java/coil/fetch/HttpFetcherTest.kt
+++ b/coil-base/src/test/java/coil/fetch/HttpFetcherTest.kt
@@ -64,7 +64,7 @@ class HttpFetcherTest {
         assertEquals(url.toString(), fetcher.key(url))
 
         val result = runBlocking {
-            fetcher.fetch(pool, url, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, url, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)
@@ -79,7 +79,7 @@ class HttpFetcherTest {
         assertEquals(uri.toString(), fetcher.key(uri))
 
         val result = runBlocking {
-            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions())
+            fetcher.fetch(pool, uri, PixelSize(100, 100), createOptions(context))
         }
 
         assertTrue(result is SourceResult)

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -461,7 +461,7 @@ class EngineInterceptorTest {
                 ),
                 request = createRequest(context) { transformations(CircleCropTransformation()) },
                 size = size,
-                options = createOptions(),
+                options = createOptions(context),
                 eventListener = EventListener.NONE
             )
         }
@@ -484,7 +484,7 @@ class EngineInterceptorTest {
                 ),
                 request = createRequest(context) { transformations(emptyList()) },
                 size = size,
-                options = createOptions(),
+                options = createOptions(context),
                 eventListener = EventListener.NONE
             )
         }

--- a/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
+++ b/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
@@ -37,7 +37,7 @@ class SvgDecoderTest {
                 pool = pool,
                 source = source,
                 size = PixelSize(400, 250), // coil_logo.svg's intrinsic dimensions are 200x200.
-                options = createOptions(scale = Scale.FIT)
+                options = createOptions(context = context, scale = Scale.FIT)
             )
         }
 
@@ -56,7 +56,7 @@ class SvgDecoderTest {
                 pool = pool,
                 source = source,
                 size = PixelSize(326, 50),
-                options = createOptions(scale = Scale.FILL)
+                options = createOptions(context = context, scale = Scale.FILL)
             )
         }
 

--- a/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
+++ b/coil-test/src/main/java/coil/util/SharedTestFunctions.kt
@@ -40,6 +40,7 @@ fun createMockWebServer(context: Context, vararg images: String): MockWebServer 
 }
 
 fun createOptions(
+    context: Context,
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
     scale: Scale = Scale.FILL,
     allowInexactSize: Boolean = false,
@@ -51,6 +52,7 @@ fun createOptions(
     networkCachePolicy: CachePolicy = CachePolicy.ENABLED
 ): Options {
     return Options(
+        context,
         config,
         null,
         scale,
@@ -66,6 +68,7 @@ fun createOptions(
 
 @RequiresApi(26)
 fun createOptions(
+    context: Context,
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
     colorSpace: ColorSpace? = null,
     scale: Scale = Scale.FILL,
@@ -78,6 +81,7 @@ fun createOptions(
     networkCachePolicy: CachePolicy = CachePolicy.ENABLED
 ): Options {
     return Options(
+        context,
         config,
         colorSpace,
         scale,

--- a/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
+++ b/coil-video/src/androidTest/java/coil/fetch/VideoFrameFetcherTest.kt
@@ -45,7 +45,7 @@ class VideoFrameFetcherTest {
                 pool = pool,
                 data = "$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/video.mp4".toUri(),
                 size = OriginalSize,
-                options = createOptions()
+                options = createOptions(context)
             )
         }
 
@@ -69,6 +69,7 @@ class VideoFrameFetcherTest {
                 data = "$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/video.mp4".toUri(),
                 size = OriginalSize,
                 options = createOptions(
+                    context = context,
                     parameters = Parameters.Builder()
                         .set(VIDEO_FRAME_MICROS_KEY, 32600000L)
                         .build()


### PR DESCRIPTION
Fixes #469.