### PR TITLE
Work around compiler bug in Lifecycles.

### DIFF
--- a/coil-base/src/main/java/coil/util/Lifecycles.kt
+++ b/coil-base/src/main/java/coil/util/Lifecycles.kt
@@ -36,7 +36,7 @@ internal suspend fun Lifecycle.observeStarted() {
             addObserver(observer!!)
         }
     } finally {
-        // 'observer' will always be null if this method is inlined.
+        // 'observer' will always be null if this method is marked as 'inline'.
         observer?.let(::removeObserver)
     }
 }

--- a/coil-base/src/main/java/coil/util/Lifecycles.kt
+++ b/coil-base/src/main/java/coil/util/Lifecycles.kt
@@ -19,20 +19,24 @@ internal suspend inline fun Lifecycle.awaitStarted() {
     if (currentState.isAtLeast(STARTED)) return
 
     // Slow path: observe the lifecycle until we're started.
+    observeStarted()
+}
+
+/** Cannot be 'inline' due to a compiler bug. There is a test that guards against this bug. */
+@MainThread
+internal suspend fun Lifecycle.observeStarted() {
     var observer: LifecycleObserver? = null
     try {
         suspendCancellableCoroutine<Unit> { continuation ->
             observer = object : DefaultLifecycleObserver {
                 override fun onStart(owner: LifecycleOwner) {
-                    removeObserver(this)
                     continuation.resume(Unit)
                 }
             }
             addObserver(observer!!)
         }
-    } catch (throwable: Throwable) {
-        // Ensure exceptions are handled on the main thread.
+    } finally {
+        // 'observer' will always be null if this method is inlined.
         observer?.let(::removeObserver)
-        throw throwable
     }
 }

--- a/coil-base/src/test/java/coil/lifecycle/LifecyclesTest.kt
+++ b/coil-base/src/test/java/coil/lifecycle/LifecyclesTest.kt
@@ -15,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -48,12 +49,16 @@ class LifecyclesTest {
 
     @Test
     fun `dispatches after start event`() = runBlockingTest {
+        assertEquals(0, lifecycle.observerCount)
+
         val job = launch { lifecycle.awaitStarted() }
 
         assertFalse(job.isCompleted)
+        assertEquals(1, lifecycle.observerCount)
 
         lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
 
         assertTrue(job.isCompleted)
+        assertEquals(0, lifecycle.observerCount)
     }
 }

--- a/coil-base/src/test/java/coil/lifecycle/LifecyclesTest.kt
+++ b/coil-base/src/test/java/coil/lifecycle/LifecyclesTest.kt
@@ -61,4 +61,19 @@ class LifecyclesTest {
         assertTrue(job.isCompleted)
         assertEquals(0, lifecycle.observerCount)
     }
+
+    @Test
+    fun `observer is removed if cancelled`() = runBlockingTest {
+        assertEquals(0, lifecycle.observerCount)
+
+        val job = launch { lifecycle.awaitStarted() }
+
+        assertFalse(job.isCompleted)
+        assertEquals(1, lifecycle.observerCount)
+
+        job.cancel()
+
+        assertTrue(job.isCompleted)
+        assertEquals(0, lifecycle.observerCount)
+    }
 }


### PR DESCRIPTION
Noticed this while adding more tests. Currently the "catch" that removes the `observer` won't work if the function is inlined as it will be `null` if the method is inlined.

Working on reproducing this in a small project to file a bug.