### PR TITLE
Add Context.imageLoader extension function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ imageView.load("https://www.example.com/image.jpg") {
 
 #### Image Loaders
 
-`imageView.load` uses the singleton `ImageLoader` to enqueue an `ImageRequest`. The singleton `ImageLoader` can be accessed using:
+`imageView.load` uses the singleton `ImageLoader` to enqueue an `ImageRequest`. The singleton `ImageLoader` can be accessed using an extension function:
 
 ```kotlin
-val imageLoader = Coil.imageLoader(context)
+val imageLoader = context.imageLoader
 ```
 
 Optionally, you can create your own `ImageLoader` instance(s) and inject them with dependency injection:

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ imageView.load("https://www.example.com/image.jpg") {
 
 #### Image Loaders
 
-`imageView.load` uses the singleton `ImageLoader` to enqueue an `ImageRequest`. The singleton `ImageLoader` can be accessed using an extension function:
+`imageView.load` uses the singleton `ImageLoader` to enqueue an `ImageRequest`. The singleton `ImageLoader` can be accessed using:
 
 ```kotlin
-val imageLoader = context.imageLoader
+val imageLoader = Coil.imageLoader(context)
 ```
 
 Optionally, you can create your own `ImageLoader` instance(s) and inject them with dependency injection:

--- a/coil-singleton/api/coil-singleton.api
+++ b/coil-singleton/api/coil-singleton.api
@@ -7,6 +7,10 @@ public final class coil/Coil {
 	public static final fun setImageLoader (Lcoil/ImageLoaderFactory;)V
 }
 
+public final class coil/Contexts {
+	public static final fun imageLoader (Landroid/content/Context;)Lcoil/ImageLoader;
+}
+
 public abstract interface class coil/ImageLoaderFactory {
 	public abstract fun newImageLoader ()Lcoil/ImageLoader;
 }

--- a/coil-singleton/src/main/java/coil/Contexts.kt
+++ b/coil-singleton/src/main/java/coil/Contexts.kt
@@ -1,0 +1,12 @@
+@file:JvmName("Contexts")
+@file:Suppress("unused")
+
+package coil
+
+import android.content.Context
+
+/**
+ * Get the default [ImageLoader]. This is an alias for [Coil.imageLoader].
+ */
+inline val Context.imageLoader: ImageLoader
+    @JvmName("imageLoader") get() = Coil.imageLoader(this)

--- a/coil-singleton/src/main/java/coil/ImageViews.kt
+++ b/coil-singleton/src/main/java/coil/ImageViews.kt
@@ -19,7 +19,7 @@ import java.io.File
 @JvmSynthetic
 inline fun ImageView.load(
     uri: String?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(uri, imageLoader, builder)
 
@@ -27,7 +27,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     url: HttpUrl?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(url, imageLoader, builder)
 
@@ -35,7 +35,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     uri: Uri?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(uri, imageLoader, builder)
 
@@ -43,7 +43,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     file: File?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(file, imageLoader, builder)
 
@@ -51,7 +51,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     @DrawableRes drawableResId: Int,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(drawableResId, imageLoader, builder)
 
@@ -59,7 +59,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     drawable: Drawable?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(drawable, imageLoader, builder)
 
@@ -67,14 +67,14 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.load(
     bitmap: Bitmap?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable = loadAny(bitmap, imageLoader, builder)
 
 /**
  * Load the image referenced by [data] and set it on this [ImageView].
  *
- * This is the type-unsafe version of [ImageView.load].
+ * [ImageView.loadAny] is the type-unsafe version of [ImageView.load].
  *
  * Example:
  * ```
@@ -91,7 +91,7 @@ inline fun ImageView.load(
 @JvmSynthetic
 inline fun ImageView.loadAny(
     data: Any?,
-    imageLoader: ImageLoader = Coil.imageLoader(context),
+    imageLoader: ImageLoader = context.imageLoader,
     builder: ImageRequest.Builder.() -> Unit = {}
 ): Disposable {
     val request = ImageRequest.Builder(context)

--- a/coil-singleton/src/test/java/coil/ImageLoaderFactoryTest.kt
+++ b/coil-singleton/src/test/java/coil/ImageLoaderFactoryTest.kt
@@ -46,11 +46,11 @@ class ImageLoaderFactoryTest {
     fun `application factory is invoked exactly once`() {
         assertFalse((context.applicationContext as TestApplication).isInitialized.get())
 
-        val imageLoader1 = Coil.imageLoader(context)
+        val imageLoader1 = context.imageLoader
 
         assertTrue((context.applicationContext as TestApplication).isInitialized.get())
 
-        val imageLoader2 = Coil.imageLoader(context)
+        val imageLoader2 = context.imageLoader
 
         assertSame(imageLoader1, imageLoader2)
     }
@@ -67,13 +67,13 @@ class ImageLoaderFactoryTest {
 
         assertFalse(isInitialized.get())
 
-        val imageLoader2 = Coil.imageLoader(context)
+        val imageLoader2 = context.imageLoader
 
         assertSame(imageLoader1, imageLoader2)
 
         assertTrue(isInitialized.get())
 
-        val imageLoader3 = Coil.imageLoader(context)
+        val imageLoader3 = context.imageLoader
 
         assertSame(imageLoader1, imageLoader3)
     }
@@ -91,7 +91,7 @@ class ImageLoaderFactoryTest {
             ImageLoader(context)
         }
 
-        Coil.imageLoader(context)
+        context.imageLoader
 
         assertTrue(isInitialized.get())
         assertFalse((context.applicationContext as TestApplication).isInitialized.get())

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -128,10 +128,10 @@ val imageLoader = ImageLoader.Builder(context)
 Coil.setImageLoader(imageLoader)
 ```
 
-The default `ImageLoader` can be retrieved like so:
+The default `ImageLoader` can be retrieved using an extension function on `Context`:
 
 ```kotlin
-val imageLoader = Coil.imageLoader(context)
+val imageLoader = context.imageLoader
 ```
 
 Setting a default `ImageLoader` is optional. If you don't set one, Coil will lazily create an `ImageLoader` with the default values.
@@ -152,12 +152,11 @@ imageView.load("https://www.example.com/image.jpg")
 The above call is equivalent to:
 
 ```kotlin
-val imageLoader = Coil.imageLoader(context)
 val request = ImageRequest.Builder(imageView.context)
     .data("https://www.example.com/image.jpg")
     .target(imageView)
     .build()
-imageLoader.enqueue(request)
+context.imageLoader.enqueue(request)
 ```
 
 `ImageView.load` calls can be configured with an optional trailing lambda parameter:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -152,11 +152,12 @@ imageView.load("https://www.example.com/image.jpg")
 The above call is equivalent to:
 
 ```kotlin
+val imageLoader = context.imageLoader
 val request = ImageRequest.Builder(imageView.context)
     .data("https://www.example.com/image.jpg")
     .target(imageView)
     .build()
-context.imageLoader.enqueue(request)
+imageLoader.enqueue(request)
 ```
 
 `ImageView.load` calls can be configured with an optional trailing lambda parameter:

--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -37,7 +37,7 @@ Coil performs best when you create a single `ImageLoader` and share it throughou
 
 If you use a dependency injector like [Dagger](https://github.com/google/dagger), then you should create a single `ImageLoader` instance and inject it throughout your app.
 
-However, if you'd prefer a singleton the `io.coil-kt:coil` artifact provides a default `ImageLoader` instance that can be accessed with `Coil.imageLoader(context)`. [Read here](../getting_started/#singleton) for how to initialize the singleton `ImageLoader` instance.
+However, if you'd prefer a singleton the `io.coil-kt:coil` artifact provides a default `ImageLoader` instance that can be accessed using the extension function `context.imageLoader`. [Read here](../getting_started/#singleton) for how to initialize the singleton `ImageLoader` instance.
 
 !!! Note
     Use the `io.coil-kt:coil-base` artifact if you are using dependency injection.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -78,7 +78,6 @@ Picasso.get()
     })
 
 // Coil
-val imageLoader = Coil.imageLoader(context)
 val request = ImageRequest.Builder(context)
     .data(url)
     .target(
@@ -93,7 +92,7 @@ val request = ImageRequest.Builder(context)
         }
     )
     .build()
-imageLoader.enqueue(request)
+context.imageLoader.enqueue(request)
 ```
 
 ### Background Thread
@@ -112,10 +111,9 @@ val drawable = Picasso.get()
     .get()
 
 // Coil (suspends the current coroutine; non-blocking and thread safe)
-val imageLoader = Coil.imageLoader(context)
 val request = ImageRequest.Builder(context)
     .data(url)
     .size(width, height)
     .build()
-val drawable = imageLoader.execute(request).drawable
+val drawable = context.imageLoader.execute(request).drawable
 ```


### PR DESCRIPTION
Adds a `context.imageLoader` extension function. Have added this internally and it seems like people prefer it. This makes it so the singleton `ImageLoader` is accessed the same way as `context.layoutInflater`, `context.windowManager`, and other UI-related services.