### PR TITLE
Guard against missing/invalid ActivityManager.

### DIFF
--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -14,15 +14,15 @@ internal object Utils {
 
     private const val CACHE_DIRECTORY_NAME = "image_cache"
 
-    private const val MIN_DISK_CACHE_SIZE = 10L * 1024 * 1024 // 10MB
-    private const val MAX_DISK_CACHE_SIZE = 250L * 1024 * 1024 // 250MB
+    private const val MIN_DISK_CACHE_SIZE_BYTES = 10L * 1024 * 1024 // 10MB
+    private const val MAX_DISK_CACHE_SIZE_BYTES = 250L * 1024 * 1024 // 250MB
 
     private const val DISK_CACHE_PERCENTAGE = 0.02
 
     private const val STANDARD_MULTIPLIER = 0.2
     private const val LOW_MEMORY_MULTIPLIER = 0.15
 
-    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 2 * 1024 // 2GB
+    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 2 * 1024
 
     const val REQUEST_TYPE_ENQUEUE = 0
     const val REQUEST_TYPE_EXECUTE = 1
@@ -44,9 +44,9 @@ internal object Utils {
         return try {
             val cacheDir = StatFs(cacheDirectory.absolutePath)
             val size = DISK_CACHE_PERCENTAGE * cacheDir.blockCountCompat * cacheDir.blockSizeCompat
-            return size.toLong().coerceIn(MIN_DISK_CACHE_SIZE, MAX_DISK_CACHE_SIZE)
+            return size.toLong().coerceIn(MIN_DISK_CACHE_SIZE_BYTES, MAX_DISK_CACHE_SIZE_BYTES)
         } catch (_: Exception) {
-            MIN_DISK_CACHE_SIZE
+            MIN_DISK_CACHE_SIZE_BYTES
         }
     }
 

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -22,7 +22,7 @@ internal object Utils {
     private const val STANDARD_MULTIPLIER = 0.2
     private const val LOW_MEMORY_MULTIPLIER = 0.15
 
-    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 2 * 1024
+    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 256
 
     const val REQUEST_TYPE_ENQUEUE = 0
     const val REQUEST_TYPE_EXECUTE = 1

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -22,7 +22,7 @@ internal object Utils {
     private const val STANDARD_MULTIPLIER = 0.2
     private const val LOW_MEMORY_MULTIPLIER = 0.15
 
-    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 2L * 1024 // 2GB
+    private const val DEFAULT_MEMORY_CLASS_MEGABYTES = 2 * 1024 // 2GB
 
     const val REQUEST_TYPE_ENQUEUE = 0
     const val REQUEST_TYPE_EXECUTE = 1
@@ -52,14 +52,14 @@ internal object Utils {
 
     /** Modified from Picasso. */
     fun calculateAvailableMemorySize(context: Context, percentage: Double): Long {
-        return try {
+        val memoryClassMegabytes = try {
             val activityManager: ActivityManager = context.requireSystemService()
             val isLargeHeap = (context.applicationInfo.flags and ApplicationInfo.FLAG_LARGE_HEAP) != 0
-            val memoryClassMegabytes = if (isLargeHeap) activityManager.largeMemoryClass else activityManager.memoryClass
-            (percentage * memoryClassMegabytes * 1024 * 1024).toLong()
+            if (isLargeHeap) activityManager.largeMemoryClass else activityManager.memoryClass
         } catch (_: Exception) {
             DEFAULT_MEMORY_CLASS_MEGABYTES
         }
+        return (percentage * memoryClassMegabytes * 1024 * 1024).toLong()
     }
 
     fun getDefaultAvailableMemoryPercentage(context: Context): Double {


### PR DESCRIPTION
`getSystemService<ActivityManager>()` throws an exception when used in Android Studio's View/Composable preview mode.

Fixes: #535 and https://github.com/chrisbanes/accompanist/issues/100

cc @chrisbanes