### PR TITLE
Add a recipe for handling remote views

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -203,7 +203,13 @@ detailImageView.load("https://www.example.com/image.jpg") {
 Coil does not provide a `RemoteViewTarget` out of the box. You can easily recreate one though for updating remote views like widgets.
 
 ```kotlin
-class RemoteViewsTarget(private val context: Context, private val componentName: ComponentName, private val remoteViews: RemoteViews, @IdRes val imageViewId: Int) : Target {
+class RemoteViewsTarget(
+    private val context: Context, 
+    private val componentName: ComponentName, 
+    private val remoteViews: RemoteViews, 
+    @IdRes val imageViewId: Int
+) : Target {
+
     override fun onStart(placeholder: Drawable?) {
         setDrawable(placeholder)
     }
@@ -233,7 +239,8 @@ Then just set it as your target when enqueuing.
 val remoteViewTarget = RemoteViewTarget(...)
 val request = ImageRequest.Builder(context)
     .data("https://www.example.com/image.jpg")
-    .target(remoteViewTarget).build()
+    .target(remoteViewTarget)
+    .build()
 
 context.imageLoader.enqueue(request)
 ```


### PR DESCRIPTION
I could not find any documentation on handling remote views. Glide provides an `AppWidgetTarget` for updating widgets that I was looking for the equivalent of.

I thought about making a PR to add this as a target but saw that you are not accepting features at this time so I thought it would be good as a recipe. No problem if this is too niche but I think it could help others running in to the same problem.

Thanks for your work on this library!