### PR TITLE
Updated documentation around ImageLoaderFactory

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -102,11 +102,11 @@ If you are using the `io.coil-kt:coil` artifact, you can set the singleton [`Ima
 class MyApplication : Application(), ImageLoaderFactory {
 
     override fun newImageLoader(): ImageLoader {
-        return ImageLoader.Builder(context)
+        return ImageLoader.Builder(applicationContext)
             .crossfade(true)
             .okHttpClient {
                 OkHttpClient.Builder()
-                    .cache(CoilUtils.createDefaultCache(context))
+                    .cache(CoilUtils.createDefaultCache(applicationContext))
                     .build()
             }
             .build()


### PR DESCRIPTION
The code snippet that demonstrates `ImageLoaderFactory` usage  was referencing a `context` property which is not defined in that scope. Replaced it with the application-scoped `applicationContext`.