### PR TITLE
Align SVG documentation with API

### DIFF
--- a/coil-svg/README.md
+++ b/coil-svg/README.md
@@ -11,7 +11,7 @@ And add the decoder to your component registry when constructing your `ImageLoad
 ```kotlin
 val imageLoader = ImageLoader.Builder(context)
     .componentRegistry {
-        add(SvgDecoder())
+        add(SvgDecoder(context))
     }
     .build()
 ```


### PR DESCRIPTION
The documentation for the `coil-svg`-API suggested that you
should invoke the `SvgDecoder`-constructor without any arguments.
However, the `SvgDecoder`-constructor requires a `Context`. This
PR makes the documentation reflect this fact.