### PR TITLE
Add an empty bitmap pool implementation.

### DIFF
--- a/coil-base/src/main/java/coil/bitmap/BitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/BitmapPool.kt
@@ -18,7 +18,9 @@ interface BitmapPool {
          */
         @JvmStatic
         @JvmName("create")
-        operator fun invoke(maxSize: Int): BitmapPool = RealBitmapPool(maxSize)
+        operator fun invoke(maxSize: Int): BitmapPool {
+            return if (maxSize == 0) EmptyBitmapPool() else RealBitmapPool(maxSize)
+        }
     }
 
     /**

--- a/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
@@ -1,0 +1,31 @@
+package coil.bitmap
+
+import android.graphics.Bitmap
+import androidx.core.graphics.createBitmap
+import coil.util.isHardware
+
+/**
+ * A lock-free [BitmapPool] implementation that stores nothing and
+ * immediately recycles any [Bitmap]s that are added to the pool.
+ */
+internal class EmptyBitmapPool : BitmapPool {
+
+    override fun put(bitmap: Bitmap) {
+        bitmap.recycle()
+    }
+
+    override fun get(width: Int, height: Int, config: Bitmap.Config): Bitmap {
+        require(!config.isHardware) { "Cannot create a mutable hardware bitmap." }
+        return createBitmap(width, height, config)
+    }
+
+    override fun getOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
+
+    override fun getDirty(width: Int, height: Int, config: Bitmap.Config): Bitmap = get(width, height, config)
+
+    override fun getDirtyOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
+
+    override fun trimMemory(level: Int) {}
+
+    override fun clear() {}
+}

--- a/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
@@ -2,26 +2,19 @@ package coil.bitmap
 
 import android.graphics.Bitmap
 import androidx.core.graphics.createBitmap
-import coil.util.isHardware
 
-/**
- * A lock-free [BitmapPool] implementation that stores nothing and
- * immediately recycles any [Bitmap]s that are added to the pool.
- */
+/** A lock-free [BitmapPool] implementation that recycles any [Bitmap]s that are added to it. */
 internal class EmptyBitmapPool : BitmapPool {
 
     override fun put(bitmap: Bitmap) {
         bitmap.recycle()
     }
 
-    override fun get(width: Int, height: Int, config: Bitmap.Config): Bitmap {
-        require(!config.isHardware) { "Cannot create a mutable hardware bitmap." }
-        return createBitmap(width, height, config)
-    }
+    override fun get(width: Int, height: Int, config: Bitmap.Config) = createBitmap(width, height, config)
 
     override fun getOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
 
-    override fun getDirty(width: Int, height: Int, config: Bitmap.Config): Bitmap = get(width, height, config)
+    override fun getDirty(width: Int, height: Int, config: Bitmap.Config) = createBitmap(width, height, config)
 
     override fun getDirtyOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
 

--- a/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/EmptyBitmapPool.kt
@@ -2,6 +2,7 @@ package coil.bitmap
 
 import android.graphics.Bitmap
 import androidx.core.graphics.createBitmap
+import coil.util.isHardware
 
 /** A lock-free [BitmapPool] implementation that recycles any [Bitmap]s that are added to it. */
 internal class EmptyBitmapPool : BitmapPool {
@@ -10,15 +11,25 @@ internal class EmptyBitmapPool : BitmapPool {
         bitmap.recycle()
     }
 
-    override fun get(width: Int, height: Int, config: Bitmap.Config) = createBitmap(width, height, config)
+    override fun get(width: Int, height: Int, config: Bitmap.Config) = getDirty(width, height, config)
 
-    override fun getOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
+    override fun getOrNull(width: Int, height: Int, config: Bitmap.Config) = getDirtyOrNull(width, height, config)
 
-    override fun getDirty(width: Int, height: Int, config: Bitmap.Config) = createBitmap(width, height, config)
+    override fun getDirty(width: Int, height: Int, config: Bitmap.Config): Bitmap {
+        assertNotHardware(config)
+        return createBitmap(width, height, config)
+    }
 
-    override fun getDirtyOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? = null
+    override fun getDirtyOrNull(width: Int, height: Int, config: Bitmap.Config): Bitmap? {
+        assertNotHardware(config)
+        return null
+    }
 
     override fun trimMemory(level: Int) {}
 
     override fun clear() {}
+
+    private fun assertNotHardware(config: Bitmap.Config) {
+        require(!config.isHardware) { "Cannot create a mutable hardware bitmap." }
+    }
 }

--- a/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
@@ -92,25 +92,24 @@ internal class RealBitmapPool(
         return getDirtyOrNull(width, height, config) ?: createBitmap(width, height, config)
     }
 
+    @Synchronized
     override fun getDirtyOrNull(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {
         require(!config.isHardware) { "Cannot create a mutable hardware bitmap." }
 
-        synchronized(this) {
-            val result = strategy.get(width, height, config)
-            if (result == null) {
-                logger?.log(TAG, Log.VERBOSE) { "Missing bitmap=${strategy.stringify(width, height, config)}" }
-                misses++
-            } else {
-                bitmaps -= result
-                currentSize -= result.allocationByteCountCompat
-                hits++
-                normalize(result)
-            }
-
-            logger?.log(TAG, Log.VERBOSE) { "Get bitmap=${strategy.stringify(width, height, config)}\n${logStats()}" }
-
-            return result
+        val result = strategy.get(width, height, config)
+        if (result == null) {
+            logger?.log(TAG, Log.VERBOSE) { "Missing bitmap=${strategy.stringify(width, height, config)}" }
+            misses++
+        } else {
+            bitmaps -= result
+            currentSize -= result.allocationByteCountCompat
+            hits++
+            normalize(result)
         }
+
+        logger?.log(TAG, Log.VERBOSE) { "Get bitmap=${strategy.stringify(width, height, config)}\n${logStats()}" }
+
+        return result
     }
 
     override fun clear() = clearMemory()

--- a/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
+++ b/coil-base/src/main/java/coil/bitmap/RealBitmapPool.kt
@@ -93,10 +93,8 @@ internal class RealBitmapPool(
     }
 
     override fun getDirtyOrNull(@Px width: Int, @Px height: Int, config: Bitmap.Config): Bitmap? {
-        // Short circuit as the pool does not keep hardware bitmaps.
-        if (config.isHardware) return null
+        require(!config.isHardware) { "Cannot create a mutable hardware bitmap." }
 
-        // Check the strategy and update our metadata.
         synchronized(this) {
             val result = strategy.get(width, height, config)
             if (result == null) {

--- a/coil-base/src/test/java/coil/bitmap/RealBitmapPoolTest.kt
+++ b/coil-base/src/test/java/coil/bitmap/RealBitmapPoolTest.kt
@@ -7,13 +7,16 @@ import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
 import coil.util.DEFAULT_BITMAP_SIZE
 import coil.util.createBitmap
+import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
@@ -150,6 +153,17 @@ class RealBitmapPoolTest {
         pool.put(bitmap)
 
         assertEquals(1, strategy.numPuts)
+    }
+
+    @Test
+    fun `hardware bitmaps are not kept`() {
+        assumeTrue(SDK_INT >= 26)
+
+        val bitmap = createBitmap(config = Bitmap.Config.HARDWARE)
+
+        pool.put(bitmap)
+
+        assertNull(pool.getOrNull(bitmap.width, bitmap.height, bitmap.config))
     }
 
     private fun RealBitmapPool.fill(fillCount: Int) {

--- a/coil-base/src/test/java/coil/util/TestFunctions.kt
+++ b/coil-base/src/test/java/coil/util/TestFunctions.kt
@@ -3,6 +3,7 @@
 package coil.util
 
 import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
 import android.os.Looper
 import androidx.core.graphics.createBitmap
 import org.robolectric.Shadows
@@ -13,7 +14,7 @@ fun createBitmap(
     width: Int = 100,
     height: Int = 100,
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
-    isMutable: Boolean = config != Bitmap.Config.HARDWARE
+    isMutable: Boolean = SDK_INT < 26 || config != Bitmap.Config.HARDWARE
 ): Bitmap {
     val bitmap = createBitmap(width, height, config)
     Shadows.shadowOf(bitmap).setMutable(isMutable)

--- a/coil-base/src/test/java/coil/util/TestFunctions.kt
+++ b/coil-base/src/test/java/coil/util/TestFunctions.kt
@@ -13,7 +13,7 @@ fun createBitmap(
     width: Int = 100,
     height: Int = 100,
     config: Bitmap.Config = Bitmap.Config.ARGB_8888,
-    isMutable: Boolean = true
+    isMutable: Boolean = config != Bitmap.Config.HARDWARE
 ): Bitmap {
     val bitmap = createBitmap(width, height, config)
     Shadows.shadowOf(bitmap).setMutable(isMutable)

--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -23,6 +23,7 @@ public final class coil/decode/ImageDecoderDecoder$Companion {
 public final class coil/drawable/MovieDrawable : android/graphics/drawable/Drawable, androidx/vectordrawable/graphics/drawable/Animatable2Compat {
 	public static final field Companion Lcoil/drawable/MovieDrawable$Companion;
 	public static final field REPEAT_INFINITE I
+	public fun <init> (Landroid/graphics/Movie;)V
 	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;)V
 	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap$Config;)V
 	public fun <init> (Landroid/graphics/Movie;Lcoil/bitmap/BitmapPool;Landroid/graphics/Bitmap$Config;Lcoil/size/Scale;)V

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -29,7 +29,7 @@ import coil.size.Scale
  */
 class MovieDrawable @JvmOverloads constructor(
     private val movie: Movie,
-    private val pool: BitmapPool,
+    private val pool: BitmapPool = BitmapPool(0),
     val config: Bitmap.Config = Bitmap.Config.ARGB_8888,
     val scale: Scale = Scale.FIT
 ) : Drawable(), Animatable2Compat {


### PR DESCRIPTION
Adds an empty bitmap pool implementation. This should be slightly more efficient on API 24 and up or if `bitmapPoolPercentage` is set to 0 since it avoids locking + all of the pool management code in `RealBitmapPool`.