### PR TITLE
Stabilize EventListener.

### DIFF
--- a/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
+++ b/coil-base/src/androidTest/java/coil/util/SystemCallbacksTest.kt
@@ -10,7 +10,6 @@ import coil.ComponentRegistry
 import coil.EventListener
 import coil.ImageLoader
 import coil.RealImageLoader
-import coil.annotation.ExperimentalCoilApi
 import coil.bitmap.BitmapPool
 import coil.bitmap.RealBitmapReferenceCounter
 import coil.memory.MemoryCache
@@ -22,7 +21,6 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoilApi::class)
 class SystemCallbacksTest {
 
     private lateinit var context: Context

--- a/coil-base/src/main/java/coil/EventListener.kt
+++ b/coil-base/src/main/java/coil/EventListener.kt
@@ -5,7 +5,6 @@ import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
 import coil.EventListener.Factory
-import coil.annotation.ExperimentalCoilApi
 import coil.decode.DecodeResult
 import coil.decode.Decoder
 import coil.decode.Options
@@ -27,7 +26,6 @@ import coil.transition.TransitionTarget
  *
  * @see ImageLoader.Builder.eventListener
  */
-@ExperimentalCoilApi
 interface EventListener : ImageRequest.Listener {
 
     /**

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -313,7 +313,6 @@ interface ImageLoader {
         /**
          * Set a single [EventListener] that will receive all callbacks for requests launched by this image loader.
          */
-        @ExperimentalCoilApi
         fun eventListener(listener: EventListener) = eventListener(EventListener.Factory(listener))
 
         /**
@@ -321,7 +320,6 @@ interface ImageLoader {
          *
          * @see eventListener
          */
-        @ExperimentalCoilApi
         fun eventListener(factory: EventListener.Factory) = apply {
             this.eventListenerFactory = factory
         }

--- a/coil-base/src/main/java/coil/memory/DelegateService.kt
+++ b/coil-base/src/main/java/coil/memory/DelegateService.kt
@@ -5,7 +5,6 @@ import androidx.annotation.MainThread
 import androidx.lifecycle.LifecycleObserver
 import coil.EventListener
 import coil.ImageLoader
-import coil.annotation.ExperimentalCoilApi
 import coil.bitmap.BitmapReferenceCounter
 import coil.request.ImageRequest
 import coil.target.PoolableViewTarget
@@ -19,7 +18,6 @@ import coil.util.requestManager
 import kotlinx.coroutines.Job
 
 /** [DelegateService] wraps [Target]s to support [Bitmap] pooling and [ImageRequest]s to manage their lifecycle. */
-@OptIn(ExperimentalCoilApi::class)
 internal class DelegateService(
     private val imageLoader: ImageLoader,
     private val referenceCounter: BitmapReferenceCounter,


### PR DESCRIPTION
The existing methods for this interface are unlikely to change going forward.