### PR TITLE
Support preferring exact intrinsic size in CrossfadeDrawable.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -231,7 +231,8 @@ public final class coil/drawable/CrossfadeDrawable : android/graphics/drawable/D
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;I)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZ)V
-	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZZ)V
+	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearAnimationCallbacks ()V
 	public fun draw (Landroid/graphics/Canvas;)V
 	public fun getAlpha ()I
@@ -241,6 +242,7 @@ public final class coil/drawable/CrossfadeDrawable : android/graphics/drawable/D
 	public fun getIntrinsicHeight ()I
 	public fun getIntrinsicWidth ()I
 	public fun getOpacity ()I
+	public final fun getPreferExactIntrinsicSize ()Z
 	public final fun getScale ()Lcoil/size/Scale;
 	public fun invalidateDrawable (Landroid/graphics/drawable/Drawable;)V
 	public fun isRunning ()Z
@@ -832,9 +834,11 @@ public abstract interface class coil/transform/Transformation {
 public final class coil/transition/CrossfadeTransition : coil/transition/Transition {
 	public fun <init> ()V
 	public fun <init> (I)V
-	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IZ)V
+	public synthetic fun <init> (IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDurationMillis ()I
+	public final fun getPreferExactIntrinsicSize ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun transition (Lcoil/transition/TransitionTarget;Lcoil/request/ImageResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -231,6 +231,7 @@ public final class coil/drawable/CrossfadeDrawable : android/graphics/drawable/D
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;I)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZ)V
+	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZZ)V
 	public synthetic fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lcoil/size/Scale;IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clearAnimationCallbacks ()V
@@ -834,6 +835,7 @@ public abstract interface class coil/transform/Transformation {
 public final class coil/transition/CrossfadeTransition : coil/transition/Transition {
 	public fun <init> ()V
 	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (IZ)V
 	public synthetic fun <init> (IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NEWER_VERSION_IN_SINCE_KOTLIN", "unused")
+
 package coil.drawable
 
 import android.content.res.ColorStateList
@@ -34,7 +36,7 @@ import kotlin.math.roundToInt
  *  [start] **or** [end] return -1 for that dimension. This is useful for views that require an exact intrinsic
  *  size to scale the drawable.
  */
-class CrossfadeDrawable @JvmOverloads constructor(
+class CrossfadeDrawable(
     start: Drawable?,
     end: Drawable?,
     val scale: Scale = Scale.FIT,
@@ -278,4 +280,24 @@ class CrossfadeDrawable @JvmOverloads constructor(
 
         const val DEFAULT_DURATION = 100
     }
+
+    // region - Kept for binary compatibility. Only visible from Java.
+
+    @SinceKotlin("999.9")
+    constructor(start: Drawable?, end: Drawable?) :
+        this(start, end, Scale.FIT, DEFAULT_DURATION, true, false)
+
+    @SinceKotlin("999.9")
+    constructor(start: Drawable?, end: Drawable?, scale: Scale) :
+        this(start, end, scale, DEFAULT_DURATION, true, false)
+
+    @SinceKotlin("999.9")
+    constructor(start: Drawable?, end: Drawable?, scale: Scale, durationMillis: Int) :
+        this(start, end, scale, durationMillis, true, false)
+
+    @SinceKotlin("999.9")
+    constructor(start: Drawable?, end: Drawable?, scale: Scale = Scale.FIT, durationMillis: Int = DEFAULT_DURATION, fadeStart: Boolean = true) :
+        this(start, end, scale, durationMillis, fadeStart, false)
+
+    // endregion
 }

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -281,7 +281,7 @@ class CrossfadeDrawable(
         const val DEFAULT_DURATION = 100
     }
 
-    // region - Kept for binary compatibility. Only visible from Java.
+    // region - Simulates `@JvmOverloads` for Java callers. Kept for binary compatibility.
 
     @SinceKotlin("999.9")
     constructor(start: Drawable?, end: Drawable?) :

--- a/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
+++ b/coil-base/src/main/java/coil/drawable/CrossfadeDrawable.kt
@@ -29,13 +29,18 @@ import kotlin.math.roundToInt
  * @param scale The scaling algorithm for [start] and [end].
  * @param durationMillis The duration of the crossfade animation.
  * @param fadeStart If false, the start drawable will not fade out while the end drawable fades in.
+ * @param preferExactIntrinsicSize If true, this drawable's intrinsic width/height will only be -1 if
+ *  [start] **and** [end] return -1 for that dimension. If false, the intrinsic width/height will be -1 if
+ *  [start] **or** [end] return -1 for that dimension. This is useful for views that require an exact intrinsic
+ *  size to scale the drawable.
  */
 class CrossfadeDrawable @JvmOverloads constructor(
     start: Drawable?,
     end: Drawable?,
     val scale: Scale = Scale.FIT,
     val durationMillis: Int = DEFAULT_DURATION,
-    val fadeStart: Boolean = true
+    val fadeStart: Boolean = true,
+    val preferExactIntrinsicSize: Boolean = false
 ) : Drawable(), Drawable.Callback, Animatable2Compat {
 
     private val callbacks = mutableListOf<Animatable2Compat.AnimationCallback>()
@@ -253,7 +258,11 @@ class CrossfadeDrawable @JvmOverloads constructor(
     }
 
     private fun computeIntrinsicDimension(startSize: Int?, endSize: Int?): Int {
-        return if (startSize == -1 || endSize == -1) -1 else max(startSize ?: -1, endSize ?: -1)
+        return if (!preferExactIntrinsicSize && (startSize == -1 || endSize == -1)) {
+            -1
+        } else {
+            max(startSize ?: -1, endSize ?: -1)
+        }
     }
 
     private fun markDone() {

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -15,10 +15,16 @@ import coil.util.scale
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
-/** A [Transition] that crossfades from the current drawable to a new one. */
+/**
+ * A [Transition] that crossfades from the current drawable to a new one.
+ *
+ * @param durationMillis The duration of the animation in milliseconds.
+ * @param preferExactIntrinsicSize See [CrossfadeDrawable.preferExactIntrinsicSize].
+ */
 @ExperimentalCoilApi
 class CrossfadeTransition @JvmOverloads constructor(
-    val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION
+    val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION,
+    val preferExactIntrinsicSize: Boolean = false
 ) : Transition {
 
     init {
@@ -51,7 +57,8 @@ class CrossfadeTransition @JvmOverloads constructor(
                     end = result.drawable,
                     scale = (target.view as? ImageView)?.scale ?: Scale.FILL,
                     durationMillis = durationMillis,
-                    fadeStart = result !is SuccessResult || !result.metadata.isPlaceholderMemoryCacheKeyPresent
+                    fadeStart = result !is SuccessResult || !result.metadata.isPlaceholderMemoryCacheKeyPresent,
+                    preferExactIntrinsicSize = preferExactIntrinsicSize
                 )
                 outerCrossfade = crossfade
                 crossfade.registerAnimationCallback(object : Animatable2Compat.AnimationCallback() {

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -1,3 +1,5 @@
+@file:Suppress("NEWER_VERSION_IN_SINCE_KOTLIN", "unused")
+
 package coil.transition
 
 import android.graphics.drawable.Drawable
@@ -22,7 +24,7 @@ import kotlin.coroutines.resume
  * @param preferExactIntrinsicSize See [CrossfadeDrawable.preferExactIntrinsicSize].
  */
 @ExperimentalCoilApi
-class CrossfadeTransition @JvmOverloads constructor(
+class CrossfadeTransition(
     val durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION,
     val preferExactIntrinsicSize: Boolean = false
 ) : Transition {
@@ -86,4 +88,14 @@ class CrossfadeTransition @JvmOverloads constructor(
     override fun hashCode() = durationMillis.hashCode()
 
     override fun toString() = "CrossfadeTransition(durationMillis=$durationMillis)"
+
+    // region - Kept for binary compatibility. Only visible from Java.
+
+    @SinceKotlin("999.9")
+    constructor() : this(CrossfadeDrawable.DEFAULT_DURATION, false)
+
+    @SinceKotlin("999.9")
+    constructor(durationMillis: Int = CrossfadeDrawable.DEFAULT_DURATION) : this(durationMillis, false)
+
+    // endregion
 }

--- a/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
+++ b/coil-base/src/main/java/coil/transition/CrossfadeTransition.kt
@@ -89,7 +89,7 @@ class CrossfadeTransition(
 
     override fun toString() = "CrossfadeTransition(durationMillis=$durationMillis)"
 
-    // region - Kept for binary compatibility. Only visible from Java.
+    // region - Simulates `@JvmOverloads` for Java callers. Kept for binary compatibility.
 
     @SinceKotlin("999.9")
     constructor() : this(CrossfadeDrawable.DEFAULT_DURATION, false)

--- a/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
+++ b/coil-base/src/test/java/coil/drawable/CrossfadeDrawableTest.kt
@@ -8,6 +8,7 @@ import android.graphics.drawable.ColorDrawable
 import androidx.test.core.app.ApplicationProvider
 import coil.size.Scale
 import coil.util.createBitmap
+import coil.util.toDrawable
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -185,6 +186,48 @@ class CrossfadeDrawableTest {
         crossfadeDrawable.draw(Canvas())
 
         assertEquals(0, endDrawable.alpha)
+    }
+
+    @Test
+    fun `preferExactIntrinsicSize=false`() {
+        val drawable1 = CrossfadeDrawable(
+            start = ColorDrawable(),
+            end = createBitmap().toDrawable(context),
+            preferExactIntrinsicSize = false
+        )
+
+        assertEquals(-1, drawable1.intrinsicWidth)
+        assertEquals(-1, drawable1.intrinsicHeight)
+
+        val drawable2 = CrossfadeDrawable(
+            start = null,
+            end = createBitmap().toDrawable(context),
+            preferExactIntrinsicSize = false
+        )
+
+        assertEquals(100, drawable2.intrinsicWidth)
+        assertEquals(100, drawable2.intrinsicHeight)
+    }
+
+    @Test
+    fun `preferExactIntrinsicSize=true`() {
+        val drawable1 = CrossfadeDrawable(
+            start = ColorDrawable(),
+            end = createBitmap().toDrawable(context),
+            preferExactIntrinsicSize = true
+        )
+
+        assertEquals(100, drawable1.intrinsicWidth)
+        assertEquals(100, drawable1.intrinsicHeight)
+
+        val drawable2 = CrossfadeDrawable(
+            start = null,
+            end = createBitmap().toDrawable(context),
+            preferExactIntrinsicSize = true
+        )
+
+        assertEquals(100, drawable2.intrinsicWidth)
+        assertEquals(100, drawable2.intrinsicHeight)
     }
 
     private class TestDrawable(


### PR DESCRIPTION
Fixes: #223 
Fixes: #230 

By default, `CrossfadeDrawable`'s intrinsic size is -1 if **either** of its child drawables have a -1 intrinsic size. This PR adds an option so its intrinsic size will only be -1 if **both** of its child drawables have an intrinsic size of -1.

This allows a user to use crossfade with `PhotoView` and `CircleImageView` since they both require an exact (>0) intrinsic size.