### PR TITLE
Change CENTER and MATRIX scale types to resolve to OriginalSize.

### DIFF
--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -863,7 +863,7 @@ class ImageRequest private constructor(
 
         private fun resolveSizeResolver(): SizeResolver {
             val target = target
-            return if (target is ImageViewTarget && target.view.scaleType.let { it == MATRIX || it == CENTER }) {
+            return if (target is ImageViewTarget && target.view.scaleType.let { it == CENTER || it == MATRIX }) {
                 SizeResolver(OriginalSize)
             } else if (target is ViewTarget<*>) {
                 ViewSizeResolver(target.view)

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -10,6 +10,8 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
 import android.widget.ImageView
+import android.widget.ImageView.ScaleType.CENTER
+import android.widget.ImageView.ScaleType.MATRIX
 import androidx.annotation.DrawableRes
 import androidx.annotation.MainThread
 import androidx.annotation.Px
@@ -861,7 +863,13 @@ class ImageRequest private constructor(
 
         private fun resolveSizeResolver(): SizeResolver {
             val target = target
-            return if (target is ViewTarget<*>) ViewSizeResolver(target.view) else DisplaySizeResolver(context)
+            return if (target is ImageViewTarget && target.view.scaleType.let { it == MATRIX || it == CENTER }) {
+                SizeResolver(OriginalSize)
+            } else if (target is ViewTarget<*>) {
+                ViewSizeResolver(target.view)
+            } else {
+                DisplaySizeResolver(context)
+            }
         }
 
         private fun resolveScale(): Scale {


### PR DESCRIPTION
Fixes #545 

This changes the default behaviour for the `CENTER` and `MATRIX` scale types to [better match](https://thoughtbot.com/blog/android-imageview-scaletype-a-visual-guide) `ImageView.setImageDrawable`. Before, the image would be scaled to fit in the `ImageView`'s bounds. Now we default to `OriginalSize` for those scale types.

NOTE: This only changes the default behaviour. Explicitly setting the size is not affected by this change.