### PR TITLE
Update documentation for fakeImageLoader

### DIFF
--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -77,7 +77,7 @@ val fakeImageLoader = object : ImageLoader {
         return SuccessResult(
             drawable = drawable,
             request = request,
-            metadata = Metadata(
+            metadata = ImageResult.Metadata(
                 memoryCacheKey = MemoryCache.Key(""),
                 isSampled = false,
                 dataSource = DataSource.MEMORY_CACHE,


### PR DESCRIPTION
Use ImageResult.Metadata instead of just Metadata.