### PR TITLE
Centralize AGP and Kotlin plugin Strings.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import java.net.URL
 
 buildscript {
+    apply(from = "buildSrc/extra.gradle.kts")
     repositories {
         google()
         mavenCentral()
@@ -18,12 +19,12 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:4.1.1")
+        classpath(rootProject.extra.get("androidGradlePlugin").toString())
+        classpath(rootProject.extra.get("kotlinPlugin").toString())
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")
         classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.3.0")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
-        classpath(kotlin("gradle-plugin", version = "1.4.21"))
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,15 +1,14 @@
-
 import coil.by
 import coil.groupId
 import coil.versionName
 import com.android.build.gradle.BaseExtension
-import java.net.URL
 import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
+import java.net.URL
 
 buildscript {
     apply(from = "buildSrc/extra.gradle.kts")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath(rootProject.extra.get("androidGradlePlugin").toString())
+        classpath(rootProject.extra.get("androidPlugin").toString())
         classpath(rootProject.extra.get("kotlinPlugin").toString())
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,15 @@
+
 import coil.by
 import coil.groupId
 import coil.versionName
 import com.android.build.gradle.BaseExtension
+import java.net.URL
 import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
-import java.net.URL
 
 buildscript {
     apply(from = "buildSrc/extra.gradle.kts")
@@ -19,8 +20,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath(rootProject.extra.get("androidPlugin").toString())
-        classpath(rootProject.extra.get("kotlinPlugin").toString())
+        classpath(rootProject.extra["androidPlugin"].toString())
+        classpath(rootProject.extra["kotlinPlugin"].toString())
         classpath("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")
         classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.3.0")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,12 +4,15 @@ plugins {
 
 repositories {
     google()
+    mavenCentral()
     jcenter()
 }
 
+apply(from = "extra.gradle.kts")
+
 dependencies {
-    implementation("com.android.tools.build:gradle:4.1.1")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21")
+    implementation(rootProject.extra.get("androidGradlePlugin").toString())
+    implementation(rootProject.extra.get("kotlinPlugin").toString())
 }
 
 kotlinDslPluginOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,8 +11,8 @@ repositories {
 apply(from = "extra.gradle.kts")
 
 dependencies {
-    implementation(rootProject.extra.get("androidPlugin").toString())
-    implementation(rootProject.extra.get("kotlinPlugin").toString())
+    implementation(rootProject.extra["androidPlugin"].toString())
+    implementation(rootProject.extra["kotlinPlugin"].toString())
 }
 
 kotlinDslPluginOptions {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 apply(from = "extra.gradle.kts")
 
 dependencies {
-    implementation(rootProject.extra.get("androidGradlePlugin").toString())
+    implementation(rootProject.extra.get("androidPlugin").toString())
     implementation(rootProject.extra.get("kotlinPlugin").toString())
 }
 

--- a/buildSrc/extra.gradle.kts
+++ b/buildSrc/extra.gradle.kts
@@ -1,4 +1,4 @@
 rootProject.extra.apply {
-    set("androidGradlePlugin", "com.android.tools.build:gradle:4.1.1")
+    set("androidPlugin", "com.android.tools.build:gradle:4.1.1")
     set("kotlinPlugin", "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21")
 }

--- a/buildSrc/extra.gradle.kts
+++ b/buildSrc/extra.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.extra.apply {
+    set("androidGradlePlugin", "com.android.tools.build:gradle:4.1.1")
+    set("kotlinPlugin", "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21")
+}


### PR DESCRIPTION
Re-adds code from #622 to centralize AGP and Kotlin plugin Strings.