### PR TITLE
Delete compileOptions config in root build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,15 +115,3 @@ allprojects {
         }
     }
 }
-
-subprojects {
-    afterEvaluate {
-        extensions.configure<BaseExtension> {
-            // Require that all Android projects target Java 8.
-            compileOptions {
-                sourceCompatibility = JavaVersion.VERSION_1_8
-                targetCompatibility = JavaVersion.VERSION_1_8
-            }
-        }
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 import coil.by
 import coil.groupId
 import coil.versionName
-import com.android.build.gradle.BaseExtension
 import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent


### PR DESCRIPTION
`compileOptions` in root `build.gradle.kts` could be deleted because it has been integrated into `setupBaseModule` function.