### PR TITLE
Add gradle-versions-plugin for update checking

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,8 @@
 import coil.by
 import coil.groupId
+import coil.isStableVersion
 import coil.versionName
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
@@ -24,10 +26,12 @@ buildscript {
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")
         classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
+        classpath("com.github.ben-manes:gradle-versions-plugin:0.36.0")
     }
 }
 
 apply(plugin = "binary-compatibility-validator")
+apply(plugin = "com.github.ben-manes.versions")
 
 extensions.configure<ApiValidationExtension> {
     ignoredProjects = mutableSetOf("coil-sample", "coil-test")
@@ -48,6 +52,12 @@ allprojects {
     extensions.configure<KtlintExtension>("ktlint") {
         version by "0.40.0"
         disabledRules by setOf("indent", "max-line-length")
+    }
+
+    tasks.withType<DependencyUpdatesTask> {
+        rejectVersionIf {
+            candidate.version.isStableVersion().not()
+        }
     }
 
     tasks.withType<KotlinCompile>().configureEach {

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -14,6 +14,7 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.kotlin
 import org.gradle.kotlin.dsl.project
+import java.util.Locale
 import kotlin.math.pow
 
 val Project.minSdk: Int
@@ -141,6 +142,11 @@ fun Project.setupAppModule(block: BaseAppModuleExtension.() -> Unit = {}): BaseA
         }
         block()
     }
+}
+
+fun String.isStableVersion(): Boolean {
+    val stableKeyword = listOf("RELEASE", "FINAL", "GA").any { toUpperCase(Locale.ROOT).contains(it) }
+    return stableKeyword || Regex("^[0-9,.v-]+(-r)?$").matches(this)
 }
 
 inline infix fun <T> Property<T>.by(value: T) = set(value)


### PR DESCRIPTION
- Add a plugin named [gradle-versions-plugin](https://github.com/ben-manes/gradle-versions-plugin) to check dependency updates.
- Rules by `isStableVersion` to limit check stable versions only