### PR TITLE
Enable the JVM IR backend.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,14 +52,16 @@ allprojects {
 
     tasks.withType<KotlinCompile>().configureEach {
         kotlinOptions {
+            jvmTarget = "1.8"
             allWarningsAsErrors = true
+            useIR = true
+
             val arguments = mutableListOf("-progressive", "-Xopt-in=kotlin.RequiresOptIn")
             if (project.name != "coil-test") {
                 arguments += "-Xopt-in=coil.annotation.ExperimentalCoilApi"
                 arguments += "-Xopt-in=coil.annotation.InternalCoilApi"
             }
             freeCompilerArgs = arguments
-            jvmTarget = "1.8"
         }
     }
 

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -347,6 +347,22 @@ public final class coil/memory/MemoryCache$Key$Companion {
 	public final fun create (Ljava/lang/String;)Lcoil/memory/MemoryCache$Key;
 }
 
+public final class coil/memory/MemoryCache$Key$Complex$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcoil/memory/MemoryCache$Key$Complex;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcoil/memory/MemoryCache$Key$Complex;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class coil/memory/MemoryCache$Key$Simple$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcoil/memory/MemoryCache$Key$Simple;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcoil/memory/MemoryCache$Key$Simple;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class coil/network/HttpException : java/lang/RuntimeException {
 	public fun <init> (Lokhttp3/Response;)V
 	public final fun getResponse ()Lokhttp3/Response;
@@ -660,7 +676,7 @@ public final class coil/size/OriginalSize : coil/size/Size {
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class coil/size/OriginalSize$Creator : android/os/Parcelable$Creator {
+public final class coil/size/OriginalSize$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcoil/size/OriginalSize;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
@@ -684,7 +700,7 @@ public final class coil/size/PixelSize : coil/size/Size {
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public class coil/size/PixelSize$Creator : android/os/Parcelable$Creator {
+public final class coil/size/PixelSize$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcoil/size/PixelSize;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -336,7 +336,7 @@ internal class EngineInterceptor(
 
     /** Apply any [Transformation]s and return an updated [DrawableResult]. */
     @VisibleForTesting
-    internal suspend inline fun applyTransformations(
+    suspend inline fun applyTransformations(
         result: DrawableResult,
         request: ImageRequest,
         size: Size,

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -4,6 +4,7 @@ public abstract class coil/fetch/VideoFrameFetcher : coil/fetch/Fetcher {
 	public static final field VIDEO_FRAME_OPTION_KEY Ljava/lang/String;
 	public fun <init> (Landroid/content/Context;)V
 	public fun fetch (Lcoil/bitmap/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun fetch$suspendImpl (Lcoil/fetch/VideoFrameFetcher;Lcoil/bitmap/BitmapPool;Ljava/lang/Object;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Ljava/lang/Object;)Z
 	protected abstract fun setDataSource (Landroid/media/MediaMetadataRetriever;Ljava/lang/Object;)V
 }


### PR DESCRIPTION
https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together/

Blocked by: https://youtrack.jetbrains.com/issue/KT-44993 (or a similar `inline` bug). **This bug is fixed in Kotlin `1.5.0`.**