### PR TITLE
Use the view bounds as the intrinsic size of an SVG in SvgDecoder.

### DIFF
--- a/coil-svg/api/coil-svg.api
+++ b/coil-svg/api/coil-svg.api
@@ -1,5 +1,7 @@
 public final class coil/decode/SvgDecoder : coil/decode/Decoder {
 	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Z)V
+	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
 }

--- a/coil-svg/src/androidTest/assets/coil_logo.svg
+++ b/coil-svg/src/androidTest/assets/coil_logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="200px"
-    height="200px" viewBox="332.5 200 140 140" xml:space="preserve">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="1000px"
+    height="250px" viewBox="332.5 200 140 140" xml:space="preserve">
 <g>
 	<g>
 		<path fill="#45DFF4" d="M392.728,303.382l-32.384-24.241l-3.243,2.431c-5.523,4.131-5.523,10.837,0,14.97l35.627,26.672

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -3,17 +3,16 @@
 package coil.decode
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
-import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.drawable.toDrawable
 import coil.bitmap.BitmapPool
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size
 import coil.util.indexOf
+import coil.util.toSoftware
 import com.caverock.androidsvg.SVG
 import okio.BufferedSource
 import okio.ByteString.Companion.encodeUtf8
@@ -23,12 +22,12 @@ import okio.buffer
  * A [Decoder] that uses [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) to decode SVG files.
  *
  * @param context A [Context] used to create the [Drawable].
- * @param useViewBoundsAsSize If true, uses the SVG's view bounds as the intrinsic size for the SVG.
+ * @param useViewBoundsAsIntrinsicSize If true, uses the SVG's view bounds as the intrinsic size for the SVG.
  *  If false, uses the SVG's width/height as the intrinsic size for the SVG.
  */
 class SvgDecoder @JvmOverloads constructor(
     private val context: Context,
-    private val useViewBoundsAsSize: Boolean = true
+    private val useViewBoundsAsIntrinsicSize: Boolean = true
 ) : Decoder {
 
     override fun handles(source: BufferedSource, mimeType: String?): Boolean {
@@ -50,19 +49,19 @@ class SvgDecoder @JvmOverloads constructor(
 
         val svgWidth: Float
         val svgHeight: Float
-        val viewBox: RectF? = svg.documentViewBox
-        if (useViewBoundsAsSize && viewBox != null) {
-            svgWidth = viewBox.width()
-            svgHeight = viewBox.height()
-        } else {
-            svgWidth = svg.documentWidth
-            svgHeight = svg.documentHeight
-        }
-
         val bitmapWidth: Int
         val bitmapHeight: Int
+        val viewBox: RectF? = svg.documentViewBox
         when (size) {
             is PixelSize -> {
+                if (useViewBoundsAsIntrinsicSize && viewBox != null) {
+                    svgWidth = viewBox.width()
+                    svgHeight = viewBox.height()
+                } else {
+                    svgWidth = svg.documentWidth
+                    svgHeight = svg.documentHeight
+                }
+
                 if (svgWidth > 0 && svgHeight > 0) {
                     val multiplier = DecodeUtils.computeSizeMultiplier(
                         srcWidth = svgWidth,
@@ -79,9 +78,15 @@ class SvgDecoder @JvmOverloads constructor(
                 }
             }
             is OriginalSize -> {
+                svgWidth = svg.documentWidth
+                svgHeight = svg.documentHeight
+
                 if (svgWidth > 0 && svgHeight > 0) {
                     bitmapWidth = svgWidth.toInt()
                     bitmapHeight = svgHeight.toInt()
+                } else if (useViewBoundsAsIntrinsicSize && viewBox != null) {
+                    bitmapWidth = viewBox.width().toInt()
+                    bitmapHeight = viewBox.height().toInt()
                 } else {
                     bitmapWidth = DEFAULT_SIZE
                     bitmapHeight = DEFAULT_SIZE
@@ -90,18 +95,14 @@ class SvgDecoder @JvmOverloads constructor(
         }
 
         // Set the SVG's view box to enable scaling if it is not set.
-        if (svg.documentViewBox == null && svgWidth > 0 && svgHeight > 0) {
+        if (viewBox == null && svgWidth > 0 && svgHeight > 0) {
             svg.setDocumentViewBox(0f, 0f, svgWidth, svgHeight)
         }
 
         svg.setDocumentWidth("100%")
         svg.setDocumentHeight("100%")
 
-        val config = when {
-            SDK_INT >= 26 && options.config == Bitmap.Config.HARDWARE -> Bitmap.Config.ARGB_8888
-            else -> options.config
-        }
-        val bitmap = pool.get(bitmapWidth, bitmapHeight, config)
+        val bitmap = pool.get(bitmapWidth, bitmapHeight, options.config.toSoftware())
         svg.renderToCanvas(Canvas(bitmap))
 
         DecodeResult(

--- a/coil-svg/src/main/java/coil/util/Extensions.kt
+++ b/coil-svg/src/main/java/coil/util/Extensions.kt
@@ -2,6 +2,8 @@
 
 package coil.util
 
+import android.graphics.Bitmap
+import android.os.Build.VERSION.SDK_INT
 import okio.BufferedSource
 import okio.ByteString
 
@@ -19,4 +21,12 @@ internal fun BufferedSource.indexOf(bytes: ByteString, fromIndex: Long, toIndex:
         currentIndex++
     }
     return -1
+}
+
+internal val Bitmap.Config.isHardware: Boolean
+    get() = SDK_INT >= 26 && this == Bitmap.Config.HARDWARE
+
+/** Convert null and [Bitmap.Config.HARDWARE] configs to [Bitmap.Config.ARGB_8888]. */
+internal fun Bitmap.Config?.toSoftware(): Bitmap.Config {
+    return if (this == null || isHardware) Bitmap.Config.ARGB_8888 else this
 }


### PR DESCRIPTION
Currently we use an SVG's `width`/`height` to determine its intrinsic size and its aspect ratio. However, we should actually be using its `viewBox` since that's the actual size of the rendered content. e.g. we could have an SVG that's 500x500, but a view box that's only the center 100x200 pixels. In that case the aspect ratio of the rendered content is 1x2 and not 1x1.

Also adds a `useViewBoundsAsIntrinsicSize` constructor param to opt out of the changes if it causes issues.