### PR TITLE
Add VideoFrameDecoder to support decoding video frames from any source.

### DIFF
--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -11,6 +11,8 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.decode.SvgDecoder
 import coil.decode.VideoFrameDecoder
+import coil.fetch.VideoFrameFileFetcher
+import coil.fetch.VideoFrameUriFetcher
 import coil.util.DebugLogger
 import okhttp3.Cache
 import okhttp3.Dispatcher
@@ -24,12 +26,19 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
             .availableMemoryPercentage(0.25) // Use 25% of the application's available memory.
             .crossfade(true) // Show a short crossfade when loading images from network or disk.
             .componentRegistry {
+                // GIFs
                 if (SDK_INT >= 28) {
                     add(ImageDecoderDecoder(this@Application))
                 } else {
                     add(GifDecoder())
                 }
+
+                // SVGs
                 add(SvgDecoder(this@Application))
+
+                // Video frames
+                add(VideoFrameFileFetcher(this@Application))
+                add(VideoFrameUriFetcher(this@Application))
                 add(VideoFrameDecoder(this@Application))
             }
             .okHttpClient {

--- a/coil-sample/src/main/java/coil/sample/Application.kt
+++ b/coil-sample/src/main/java/coil/sample/Application.kt
@@ -10,8 +10,7 @@ import coil.ImageLoaderFactory
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.decode.SvgDecoder
-import coil.fetch.VideoFrameFileFetcher
-import coil.fetch.VideoFrameUriFetcher
+import coil.decode.VideoFrameDecoder
 import coil.util.DebugLogger
 import okhttp3.Cache
 import okhttp3.Dispatcher
@@ -25,17 +24,13 @@ class Application : MultiDexApplication(), ImageLoaderFactory {
             .availableMemoryPercentage(0.25) // Use 25% of the application's available memory.
             .crossfade(true) // Show a short crossfade when loading images from network or disk.
             .componentRegistry {
-                // Fetchers
-                add(VideoFrameFileFetcher(this@Application))
-                add(VideoFrameUriFetcher(this@Application))
-
-                // Decoders
                 if (SDK_INT >= 28) {
                     add(ImageDecoderDecoder(this@Application))
                 } else {
                     add(GifDecoder())
                 }
                 add(SvgDecoder(this@Application))
+                add(VideoFrameDecoder(this@Application))
             }
             .okHttpClient {
                 // Create a disk cache with "unlimited" size. Don't do this in production.

--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -18,7 +18,7 @@ val imageLoader = ImageLoader.Builder(context)
     .build()
 ```
 
-`VideoFrameFileFetcher` and `VideoFrameUriFetcher` are the optimal ways to decode video frames from `File`s and non-network `Uri`s and will be used automatically for those data types. `VideoFrameDecoder` handles all data types, but creates a temporary file on disk to decode the source.
+`VideoFrameDecoder` handles all data sources, but creates a temporary file on disk to decode the source. `VideoFrameFileFetcher` and `VideoFrameUriFetcher` don't create a temporary file, but only work for `File`s and local `Uri`s respectively. Registering all 3 components ensures that `VideoFrameFileFetcher` and `VideoFrameUriFetcher` are automatically used when appropriate and `VideoFrameDecoder` is used as a fallback.
 
 To specify the time code of the frame to extract from a video, use `videoFrameMillis` or `videoFrameMicros`:
 

--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -11,14 +11,10 @@ And add the two fetchers to your component registry when constructing your `Imag
 ```kotlin
 val imageLoader = ImageLoader.Builder(context)
     .componentRegistry {
-         add(VideoFrameFileFetcher())
-         add(VideoFrameUriFetcher())
+         add(VideoFrameDecoder())
     }
     .build()
 ```
-
-!!! Note
-    Video frame decoding is only supported for `File`s and `Uri`s (`content` and `file` schemes only).
 
 To specify the time code of the frame to extract from a video, use `videoFrameMillis` or `videoFrameMicros`:
 

--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -6,15 +6,19 @@ To add video frame support, import the extension library:
 implementation("io.coil-kt:coil-video:1.1.1")
 ```
 
-And add the two fetchers to your component registry when constructing your `ImageLoader`:
+And add the two fetchers and the decoder to your component registry when constructing your `ImageLoader`:
 
 ```kotlin
 val imageLoader = ImageLoader.Builder(context)
     .componentRegistry {
-         add(VideoFrameDecoder())
+        add(VideoFrameFileFetcher())
+        add(VideoFrameUriFetcher())
+        add(VideoFrameDecoder())
     }
     .build()
 ```
+
+`VideoFrameFileFetcher` and `VideoFrameUriFetcher` are the optimal ways to decode video frames from `File`s and non-network `Uri`s and will be used automatically for those data types. `VideoFrameDecoder` handles all data types, but creates a temporary file on disk to decode the source.
 
 To specify the time code of the frame to extract from a video, use `videoFrameMillis` or `videoFrameMicros`:
 

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -1,3 +1,15 @@
+public final class coil/decode/VideoFrameDecoder : coil/decode/Decoder {
+	public static final field Companion Lcoil/decode/VideoFrameDecoder$Companion;
+	public static final field VIDEO_FRAME_MICROS_KEY Ljava/lang/String;
+	public static final field VIDEO_FRAME_OPTION_KEY Ljava/lang/String;
+	public fun <init> (Landroid/content/Context;)V
+	public fun decode (Lcoil/bitmap/BitmapPool;Lokio/BufferedSource;Lcoil/size/Size;Lcoil/decode/Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun handles (Lokio/BufferedSource;Ljava/lang/String;)Z
+}
+
+public final class coil/decode/VideoFrameDecoder$Companion {
+}
+
 public abstract class coil/fetch/VideoFrameFetcher : coil/fetch/Fetcher {
 	public static final field Companion Lcoil/fetch/VideoFrameFetcher$Companion;
 	public static final field VIDEO_FRAME_MICROS_KEY Ljava/lang/String;

--- a/coil-video/src/androidTest/java/coil/fetch/VideoFrameDecoderTest.kt
+++ b/coil-video/src/androidTest/java/coil/fetch/VideoFrameDecoderTest.kt
@@ -1,0 +1,57 @@
+package coil.fetch
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.os.Build.VERSION.SDK_INT
+import androidx.test.core.app.ApplicationProvider
+import coil.bitmap.BitmapPool
+import coil.decode.Options
+import coil.decode.VideoFrameDecoder
+import coil.size.OriginalSize
+import coil.util.decodeBitmapAsset
+import coil.util.isSimilarTo
+import kotlinx.coroutines.runBlocking
+import okio.buffer
+import okio.source
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class VideoFrameDecoderTest {
+
+    private lateinit var context: Context
+    private lateinit var pool: BitmapPool
+    private lateinit var decoder: VideoFrameDecoder
+
+    @Before
+    fun before() {
+        context = ApplicationProvider.getApplicationContext()
+        pool = BitmapPool(0)
+        decoder = VideoFrameDecoder(context)
+    }
+
+    @Test
+    fun basic() {
+        // MediaMetadataRetriever.getFrameAtTime does not work on the emulator pre-API 23.
+        assumeTrue(SDK_INT >= 23)
+
+        val result = runBlocking {
+            decoder.decode(
+                pool = pool,
+                source = context.assets.open("video.mp4").source().buffer(),
+                size = OriginalSize,
+                options = Options(context)
+            )
+        }
+
+        val actual = (result.drawable as? BitmapDrawable)?.bitmap
+        assertNotNull(actual)
+        assertFalse(result.isSampled)
+
+        val expected = context.decodeBitmapAsset("video_frame_1.jpg")
+        assertTrue(actual.isSimilarTo(expected))
+    }
+}

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -31,15 +31,18 @@ class VideoFrameDecoder(private val context: Context) : Decoder {
         options: Options
     ): DecodeResult {
         val tempFile = File.createTempFile("tmp", null, context.cacheDir.apply { mkdirs() })
-        source.use { tempFile.sink().use(it::readAll) }
-
-        val retriever = MediaMetadataRetriever()
         try {
-            retriever.setDataSource(tempFile.path)
-            return delegate.decode(pool, retriever, size, options)
+            source.use { tempFile.sink().use(it::readAll) }
+
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(tempFile.path)
+                return delegate.decode(pool, retriever, size, options)
+            } finally {
+                retriever.release()
+            }
         } finally {
             tempFile.delete()
-            retriever.release()
         }
     }
 

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -1,0 +1,50 @@
+@file:Suppress("unused")
+
+package coil.decode
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import coil.bitmap.BitmapPool
+import coil.size.Size
+import okio.BufferedSource
+import okio.sink
+import java.io.File
+
+/**
+ * A [Decoder] that uses [MediaMetadataRetriever] to fetch and decode a frame from a video.
+ *
+ * NOTE: [VideoFrameDecoder] creates a temporary copy of the video on the file system. This may cause the decode
+ * process to fail if the video being decoded is very large and/or the device is very low on disk space.
+ */
+class VideoFrameDecoder(private val context: Context) : Decoder {
+
+    private val delegate = VideoFrameDecoderDelegate(context)
+
+    override fun handles(source: BufferedSource, mimeType: String?): Boolean {
+        return mimeType != null && mimeType.startsWith("video/")
+    }
+
+    override suspend fun decode(
+        pool: BitmapPool,
+        source: BufferedSource,
+        size: Size,
+        options: Options
+    ): DecodeResult {
+        val tempFile = File.createTempFile("tmp", null, context.cacheDir)
+        source.use { tempFile.sink().use(it::readAll) }
+
+        val retriever = MediaMetadataRetriever()
+        try {
+            retriever.setDataSource(tempFile.path)
+            return delegate.decode(pool, retriever, size, options)
+        } finally {
+            tempFile.delete()
+            retriever.release()
+        }
+    }
+
+    companion object {
+        const val VIDEO_FRAME_MICROS_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_MICROS_KEY
+        const val VIDEO_FRAME_OPTION_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_OPTION_KEY
+    }
+}

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -30,7 +30,7 @@ class VideoFrameDecoder(private val context: Context) : Decoder {
         size: Size,
         options: Options
     ): DecodeResult {
-        val tempFile = File.createTempFile("tmp", null, context.cacheDir)
+        val tempFile = File.createTempFile("tmp", null, context.cacheDir.apply { mkdirs() })
         source.use { tempFile.sink().use(it::readAll) }
 
         val retriever = MediaMetadataRetriever()

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -44,7 +44,7 @@ class VideoFrameDecoder(private val context: Context) : Decoder {
     }
 
     companion object {
-        const val VIDEO_FRAME_MICROS_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_MICROS_KEY
-        const val VIDEO_FRAME_OPTION_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_OPTION_KEY
+        const val VIDEO_FRAME_MICROS_KEY = "coil#video_frame_micros"
+        const val VIDEO_FRAME_OPTION_KEY = "coil#video_frame_option"
     }
 }

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -32,6 +32,7 @@ class VideoFrameDecoder(private val context: Context) : Decoder {
     ): DecodeResult {
         val tempFile = File.createTempFile("tmp", null, context.cacheDir.apply { mkdirs() })
         try {
+            // Read the source into a temporary file.
             source.use { tempFile.sink().use(it::readAll) }
 
             val retriever = MediaMetadataRetriever()

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoderDelegate.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoderDelegate.kt
@@ -1,0 +1,162 @@
+package coil.decode
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Paint
+import android.media.MediaMetadataRetriever
+import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT
+import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION
+import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH
+import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
+import android.os.Build.VERSION.SDK_INT
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.drawable.toDrawable
+import coil.bitmap.BitmapPool
+import coil.request.videoFrameMicros
+import coil.request.videoFrameOption
+import coil.size.OriginalSize
+import coil.size.PixelSize
+import coil.size.Size
+import kotlin.math.roundToInt
+
+internal class VideoFrameDecoderDelegate(private val context: Context) {
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+
+    fun decode(
+        pool: BitmapPool,
+        retriever: MediaMetadataRetriever,
+        size: Size,
+        options: Options
+    ): DecodeResult {
+        val option = options.parameters.videoFrameOption() ?: OPTION_CLOSEST_SYNC
+        val frameMicros = options.parameters.videoFrameMicros() ?: 0L
+
+        // Resolve the dimensions to decode the video frame at accounting
+        // for the source's aspect ratio and the target's size.
+        var srcWidth = 0
+        var srcHeight = 0
+        val destSize = when (size) {
+            is PixelSize -> {
+                val rotation = if (SDK_INT >= 17) retriever.extractMetadata(METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0 else 0
+                if (rotation == 90 || rotation == 270) {
+                    srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
+                    srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
+                } else {
+                    srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
+                    srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
+                }
+
+                if (srcWidth > 0 && srcHeight > 0) {
+                    val rawScale = DecodeUtils.computeSizeMultiplier(
+                        srcWidth = srcWidth,
+                        srcHeight = srcHeight,
+                        dstWidth = size.width,
+                        dstHeight = size.height,
+                        scale = options.scale
+                    )
+                    val scale = if (options.allowInexactSize) rawScale.coerceAtMost(1.0) else rawScale
+                    val width = (scale * srcWidth).roundToInt()
+                    val height = (scale * srcHeight).roundToInt()
+                    PixelSize(width, height)
+                } else {
+                    // We were unable to decode the video's dimensions.
+                    // Fall back to decoding the video frame at the original size.
+                    // We'll scale the resulting bitmap after decoding if necessary.
+                    OriginalSize
+                }
+            }
+            is OriginalSize -> OriginalSize
+        }
+
+        val rawBitmap: Bitmap? = if (SDK_INT >= 27 && destSize is PixelSize) {
+            retriever.getScaledFrameAtTime(frameMicros, option, destSize.width, destSize.height)
+        } else {
+            retriever.getFrameAtTime(frameMicros, option)?.also {
+                srcWidth = it.width
+                srcHeight = it.height
+            }
+        }
+
+        // If you encounter this exception make sure your video is encoded in a supported codec.
+        // https://developer.android.com/guide/topics/media/media-formats#video-formats
+        checkNotNull(rawBitmap) { "Failed to decode frame at $frameMicros microseconds." }
+
+        val bitmap = normalizeBitmap(pool, rawBitmap, destSize, options)
+
+        val isSampled = if (srcWidth > 0 && srcHeight > 0) {
+            DecodeUtils.computeSizeMultiplier(srcWidth, srcHeight, bitmap.width, bitmap.height, options.scale) < 1.0
+        } else {
+            // We were unable to determine the original size of the video. Assume it is sampled.
+            true
+        }
+
+        return DecodeResult(
+            drawable = bitmap.toDrawable(context.resources),
+            isSampled = isSampled
+        )
+    }
+
+    /** Return [inBitmap] or a copy of [inBitmap] that is valid for the input [options] and [size]. */
+    private fun normalizeBitmap(
+        pool: BitmapPool,
+        inBitmap: Bitmap,
+        size: Size,
+        options: Options
+    ): Bitmap {
+        // Fast path: if the input bitmap is valid, return it.
+        if (isConfigValid(inBitmap, options) && isSizeValid(inBitmap, options, size)) {
+            return inBitmap
+        }
+
+        // Slow path: re-render the bitmap with the correct size + config.
+        val scale: Float
+        val dstWidth: Int
+        val dstHeight: Int
+        when (size) {
+            is PixelSize -> {
+                scale = DecodeUtils.computeSizeMultiplier(
+                    srcWidth = inBitmap.width,
+                    srcHeight = inBitmap.height,
+                    dstWidth = size.width,
+                    dstHeight = size.height,
+                    scale = options.scale
+                ).toFloat()
+                dstWidth = (scale * inBitmap.width).roundToInt()
+                dstHeight = (scale * inBitmap.height).roundToInt()
+            }
+            is OriginalSize -> {
+                scale = 1f
+                dstWidth = inBitmap.width
+                dstHeight = inBitmap.height
+            }
+        }
+        val safeConfig = when {
+            SDK_INT >= 26 && options.config == Bitmap.Config.HARDWARE -> Bitmap.Config.ARGB_8888
+            else -> options.config
+        }
+
+        val outBitmap = pool.get(dstWidth, dstHeight, safeConfig)
+        outBitmap.applyCanvas {
+            scale(scale, scale)
+            drawBitmap(inBitmap, 0f, 0f, paint)
+        }
+        pool.put(inBitmap)
+
+        return outBitmap
+    }
+
+    private fun isConfigValid(bitmap: Bitmap, options: Options): Boolean {
+        return SDK_INT < 26 || bitmap.config != Bitmap.Config.HARDWARE || options.config == Bitmap.Config.HARDWARE
+    }
+
+    private fun isSizeValid(bitmap: Bitmap, options: Options, size: Size): Boolean {
+        return options.allowInexactSize || size is OriginalSize ||
+            size == DecodeUtils.computePixelSize(bitmap.width, bitmap.height, size, options.scale)
+    }
+
+    companion object {
+        const val VIDEO_FRAME_MICROS_KEY = "coil#video_frame_micros"
+        const val VIDEO_FRAME_OPTION_KEY = "coil#video_frame_option"
+    }
+}

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoderDelegate.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoderDelegate.kt
@@ -154,9 +154,4 @@ internal class VideoFrameDecoderDelegate(private val context: Context) {
         return options.allowInexactSize || size is OriginalSize ||
             size == DecodeUtils.computePixelSize(bitmap.width, bitmap.height, size, options.scale)
     }
-
-    companion object {
-        const val VIDEO_FRAME_MICROS_KEY = "coil#video_frame_micros"
-        const val VIDEO_FRAME_OPTION_KEY = "coil#video_frame_option"
-    }
 }

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -4,29 +4,14 @@ package coil.fetch
 
 import android.content.ContentResolver
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.Paint
 import android.media.MediaMetadataRetriever
-import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT
-import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION
-import android.media.MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH
-import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
 import android.net.Uri
-import android.os.Build.VERSION.SDK_INT
-import androidx.core.graphics.applyCanvas
-import androidx.core.graphics.drawable.toDrawable
 import coil.bitmap.BitmapPool
 import coil.decode.DataSource
-import coil.decode.DecodeUtils
-import coil.decode.Decoder
 import coil.decode.Options
-import coil.request.videoFrameMicros
-import coil.request.videoFrameOption
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.decode.VideoFrameDecoderDelegate
 import coil.size.Size
 import java.io.File
-import kotlin.math.roundToInt
 
 /**
  * A [VideoFrameFetcher] that supports fetching and decoding a video frame from a [File].
@@ -68,13 +53,10 @@ class VideoFrameUriFetcher(private val context: Context) : VideoFrameFetcher<Uri
 
 /**
  * A [Fetcher] that uses [MediaMetadataRetriever] to fetch and decode a frame from a video.
- *
- * Due to [MediaMetadataRetriever] requiring non-sequential reads into the data source it's not
- * possible to make this a [Decoder]. Use the [VideoFrameFileFetcher] and [VideoFrameUriFetcher] implementations.
  */
-abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetcher<T> {
+abstract class VideoFrameFetcher<T : Any>(context: Context) : Fetcher<T> {
 
-    private val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+    private val delegate = VideoFrameDecoderDelegate(context)
 
     protected abstract fun MediaMetadataRetriever.setDataSource(data: T)
 
@@ -85,74 +67,11 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
         options: Options
     ): FetchResult {
         val retriever = MediaMetadataRetriever()
-
         try {
             retriever.setDataSource(data)
-
-            val option = options.parameters.videoFrameOption() ?: OPTION_CLOSEST_SYNC
-            val frameMicros = options.parameters.videoFrameMicros() ?: 0L
-
-            // Resolve the dimensions to decode the video frame at accounting
-            // for the source's aspect ratio and the target's size.
-            var srcWidth = 0
-            var srcHeight = 0
-            val destSize = when (size) {
-                is PixelSize -> {
-                    val rotation = if (SDK_INT >= 17) retriever.extractMetadata(METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0 else 0
-                    if (rotation == 90 || rotation == 270) {
-                        srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
-                        srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
-                    } else {
-                        srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
-                        srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
-                    }
-
-                    if (srcWidth > 0 && srcHeight > 0) {
-                        val rawScale = DecodeUtils.computeSizeMultiplier(
-                            srcWidth = srcWidth,
-                            srcHeight = srcHeight,
-                            dstWidth = size.width,
-                            dstHeight = size.height,
-                            scale = options.scale
-                        )
-                        val scale = if (options.allowInexactSize) rawScale.coerceAtMost(1.0) else rawScale
-                        val width = (scale * srcWidth).roundToInt()
-                        val height = (scale * srcHeight).roundToInt()
-                        PixelSize(width, height)
-                    } else {
-                        // We were unable to decode the video's dimensions.
-                        // Fall back to decoding the video frame at the original size.
-                        // We'll scale the resulting bitmap after decoding if necessary.
-                        OriginalSize
-                    }
-                }
-                is OriginalSize -> OriginalSize
-            }
-
-            val rawBitmap: Bitmap? = if (SDK_INT >= 27 && destSize is PixelSize) {
-                retriever.getScaledFrameAtTime(frameMicros, option, destSize.width, destSize.height)
-            } else {
-                retriever.getFrameAtTime(frameMicros, option)?.also {
-                    srcWidth = it.width
-                    srcHeight = it.height
-                }
-            }
-
-            // If you encounter this exception make sure your video is encoded in a supported codec.
-            // https://developer.android.com/guide/topics/media/media-formats#video-formats
-            checkNotNull(rawBitmap) { "Failed to decode frame at $frameMicros microseconds." }
-
-            val bitmap = normalizeBitmap(pool, rawBitmap, destSize, options)
-
-            val isSampled = if (srcWidth > 0 && srcHeight > 0) {
-                DecodeUtils.computeSizeMultiplier(srcWidth, srcHeight, bitmap.width, bitmap.height, options.scale) < 1.0
-            } else {
-                // We were unable to determine the original size of the video. Assume it is sampled.
-                true
-            }
-
+            val (drawable, isSampled) = delegate.decode(pool, retriever, size, options)
             return DrawableResult(
-                drawable = bitmap.toDrawable(context.resources),
+                drawable = drawable,
                 isSampled = isSampled,
                 dataSource = DataSource.DISK
             )
@@ -161,71 +80,13 @@ abstract class VideoFrameFetcher<T : Any>(private val context: Context) : Fetche
         }
     }
 
-    /** Return [inBitmap] or a copy of [inBitmap] that is valid for the input [options] and [size]. */
-    private fun normalizeBitmap(
-        pool: BitmapPool,
-        inBitmap: Bitmap,
-        size: Size,
-        options: Options
-    ): Bitmap {
-        // Fast path: if the input bitmap is valid, return it.
-        if (isConfigValid(inBitmap, options) && isSizeValid(inBitmap, options, size)) {
-            return inBitmap
-        }
-
-        // Slow path: re-render the bitmap with the correct size + config.
-        val scale: Float
-        val dstWidth: Int
-        val dstHeight: Int
-        when (size) {
-            is PixelSize -> {
-                scale = DecodeUtils.computeSizeMultiplier(
-                    srcWidth = inBitmap.width,
-                    srcHeight = inBitmap.height,
-                    dstWidth = size.width,
-                    dstHeight = size.height,
-                    scale = options.scale
-                ).toFloat()
-                dstWidth = (scale * inBitmap.width).roundToInt()
-                dstHeight = (scale * inBitmap.height).roundToInt()
-            }
-            is OriginalSize -> {
-                scale = 1f
-                dstWidth = inBitmap.width
-                dstHeight = inBitmap.height
-            }
-        }
-        val safeConfig = when {
-            SDK_INT >= 26 && options.config == Bitmap.Config.HARDWARE -> Bitmap.Config.ARGB_8888
-            else -> options.config
-        }
-
-        val outBitmap = pool.get(dstWidth, dstHeight, safeConfig)
-        outBitmap.applyCanvas {
-            scale(scale, scale)
-            drawBitmap(inBitmap, 0f, 0f, paint)
-        }
-        pool.put(inBitmap)
-
-        return outBitmap
-    }
-
-    private fun isConfigValid(bitmap: Bitmap, options: Options): Boolean {
-        return SDK_INT < 26 || bitmap.config != Bitmap.Config.HARDWARE || options.config == Bitmap.Config.HARDWARE
-    }
-
-    private fun isSizeValid(bitmap: Bitmap, options: Options, size: Size): Boolean {
-        return options.allowInexactSize || size is OriginalSize ||
-            size == DecodeUtils.computePixelSize(bitmap.width, bitmap.height, size, options.scale)
-    }
-
     companion object {
         // https://developer.android.com/guide/topics/media/media-formats#video-formats
         @JvmField internal val SUPPORTED_FILE_EXTENSIONS = arrayOf(".3gp", ".mkv", ".mp4", ".ts", ".webm")
 
         internal const val ASSET_FILE_PATH_ROOT = "android_asset"
 
-        const val VIDEO_FRAME_MICROS_KEY = "coil#video_frame_micros"
-        const val VIDEO_FRAME_OPTION_KEY = "coil#video_frame_option"
+        const val VIDEO_FRAME_MICROS_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_MICROS_KEY
+        const val VIDEO_FRAME_OPTION_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_OPTION_KEY
     }
 }

--- a/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
+++ b/coil-video/src/main/java/coil/fetch/VideoFrameFetcher.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import coil.bitmap.BitmapPool
 import coil.decode.DataSource
 import coil.decode.Options
+import coil.decode.VideoFrameDecoder
 import coil.decode.VideoFrameDecoderDelegate
 import coil.size.Size
 import java.io.File
@@ -86,7 +87,7 @@ abstract class VideoFrameFetcher<T : Any>(context: Context) : Fetcher<T> {
 
         internal const val ASSET_FILE_PATH_ROOT = "android_asset"
 
-        const val VIDEO_FRAME_MICROS_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_MICROS_KEY
-        const val VIDEO_FRAME_OPTION_KEY = VideoFrameDecoderDelegate.VIDEO_FRAME_OPTION_KEY
+        const val VIDEO_FRAME_MICROS_KEY = VideoFrameDecoder.VIDEO_FRAME_MICROS_KEY
+        const val VIDEO_FRAME_OPTION_KEY = VideoFrameDecoder.VIDEO_FRAME_OPTION_KEY
     }
 }

--- a/coil-video/src/main/java/coil/request/Videos.kt
+++ b/coil-video/src/main/java/coil/request/Videos.kt
@@ -9,8 +9,8 @@ import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
 import android.media.MediaMetadataRetriever.OPTION_NEXT_SYNC
 import android.media.MediaMetadataRetriever.OPTION_PREVIOUS_SYNC
 import coil.decode.VideoFrameDecoder
-import coil.decode.VideoFrameDecoderDelegate.Companion.VIDEO_FRAME_MICROS_KEY
-import coil.decode.VideoFrameDecoderDelegate.Companion.VIDEO_FRAME_OPTION_KEY
+import coil.decode.VideoFrameDecoder.Companion.VIDEO_FRAME_MICROS_KEY
+import coil.decode.VideoFrameDecoder.Companion.VIDEO_FRAME_OPTION_KEY
 import coil.fetch.VideoFrameFetcher
 
 /**

--- a/coil-video/src/main/java/coil/request/Videos.kt
+++ b/coil-video/src/main/java/coil/request/Videos.kt
@@ -8,15 +8,17 @@ import android.media.MediaMetadataRetriever.OPTION_CLOSEST
 import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
 import android.media.MediaMetadataRetriever.OPTION_NEXT_SYNC
 import android.media.MediaMetadataRetriever.OPTION_PREVIOUS_SYNC
+import coil.decode.VideoFrameDecoder
+import coil.decode.VideoFrameDecoderDelegate.Companion.VIDEO_FRAME_MICROS_KEY
+import coil.decode.VideoFrameDecoderDelegate.Companion.VIDEO_FRAME_OPTION_KEY
 import coil.fetch.VideoFrameFetcher
-import coil.fetch.VideoFrameFetcher.Companion.VIDEO_FRAME_MICROS_KEY
-import coil.fetch.VideoFrameFetcher.Companion.VIDEO_FRAME_OPTION_KEY
 
 /**
  * Set the time **in milliseconds** of the frame to extract from a video.
  *
  * Default: 0
  *
+ * @see VideoFrameDecoder
  * @see VideoFrameFetcher
  */
 fun ImageRequest.Builder.videoFrameMillis(frameMillis: Long): ImageRequest.Builder {
@@ -28,6 +30,7 @@ fun ImageRequest.Builder.videoFrameMillis(frameMillis: Long): ImageRequest.Build
  *
  * Default: 0
  *
+ * @see VideoFrameDecoder
  * @see VideoFrameFetcher
  */
 fun ImageRequest.Builder.videoFrameMicros(frameMicros: Long): ImageRequest.Builder {
@@ -43,6 +46,7 @@ fun ImageRequest.Builder.videoFrameMicros(frameMicros: Long): ImageRequest.Build
  * Default: [OPTION_CLOSEST_SYNC]
  *
  * @see MediaMetadataRetriever
+ * @see VideoFrameDecoder
  * @see VideoFrameFetcher
  */
 fun ImageRequest.Builder.videoFrameOption(option: Int): ImageRequest.Builder {


### PR DESCRIPTION
Fixes #687.

This finally adds support for decoding video frame from any source (including the network!) with an important caveat. `VideoFrameDecoder` creates a short lived file on disk to buffer the source into. This is less performant than decoding the file in memory and it requires enough space on disk to copy the video which could be a problem for very large video files.

`VideoFrameFileFetcher` and `VideoFrameUriFetcher` don't have this caveat which is why they're not deprecated. Long term (possibly in the next major version) we'll hopefully be able to remove this limitation on `VideoFrameDecoder` and deprecate the fetchers.