### PR TITLE
Revert "Update gradle-maven-publish-plugin(0.14.2) (#695)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
     dependencies {
         classpath(rootProject.extra["androidPlugin"].toString())
         classpath(rootProject.extra["kotlinPlugin"].toString())
-        classpath("com.vanniktech:gradle-maven-publish-plugin:0.14.2")
+        classpath("com.vanniktech:gradle-maven-publish-plugin:0.13.0")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:0.10.1")
         classpath("org.jetbrains.kotlinx:binary-compatibility-validator:0.4.0")
         classpath("org.jlleitschuh.gradle:ktlint-gradle:10.0.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,6 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=coil-kt
 POM_DEVELOPER_NAME=Coil Contributors
+
+RELEASE_REPOSITORY_URL=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+SNAPSHOT_REPOSITORY_URL=https://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
This update breaks deploying snapshots and introduces a number of unresolved deprecation warnings. Will revisit this later.