### PR TITLE
Modify repositories & setupAppModule()

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ buildscript {
     apply(from = "buildSrc/extra.gradle.kts")
     repositories {
         google()
-        mavenCentral()
         gradlePluginPortal()
     }
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,21 +30,10 @@ extensions.configure<ApiValidationExtension> {
 }
 
 allprojects {
-    repositories {
-        google()
-        mavenCentral()
-
-        // https://github.com/Kotlin/dokka/issues/41
-        jcenter {
-            content {
-                includeModule("org.jetbrains.dokka", "dokka-fatjar")
-            }
-        }
-    }
-
     group = project.groupId
     version = project.versionName
 
+    apply(from = "${rootDir.path}/buildSrc/extra.gradle.kts")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     extensions.configure<KtlintExtension>("ktlint") {
@@ -78,11 +67,13 @@ allprojects {
                 }
                 externalDocumentationLink {
                     url = URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-android/")
-                    packageListUrl = URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-android/package-list")
+                    packageListUrl =
+                        URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-android/package-list")
                 }
                 externalDocumentationLink {
                     url = URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/")
-                    packageListUrl = URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/package-list")
+                    packageListUrl =
+                        URL("https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/package-list")
                 }
                 externalDocumentationLink {
                     url = URL("https://square.github.io/okhttp/3.x/okhttp/")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 apply(from = "extra.gradle.kts")
 
 dependencies {

--- a/buildSrc/extra.gradle.kts
+++ b/buildSrc/extra.gradle.kts
@@ -1,3 +1,8 @@
+repositories {
+    google()
+    mavenCentral()
+}
+
 rootProject.extra.apply {
     set("androidPlugin", "com.android.tools.build:gradle:4.1.3")
     set("kotlinPlugin", "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")

--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -29,7 +29,17 @@ fun Project.setupAppModule(block: BaseAppModuleExtension.() -> Unit = {}) {
             versionName = project.versionName
             resConfigs("en")
             vectorDrawables.useSupportLibrary = true
+            multiDexEnabled = true
         }
+        buildTypes {
+            named("release") {
+                isMinifyEnabled = true
+                isShrinkResources = true
+                proguardFiles("shrinker-rules.pro", "shrinker-rules-android.pro")
+                signingConfig = signingConfigs.getByName("debug")
+            }
+        }
+        dependencies.add("implementation", Library.ANDROIDX_MULTIDEX)
         block()
     }
 }

--- a/coil-sample/build.gradle.kts
+++ b/coil-sample/build.gradle.kts
@@ -11,15 +11,6 @@ setupAppModule {
     defaultConfig {
         applicationId = "coil.sample"
         minSdkVersion(16)
-        multiDexEnabled = true
-    }
-    buildTypes {
-        getByName("release") {
-            isMinifyEnabled = true
-            isShrinkResources = true
-            proguardFiles("shrinker-rules.pro", "shrinker-rules-android.pro")
-            signingConfig = signingConfigs.getByName("debug")
-        }
     }
     buildFeatures {
         viewBinding = true
@@ -39,7 +30,6 @@ dependencies {
     implementation(Library.ANDROIDX_CONSTRAINT_LAYOUT)
     implementation(Library.ANDROIDX_CORE)
     implementation(Library.ANDROIDX_LIFECYCLE_VIEW_MODEL)
-    implementation(Library.ANDROIDX_MULTIDEX)
     implementation(Library.ANDROIDX_RECYCLER_VIEW)
 
     implementation(Library.MATERIAL)


### PR DESCRIPTION
- Integrate repositories into `extra.gradle.kts`
- `mavenCentral` could be removed in buildScript now, as dokka have already been avaliable in [gradlePortal](https://plugins.gradle.org/plugin/org.jetbrains.dokka-android)
- Decouple `setupAppModule()`
