### PR TITLE
Fix animated transformation scaling logic on pre-API 28.

### DIFF
--- a/coil-gif/src/androidTest/java/coil/transform/RoundedCornersAnimatedTransformation.kt
+++ b/coil-gif/src/androidTest/java/coil/transform/RoundedCornersAnimatedTransformation.kt
@@ -11,16 +11,15 @@ import android.os.Build.VERSION.SDK_INT
 
 class RoundedCornersAnimatedTransformation : AnimatedTransformation {
 
-    private val paint = Paint().apply {
-        isAntiAlias = true
-        color = Color.TRANSPARENT
-        xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
-    }
-    private val path = Path().apply {
-        fillType = Path.FillType.INVERSE_EVEN_ODD
-    }
-
     override fun transform(canvas: Canvas): PixelOpacity {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG).apply {
+            color = Color.TRANSPARENT
+            xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC)
+        }
+        val path = Path().apply {
+            fillType = Path.FillType.INVERSE_EVEN_ODD
+        }
+
         val width = canvas.width.toFloat()
         val height = canvas.height.toFloat()
         if (SDK_INT >= 21) {

--- a/coil-gif/src/main/java/coil/decode/GifDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/GifDecoder.kt
@@ -13,6 +13,7 @@ import coil.request.animationStartCallback
 import coil.request.repeatCount
 import coil.size.Size
 import coil.util.animatable2CompatCallbackOf
+import coil.util.isHardware
 import okio.BufferedSource
 import okio.buffer
 
@@ -49,7 +50,7 @@ class GifDecoder : Decoder {
             pool = pool,
             config = when {
                 movie.isOpaque && options.allowRgb565 -> Bitmap.Config.RGB_565
-                SDK_INT >= 26 && options.config == Bitmap.Config.HARDWARE -> Bitmap.Config.ARGB_8888
+                options.config.isHardware -> Bitmap.Config.ARGB_8888
                 else -> options.config
             },
             scale = options.scale

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -3,7 +3,6 @@
 package coil.decode
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.graphics.drawable.AnimatedImageDrawable
 import android.os.Build.VERSION.SDK_INT
@@ -21,6 +20,7 @@ import coil.size.PixelSize
 import coil.size.Size
 import coil.util.animatable2CallbackOf
 import coil.util.asPostProcessor
+import coil.util.isHardware
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.BufferedSource
@@ -103,7 +103,7 @@ class ImageDecoderDecoder : Decoder {
                         }
                     }
 
-                    allocator = if (options.config == Bitmap.Config.HARDWARE) {
+                    allocator = if (options.config.isHardware) {
                         ImageDecoder.ALLOCATOR_HARDWARE
                     } else {
                         ImageDecoder.ALLOCATOR_SOFTWARE

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -26,7 +26,6 @@ import coil.transform.PixelOpacity.OPAQUE
 import coil.transform.PixelOpacity.UNCHANGED
 import coil.util.forEachIndices
 import coil.util.isHardware
-import coil.util.scale
 
 /**
  * A [Drawable] that supports rendering [Movie]s (i.e. GIFs).
@@ -77,7 +76,8 @@ class MovieDrawable @JvmOverloads constructor(
         if (animatedTransformationPicture != null) {
             updateBounds(canvas.bounds, isSoftwareScalingEnabled = true)
             canvas.withSave {
-                scale(1 / softwareScale)
+                val scale = 1 / softwareScale
+                scale(scale, scale)
                 drawFrame(canvas)
             }
         } else {

--- a/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
+++ b/coil-gif/src/main/java/coil/drawable/MovieDrawable.kt
@@ -63,6 +63,7 @@ class MovieDrawable @JvmOverloads constructor(
     private var animatedTransformation: AnimatedTransformation? = null
     private var animatedTransformationPicture: Picture? = null
     private var pixelOpacity = UNCHANGED
+    private var isSoftwareScalingEnabled = false
 
     init {
         require(!config.isHardware) { "Bitmap config must not be hardware." }
@@ -72,16 +73,16 @@ class MovieDrawable @JvmOverloads constructor(
         // Compute the current frame time.
         val invalidate = updateFrameTime()
 
-        // Update the scaling values and draw the current frame.
-        if (animatedTransformationPicture != null) {
-            updateBounds(canvas.bounds, isSoftwareScalingEnabled = true)
+        // Update the scaling properties and draw the current frame.
+        if (isSoftwareScalingEnabled) {
+            updateBounds(canvas.bounds)
             canvas.withSave {
                 val scale = 1 / softwareScale
                 scale(scale, scale)
                 drawFrame(canvas)
             }
         } else {
-            updateBounds(bounds, isSoftwareScalingEnabled = false)
+            updateBounds(bounds)
             drawFrame(canvas)
         }
 
@@ -172,10 +173,12 @@ class MovieDrawable @JvmOverloads constructor(
             pixelOpacity = animatedTransformation.transform(canvas)
             picture.endRecording()
             animatedTransformationPicture = picture
+            isSoftwareScalingEnabled = true
         } else {
             // If width/height are not positive, we're unable to draw the movie.
             animatedTransformationPicture = null
             pixelOpacity = UNCHANGED
+            isSoftwareScalingEnabled = false
         }
 
         // Re-render the drawable.
@@ -202,7 +205,7 @@ class MovieDrawable @JvmOverloads constructor(
         paint.colorFilter = colorFilter
     }
 
-    private fun updateBounds(bounds: Rect, isSoftwareScalingEnabled: Boolean) {
+    private fun updateBounds(bounds: Rect) {
         if (currentBounds == bounds) return
         currentBounds.set(bounds)
 

--- a/coil-gif/src/main/java/coil/request/Gifs.kt
+++ b/coil-gif/src/main/java/coil/request/Gifs.kt
@@ -6,6 +6,7 @@ package coil.request
 import android.graphics.ImageDecoder
 import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.Drawable
+import coil.annotation.ExperimentalCoilApi
 import coil.decode.GifDecoder.Companion.ANIMATED_TRANSFORMATION_KEY
 import coil.decode.GifDecoder.Companion.ANIMATION_END_CALLBACK_KEY
 import coil.decode.GifDecoder.Companion.ANIMATION_START_CALLBACK_KEY
@@ -39,6 +40,7 @@ fun Parameters.repeatCount(): Int? = value(REPEAT_COUNT_KEY) as Int?
  * @see MovieDrawable.setAnimatedTransformation
  * @see ImageDecoder.setPostProcessor
  */
+@ExperimentalCoilApi
 fun ImageRequest.Builder.animatedTransformation(animatedTransformation: AnimatedTransformation): ImageRequest.Builder {
     return setParameter(ANIMATED_TRANSFORMATION_KEY, animatedTransformation)
 }
@@ -46,6 +48,7 @@ fun ImageRequest.Builder.animatedTransformation(animatedTransformation: Animated
 /**
  * Get the [AnimatedTransformation] that will be applied to the result if it is an animated [Drawable].
  */
+@ExperimentalCoilApi
 fun Parameters.animatedTransformation(): AnimatedTransformation? {
     return value(ANIMATED_TRANSFORMATION_KEY) as AnimatedTransformation?
 }

--- a/coil-gif/src/main/java/coil/transform/AnimatedTransformation.kt
+++ b/coil-gif/src/main/java/coil/transform/AnimatedTransformation.kt
@@ -1,16 +1,16 @@
 package coil.transform
 
 import android.graphics.Canvas
+import coil.annotation.ExperimentalCoilApi
 
 /**
  * An interface for making transformations to an animated image's pixel data.
  */
+@ExperimentalCoilApi
 fun interface AnimatedTransformation {
 
     /**
      * Apply the transformation to the [canvas].
-     *
-     * NOTE: Avoid allocating objects in this method as it will be invoked on each frame of the animation.
      *
      * @param canvas The [Canvas] to draw on.
      * @return The opacity of the image after drawing.

--- a/coil-gif/src/main/java/coil/transform/PixelOpacity.kt
+++ b/coil-gif/src/main/java/coil/transform/PixelOpacity.kt
@@ -1,8 +1,11 @@
 package coil.transform
 
+import coil.annotation.ExperimentalCoilApi
+
 /**
  * Represents the opacity of an image's pixels after applying an [AnimatedTransformation].
  */
+@ExperimentalCoilApi
 enum class PixelOpacity {
 
     /**

--- a/coil-gif/src/main/java/coil/util/Extensions.kt
+++ b/coil-gif/src/main/java/coil/util/Extensions.kt
@@ -1,8 +1,10 @@
 @file:JvmName("-GifExtensions")
+@file:Suppress("NOTHING_TO_INLINE")
 
 package coil.util
 
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.PixelFormat
 import android.graphics.PostProcessor
 import android.graphics.drawable.Animatable2
@@ -56,3 +58,5 @@ internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
 
 internal val Bitmap.Config.isHardware: Boolean
     get() = SDK_INT >= 26 && this == Bitmap.Config.HARDWARE
+
+internal inline fun Canvas.scale(scale: Float) = scale(scale, scale)

--- a/coil-gif/src/main/java/coil/util/Extensions.kt
+++ b/coil-gif/src/main/java/coil/util/Extensions.kt
@@ -1,10 +1,8 @@
 @file:JvmName("-GifExtensions")
-@file:Suppress("NOTHING_TO_INLINE")
 
 package coil.util
 
 import android.graphics.Bitmap
-import android.graphics.Canvas
 import android.graphics.PixelFormat
 import android.graphics.PostProcessor
 import android.graphics.drawable.Animatable2
@@ -58,5 +56,3 @@ internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
 
 internal val Bitmap.Config.isHardware: Boolean
     get() = SDK_INT >= 26 && this == Bitmap.Config.HARDWARE
-
-internal inline fun Canvas.scale(scale: Float) = scale(scale, scale)

--- a/coil-gif/src/main/java/coil/util/Extensions.kt
+++ b/coil-gif/src/main/java/coil/util/Extensions.kt
@@ -2,10 +2,12 @@
 
 package coil.util
 
+import android.graphics.Bitmap
 import android.graphics.PixelFormat
 import android.graphics.PostProcessor
 import android.graphics.drawable.Animatable2
 import android.graphics.drawable.Drawable
+import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.RequiresApi
 import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import coil.transform.AnimatedTransformation
@@ -45,3 +47,12 @@ internal fun animatable2CompatCallbackOf(
         onEnd?.invoke()
     }
 }
+
+internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
+    for (i in indices) {
+        action(get(i))
+    }
+}
+
+internal val Bitmap.Config.isHardware: Boolean
+    get() = SDK_INT >= 26 && this == Bitmap.Config.HARDWARE


### PR DESCRIPTION
- Fixes an issue where the animated transformation could appear blurry on pre-API 28. This was due to scaling up the bitmap after the transformation had been applied. This PR forces the transformation to be rendered at the final size so no scaling occurs.
- Optimizes `AnimatedTransformation`s so they're only run once and rendered into a `Picture` instead of running on each frame. This matches the behaviour of `ImageDecoder.PostProcessor`.
- Marks `AnimatedTransformation` as an experimental API as there is some risk associated with these changes.