### PR TITLE
Remove sourceCompatibility & targetCompatibility declaration

### DIFF
--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -42,12 +42,8 @@ private inline fun <reified T : BaseExtension> Project.setupBaseModule(crossinli
             targetSdkVersion(project.targetSdk)
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }
-        compileOptions {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
-        }
         kotlinOptions {
-            jvmTarget = "1.8"
+            jvmTarget = JavaVersion.VERSION_1_8.toString()
             allWarningsAsErrors = true
             useIR = true
 


### PR DESCRIPTION
After AGP 4.2, the default Java version in `compileOptions` is `JavaVersion.VERSION_1_8`, no need to declare `sourceCompatibility` & `targetCompatibility`.

![image](https://user-images.githubusercontent.com/10363352/114253491-02479580-99dd-11eb-9f0d-b30d7b8fa9b9.png)
![image](https://user-images.githubusercontent.com/10363352/114253502-0bd0fd80-99dd-11eb-8945-4cc15945af96.png)
