### PR TITLE
Recycle bitmaps from WeakMemoryCache

### DIFF
--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -134,7 +134,16 @@ internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCach
     override fun clearMemory() {
         logger?.log(TAG, Log.VERBOSE) { "clearMemory" }
         operationsSinceCleanUp = 0
+        recycleCachedBitmaps()
         cache.clear()
+    }
+
+    private fun recycleCachedBitmaps() {
+        cache.values.forEach { cacheValues ->
+            cacheValues.forEach { weakValue ->
+                weakValue.bitmap.get()?.recycle()
+            }
+        }
     }
 
     /** @see ComponentCallbacks2.onTrimMemory */

--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -62,11 +62,8 @@ internal object EmptyWeakMemoryCache : WeakMemoryCache {
 /** A [WeakMemoryCache] implementation backed by a [HashMap]. */
 internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCache {
 
-    @VisibleForTesting
-    internal val cache = hashMapOf<Key, ArrayList<WeakValue>>()
-
-    @VisibleForTesting
-    internal var operationsSinceCleanUp = 0
+    @VisibleForTesting internal val cache = hashMapOf<Key, ArrayList<WeakValue>>()
+    @VisibleForTesting internal var operationsSinceCleanUp = 0
 
     @Synchronized
     override fun get(key: Key): Value? {
@@ -196,15 +193,15 @@ internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCach
 
     @VisibleForTesting
     internal class WeakValue(
-            val identityHashCode: Int,
-            val bitmap: WeakReference<Bitmap>,
-            val isSampled: Boolean,
-            val size: Int
+        val identityHashCode: Int,
+        val bitmap: WeakReference<Bitmap>,
+        val isSampled: Boolean,
+        val size: Int
     )
 
     private class StrongValue(
-            override val bitmap: Bitmap,
-            override val isSampled: Boolean
+        override val bitmap: Bitmap,
+        override val isSampled: Boolean
     ) : Value
 
     companion object {

--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -62,8 +62,11 @@ internal object EmptyWeakMemoryCache : WeakMemoryCache {
 /** A [WeakMemoryCache] implementation backed by a [HashMap]. */
 internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCache {
 
-    @VisibleForTesting internal val cache = hashMapOf<Key, ArrayList<WeakValue>>()
-    @VisibleForTesting internal var operationsSinceCleanUp = 0
+    @VisibleForTesting
+    internal val cache = hashMapOf<Key, ArrayList<WeakValue>>()
+
+    @VisibleForTesting
+    internal var operationsSinceCleanUp = 0
 
     @Synchronized
     override fun get(key: Key): Value? {
@@ -139,8 +142,8 @@ internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCach
     }
 
     private fun recycleCachedBitmaps() {
-        cache.values.forEach { cacheValues ->
-            cacheValues.forEach { weakValue ->
+        for (value in cache.values) {
+            for (weakValue in value) {
                 weakValue.bitmap.get()?.recycle()
             }
         }
@@ -193,15 +196,15 @@ internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCach
 
     @VisibleForTesting
     internal class WeakValue(
-        val identityHashCode: Int,
-        val bitmap: WeakReference<Bitmap>,
-        val isSampled: Boolean,
-        val size: Int
+            val identityHashCode: Int,
+            val bitmap: WeakReference<Bitmap>,
+            val isSampled: Boolean,
+            val size: Int
     )
 
     private class StrongValue(
-        override val bitmap: Bitmap,
-        override val isSampled: Boolean
+            override val bitmap: Bitmap,
+            override val isSampled: Boolean
     ) : Value
 
     companion object {


### PR DESCRIPTION
This is the improvement pull request allowing us to recycle bitmaps from WeakMemoryCache and release still used memory after the current `WeakMemoryCache.clearMemory()` method. It is related to this issue: #747 

The solution was mentioned by @colinrtwhite . 

I tested the solution manually by changing the launching activity and then moving back from the MainActivity to the newly added activity together with clearing the memory cache and forcing the garbage collector. You can see on the screen that memory has returned to the level before the images loading.
![image](https://user-images.githubusercontent.com/24955651/117482711-0bd50680-af65-11eb-82ef-beda51db4298.png)
