### PR TITLE
Fix fakeImageLoader in docs

### DIFF
--- a/docs/image_loaders.md
+++ b/docs/image_loaders.md
@@ -51,8 +51,6 @@ For instance, you could inject a fake `ImageLoader` implementation which always 
 ```kotlin
 val fakeImageLoader = object : ImageLoader {
 
-    private val drawable = ColorDrawable(Color.BLACK)
-
     private val disposable = object : Disposable {
         override val isDisposed get() = true
         override fun dispose() {}
@@ -68,14 +66,14 @@ val fakeImageLoader = object : ImageLoader {
 
     override fun enqueue(request: ImageRequest): Disposable {
         // Always call onStart before onSuccess.
-        request.target?.onStart(drawable)
-        request.target?.onSuccess(drawable)
+        request.target?.onStart(placeholder = ColorDrawable(Color.BLACK))
+        request.target?.onSuccess(result = ColorDrawable(Color.BLACK))
         return disposable
     }
 
     override suspend fun execute(request: ImageRequest): ImageResult {
         return SuccessResult(
-            drawable = drawable,
+            drawable = ColorDrawable(Color.BLACK),
             request = request,
             metadata = ImageResult.Metadata(
                 memoryCacheKey = MemoryCache.Key(""),


### PR DESCRIPTION
Drawables are stateful, so it's not safe to re-use them across multiple requests which could be drawn at the same time. Fixed by returning new drawables for each request.

See: https://github.com/android/compose-samples/pull/538