### PR TITLE
Fix race condition while converting a drawable with shared state to a bitmap.

### DIFF
--- a/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
+++ b/coil-base/src/main/java/coil/decode/DrawableDecoderService.kt
@@ -44,13 +44,14 @@ internal class DrawableDecoderService(private val bitmapPool: BitmapPool) {
         }
 
         // Slow path: draw the drawable on a new bitmap.
-        val srcWidth = drawable.width.let { if (it > 0) it else DEFAULT_SIZE }
-        val srcHeight = drawable.height.let { if (it > 0) it else DEFAULT_SIZE }
+        val safeDrawable = drawable.mutate()
+        val srcWidth = safeDrawable.width.let { if (it > 0) it else DEFAULT_SIZE }
+        val srcHeight = safeDrawable.height.let { if (it > 0) it else DEFAULT_SIZE }
         val (width, height) = DecodeUtils.computePixelSize(srcWidth, srcHeight, size, scale)
 
         val bitmap = bitmapPool.get(width, height, config.toSoftware())
-        drawable.apply {
-            val (oldLeft, oldTop, oldRight, oldBottom) = drawable.bounds
+        safeDrawable.apply {
+            val (oldLeft, oldTop, oldRight, oldBottom) = safeDrawable.bounds
             setBounds(0, 0, width, height)
             draw(Canvas(bitmap))
             setBounds(oldLeft, oldTop, oldRight, oldBottom)


### PR DESCRIPTION
Fixes #769. Also possibly fixes #708.