### PR TITLE
Fix Licensee not finding Coil's Licence url

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/coil-kt/coil.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/coil-kt/coil.git
 
 POM_LICENCE_NAME=The Apache License, Version 2.0
-POM_LICENSE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=coil-kt


### PR DESCRIPTION
Hey folks,

It seems that there's a typo on the key for the licence url, according to to what [gradle-maven-publish-plugin](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/fc8c5c2982d319c7debf3bc88ac2e1a6e64fcbad/src/main/kotlin/com/vanniktech/maven/publish/MavenPublishBaseExtension.kt#L183) expects.

This typo then causes [Licensee](https://github.com/cashapp/licensee) to not find Coil's Licence URL, returning null, blocking us from adding it to the allowlist.

Let me know if there's something else that needs changed, happy to contribute.
