### PR TITLE
Add new allowConversionToBitmap flag, fixes #773

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,6 @@ If you would like to contribute code you can do so through GitHub by forking the
 
 When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Please also make sure your code passes all tests by running `./test.sh`.
 
+If you are making an API change, run `./gradlew apiDump` and include any changed files in your pull request.
+
 *Modified from OkHttp's [Contributing](https://square.github.io/okhttp/contributing/) section.*

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -203,13 +203,14 @@ public final class coil/decode/InterruptibleSourceKt {
 
 public final class coil/decode/Options {
 	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final synthetic fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
-	public final fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
+	public final fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
 	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
-	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
+	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowConversionToBitmap ()Z
 	public final fun getAllowInexactSize ()Z
 	public final fun getAllowRgb565 ()Z
 	public final fun getColorSpace ()Landroid/graphics/ColorSpace;
@@ -450,8 +451,9 @@ public final class coil/request/ErrorResult : coil/request/ImageResult {
 }
 
 public final class coil/request/ImageRequest {
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Object;Lcoil/target/Target;Lcoil/request/ImageRequest$Listener;Lcoil/memory/MemoryCache$Key;Lcoil/memory/MemoryCache$Key;Landroid/graphics/ColorSpace;Lkotlin/Pair;Lcoil/decode/Decoder;Ljava/util/List;Lokhttp3/Headers;Lcoil/request/Parameters;Landroidx/lifecycle/Lifecycle;Lcoil/size/SizeResolver;Lcoil/size/Scale;Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZZLcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Lcoil/request/DefinedRequestOptions;Lcoil/request/DefaultRequestOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Object;Lcoil/target/Target;Lcoil/request/ImageRequest$Listener;Lcoil/memory/MemoryCache$Key;Lcoil/memory/MemoryCache$Key;Landroid/graphics/ColorSpace;Lkotlin/Pair;Lcoil/decode/Decoder;Ljava/util/List;Lokhttp3/Headers;Lcoil/request/Parameters;Landroidx/lifecycle/Lifecycle;Lcoil/size/SizeResolver;Lcoil/size/Scale;Lkotlinx/coroutines/CoroutineDispatcher;Lcoil/transition/Transition;Lcoil/size/Precision;Landroid/graphics/Bitmap$Config;ZZZZLcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Lcoil/request/DefinedRequestOptions;Lcoil/request/DefaultRequestOptions;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowConversionToBitmap ()Z
 	public final fun getAllowHardware ()Z
 	public final fun getAllowRgb565 ()Z
 	public final fun getBitmapConfig ()Landroid/graphics/Bitmap$Config;
@@ -495,6 +497,7 @@ public final class coil/request/ImageRequest$Builder {
 	public fun <init> (Lcoil/request/ImageRequest;Landroid/content/Context;)V
 	public synthetic fun <init> (Lcoil/request/ImageRequest;Landroid/content/Context;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/String;)Lcoil/request/ImageRequest$Builder;
+	public final fun allowConversionToBitmap (Z)Lcoil/request/ImageRequest$Builder;
 	public final fun allowHardware (Z)Lcoil/request/ImageRequest$Builder;
 	public final fun allowRgb565 (Z)Lcoil/request/ImageRequest$Builder;
 	public final fun bitmapConfig (Landroid/graphics/Bitmap$Config;)Lcoil/request/ImageRequest$Builder;

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -166,7 +166,6 @@ class Options(
     ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
         allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 
-
     @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
     fun copy(
         context: Context = this.context,

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -146,4 +146,22 @@ class Options(
         networkCachePolicy: CachePolicy = this.networkCachePolicy
     ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
         allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
+
+
+    @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
+    fun copy(
+        context: Context = this.context,
+        config: Bitmap.Config = this.config,
+        colorSpace: ColorSpace? = this.colorSpace,
+        scale: Scale = this.scale,
+        allowInexactSize: Boolean = this.allowInexactSize,
+        allowRgb565: Boolean = this.allowRgb565,
+        premultipliedAlpha: Boolean = this.premultipliedAlpha,
+        headers: Headers = this.headers,
+        parameters: Parameters = this.parameters,
+        memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
+        diskCachePolicy: CachePolicy = this.diskCachePolicy,
+        networkCachePolicy: CachePolicy = this.networkCachePolicy
+    ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
+        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 }

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -132,6 +132,25 @@ class Options(
         diskCachePolicy = diskCachePolicy, networkCachePolicy = networkCachePolicy)
 
     @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
+    constructor(
+        context: Context,
+        config: Bitmap.Config,
+        colorSpace: ColorSpace?,
+        scale: Scale,
+        allowInexactSize: Boolean,
+        allowRgb565: Boolean,
+        premultipliedAlpha: Boolean,
+        headers: Headers,
+        parameters: Parameters,
+        memoryCachePolicy: CachePolicy,
+        diskCachePolicy: CachePolicy,
+        networkCachePolicy: CachePolicy
+    ) : this(context = context, config = config, colorSpace = colorSpace, scale = scale,
+        allowInexactSize = allowInexactSize, allowRgb565 = allowRgb565, premultipliedAlpha = premultipliedAlpha,
+        headers = headers, parameters = parameters, memoryCachePolicy = memoryCachePolicy,
+        diskCachePolicy = diskCachePolicy, networkCachePolicy = networkCachePolicy)
+
+    @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
     fun copy(
         context: Context = this.context,
         config: Bitmap.Config = this.config,

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -30,6 +30,8 @@ import okhttp3.Headers
  * @param premultipliedAlpha True if the color (RGB) channels of the decoded image should be pre-multiplied by the
  *  alpha channel. The default behavior is to enable pre-multiplication but in some environments it can be necessary
  *  to disable this feature to leave the source pixels unmodified.
+ * @param allowConversionToBitmap True if animated result images will be converted to a Bitmap in order to run
+ *  any requested transformations.
  * @param headers The header fields to use for any network requests.
  * @param parameters A map of custom parameters. These are used to pass custom data to a component.
  * @param memoryCachePolicy Determines if this request is allowed to read/write from/to memory.
@@ -44,6 +46,7 @@ class Options(
     val allowInexactSize: Boolean = false,
     val allowRgb565: Boolean = false,
     val premultipliedAlpha: Boolean = true,
+    val allowConversionToBitmap: Boolean = true,
     val headers: Headers = EMPTY_HEADERS,
     val parameters: Parameters = Parameters.EMPTY,
     val memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
@@ -59,13 +62,14 @@ class Options(
         allowInexactSize: Boolean = this.allowInexactSize,
         allowRgb565: Boolean = this.allowRgb565,
         premultipliedAlpha: Boolean = this.premultipliedAlpha,
+        allowConversionToBitmap: Boolean = this.allowConversionToBitmap,
         headers: Headers = this.headers,
         parameters: Parameters = this.parameters,
         memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
         diskCachePolicy: CachePolicy = this.diskCachePolicy,
         networkCachePolicy: CachePolicy = this.networkCachePolicy
     ) = Options(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
-        headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
+        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -77,6 +81,7 @@ class Options(
             allowInexactSize == other.allowInexactSize &&
             allowRgb565 == other.allowRgb565 &&
             premultipliedAlpha == other.premultipliedAlpha &&
+            allowConversionToBitmap == other.allowConversionToBitmap &&
             headers == other.headers &&
             parameters == other.parameters &&
             memoryCachePolicy == other.memoryCachePolicy &&
@@ -92,6 +97,7 @@ class Options(
         result = 31 * result + allowInexactSize.hashCode()
         result = 31 * result + allowRgb565.hashCode()
         result = 31 * result + premultipliedAlpha.hashCode()
+        result = 31 * result + allowConversionToBitmap.hashCode()
         result = 31 * result + headers.hashCode()
         result = 31 * result + parameters.hashCode()
         result = 31 * result + memoryCachePolicy.hashCode()
@@ -103,8 +109,9 @@ class Options(
     override fun toString(): String {
         return "Options(context=$context, config=$config, colorSpace=$colorSpace, scale=$scale, " +
             "allowInexactSize=$allowInexactSize, allowRgb565=$allowRgb565, premultipliedAlpha=$premultipliedAlpha, " +
-            "headers=$headers, parameters=$parameters, memoryCachePolicy=$memoryCachePolicy, " +
-            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy)"
+            "allowConversionToBitmap=$allowConversionToBitmap, headers=$headers, parameters=$parameters, " +
+            "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
+            "networkCachePolicy=$networkCachePolicy)"
     }
 
     @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
@@ -137,6 +144,6 @@ class Options(
         memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
         diskCachePolicy: CachePolicy = this.diskCachePolicy,
         networkCachePolicy: CachePolicy = this.networkCachePolicy
-    ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha, headers, parameters,
-        memoryCachePolicy, diskCachePolicy, networkCachePolicy)
+    ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
+        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 }

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -1,6 +1,7 @@
 package coil.intercept
 
 import android.graphics.Bitmap
+import android.graphics.drawable.Animatable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.Log
@@ -26,6 +27,7 @@ import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.request.ImageResult.Metadata
 import coil.request.SuccessResult
+import coil.request.get
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size
@@ -353,10 +355,17 @@ internal class EngineInterceptor(
                 drawableDecoder.convert(result.drawable, options.config, size, options.scale, options.allowInexactSize)
             }
         } else {
-            logger?.log(TAG, Log.INFO) {
-                "Converting drawable of type ${result.drawable::class.java.canonicalName} to apply transformations: $transformations"
+            if (options.allowConversionToBitmap) {
+                logger?.log(TAG, Log.INFO) {
+                    "Converting drawable of type ${result.drawable::class.java.canonicalName} to apply transformations: $transformations"
+                }
+                drawableDecoder.convert(result.drawable, options.config, size, options.scale, options.allowInexactSize)
+            } else {
+                logger?.log(TAG, Log.INFO) {
+                    "AllowConversionToBitmap=false, skipping transformations for type ${result.drawable::class.java.canonicalName}"
+                }
+                return result
             }
-            drawableDecoder.convert(result.drawable, options.config, size, options.scale, options.allowInexactSize)
         }
         eventListener.transformStart(request, input)
         val output = transformations.foldIndices(input) { bitmap, transformation ->

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -1,7 +1,6 @@
 package coil.intercept
 
 import android.graphics.Bitmap
-import android.graphics.drawable.Animatable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.Log
@@ -27,7 +26,6 @@ import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.request.ImageResult.Metadata
 import coil.request.SuccessResult
-import coil.request.get
 import coil.size.OriginalSize
 import coil.size.PixelSize
 import coil.size.Size

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -55,6 +55,7 @@ internal class RequestService(private val logger: Logger?) {
             allowInexactSize = request.allowInexactSize,
             allowRgb565 = allowRgb565,
             premultipliedAlpha = request.premultipliedAlpha,
+            allowConversionToBitmap = request.allowConversionToBitmap,
             headers = request.headers,
             parameters = request.parameters,
             memoryCachePolicy = request.memoryCachePolicy,

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -121,6 +121,9 @@ class ImageRequest private constructor(
     /** @see Builder.premultipliedAlpha */
     val premultipliedAlpha: Boolean,
 
+    /** @see Builder.allowConversionToBitmap */
+    val allowConversionToBitmap: Boolean,
+
     /** @see Builder.memoryCachePolicy */
     val memoryCachePolicy: CachePolicy,
 
@@ -181,6 +184,7 @@ class ImageRequest private constructor(
             allowHardware == other.allowHardware &&
             allowRgb565 == other.allowRgb565 &&
             premultipliedAlpha == other.premultipliedAlpha &&
+            allowConversionToBitmap == other.allowConversionToBitmap &&
             memoryCachePolicy == other.memoryCachePolicy &&
             diskCachePolicy == other.diskCachePolicy &&
             networkCachePolicy == other.networkCachePolicy &&
@@ -217,6 +221,7 @@ class ImageRequest private constructor(
         result = 31 * result + allowHardware.hashCode()
         result = 31 * result + allowRgb565.hashCode()
         result = 31 * result + premultipliedAlpha.hashCode()
+        result = 31 * result + allowConversionToBitmap.hashCode()
         result = 31 * result + memoryCachePolicy.hashCode()
         result = 31 * result + diskCachePolicy.hashCode()
         result = 31 * result + networkCachePolicy.hashCode()
@@ -238,11 +243,11 @@ class ImageRequest private constructor(
             "headers=$headers, parameters=$parameters, lifecycle=$lifecycle, sizeResolver=$sizeResolver, " +
             "scale=$scale, dispatcher=$dispatcher, transition=$transition, precision=$precision, " +
             "bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, allowRgb565=$allowRgb565, " +
-            "premultipliedAlpha=$premultipliedAlpha, memoryCachePolicy=$memoryCachePolicy, " +
-            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy, " +
-            "placeholderResId=$placeholderResId, placeholderDrawable=$placeholderDrawable, errorResId=$errorResId, " +
-            "errorDrawable=$errorDrawable, fallbackResId=$fallbackResId, fallbackDrawable=$fallbackDrawable, " +
-            "defined=$defined, defaults=$defaults)"
+            "premultipliedAlpha=$premultipliedAlpha, allowConversionToBitmap=$allowConversionToBitmap, " +
+            "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
+            "networkCachePolicy=$networkCachePolicy, placeholderResId=$placeholderResId, " +
+            "placeholderDrawable=$placeholderDrawable, errorResId=$errorResId, errorDrawable=$errorDrawable, " +
+            "fallbackResId=$fallbackResId, fallbackDrawable=$fallbackDrawable, defined=$defined, defaults=$defaults)"
     }
 
     /**
@@ -304,6 +309,7 @@ class ImageRequest private constructor(
         private var allowHardware: Boolean?
         private var allowRgb565: Boolean?
         private var premultipliedAlpha: Boolean
+        private var allowConversionToBitmap: Boolean
         private var memoryCachePolicy: CachePolicy?
         private var diskCachePolicy: CachePolicy?
         private var networkCachePolicy: CachePolicy?
@@ -343,6 +349,7 @@ class ImageRequest private constructor(
             allowHardware = null
             allowRgb565 = null
             premultipliedAlpha = true
+            allowConversionToBitmap = true
             memoryCachePolicy = null
             diskCachePolicy = null
             networkCachePolicy = null
@@ -382,6 +389,7 @@ class ImageRequest private constructor(
             allowHardware = request.defined.allowHardware
             allowRgb565 = request.defined.allowRgb565
             premultipliedAlpha = request.premultipliedAlpha
+            allowConversionToBitmap = request.allowConversionToBitmap
             memoryCachePolicy = request.defined.memoryCachePolicy
             diskCachePolicy = request.defined.diskCachePolicy
             networkCachePolicy = request.defined.networkCachePolicy
@@ -589,6 +597,14 @@ class ImageRequest private constructor(
          */
         fun premultipliedAlpha(enable: Boolean) = apply {
             this.premultipliedAlpha = enable
+        }
+
+        /**
+         * Enable/disable conversion to Bitmap in order to run any requested transformations.  Use this to disable
+         * static transformations in order to have animatedTransformations run on the unmodified result.
+         */
+        fun allowConversionToBitmap(allow: Boolean) = apply {
+            this.allowConversionToBitmap = allow
         }
 
         /**
@@ -834,6 +850,7 @@ class ImageRequest private constructor(
                 allowHardware = allowHardware ?: defaults.allowHardware,
                 allowRgb565 = allowRgb565 ?: defaults.allowRgb565,
                 premultipliedAlpha = premultipliedAlpha,
+                allowConversionToBitmap = allowConversionToBitmap,
                 memoryCachePolicy = memoryCachePolicy ?: defaults.memoryCachePolicy,
                 diskCachePolicy = diskCachePolicy ?: defaults.diskCachePolicy,
                 networkCachePolicy = networkCachePolicy ?: defaults.networkCachePolicy,

--- a/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
+++ b/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
@@ -39,16 +39,19 @@ class AnimatedAndNormalTransformationTest {
         context = ApplicationProvider.getApplicationContext()
         imageLoader = ImageLoader.Builder(context)
             .crossfade(false)
+            .componentRegistry {
+                val gifDecoder = if (VERSION.SDK_INT >= 28) {
+                    ImageDecoderDecoder(context)
+                } else {
+                    GifDecoder()
+                }
+                add(gifDecoder)
+            }
             .memoryCachePolicy(CachePolicy.DISABLED)
             .diskCachePolicy(CachePolicy.DISABLED)
             .build()
-        val decoder = if (VERSION.SDK_INT >= 28) {
-            ImageDecoderDecoder(context)
-        } else {
-            GifDecoder()
-        }
+
         imageRequestBuilder = ImageRequest.Builder(context)
-            .decoder(decoder)
             .bitmapConfig(Bitmap.Config.ARGB_8888)
             .transformations(CircleCropTransformation())
             .animatedTransformation(AnimatedCircleTransformation())

--- a/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
+++ b/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
@@ -1,0 +1,102 @@
+package coil.transform
+
+import android.content.ContentResolver
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Path.Direction
+import android.graphics.PorterDuff.Mode.SRC
+import android.graphics.PorterDuffXfermode
+import android.graphics.drawable.Animatable
+import android.os.Build.VERSION
+import androidx.core.graphics.drawable.toBitmap
+import androidx.test.core.app.ApplicationProvider
+import coil.ImageLoader
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import coil.request.SuccessResult
+import coil.request.animatedTransformation
+import coil.util.decodeBitmapAsset
+import coil.util.isSimilarTo
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AnimatedAndNormalTransformationTest {
+    private lateinit var context: Context
+    private lateinit var imageLoader: ImageLoader
+    private lateinit var imageRequestBuilder: ImageRequest.Builder
+
+    @Before
+    fun before() {
+        context = ApplicationProvider.getApplicationContext()
+        imageLoader = ImageLoader.Builder(context)
+            .crossfade(false)
+            .memoryCachePolicy(CachePolicy.DISABLED)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .build()
+        val decoder = if (VERSION.SDK_INT >= 28) {
+            ImageDecoderDecoder(context)
+        } else {
+            GifDecoder()
+        }
+        imageRequestBuilder = ImageRequest.Builder(context)
+            .decoder(decoder)
+            .bitmapConfig(Bitmap.Config.ARGB_8888)
+            .transformations(CircleCropTransformation())
+            .animatedTransformation(AnimatedCircleTransformation())
+            .allowConversionToBitmap(false)
+    }
+
+    @Test
+    fun animatedGifStillAnimated() {
+        val actual = runBlocking {
+            val imageRequest = imageRequestBuilder
+                .data("${ContentResolver.SCHEME_FILE}:///android_asset/animated.gif")
+                .build()
+            imageLoader.execute(imageRequest)
+        }
+        assertTrue(actual is SuccessResult)
+        // Make sure this is still an animated result (has not been flattened to apply CircleCropTransformation).
+        assertTrue(actual.drawable is Animatable)
+    }
+
+    @Test
+    fun staticImageStillTransformed() {
+        val actual = runBlocking {
+            val imageRequest = imageRequestBuilder
+                .data("${ContentResolver.SCHEME_FILE}:///android_asset/normal_small.jpg")
+                .build()
+            imageLoader.execute(imageRequest)
+        }
+        val expected = context.decodeBitmapAsset("normal_small_circle.png")
+        assertTrue(actual is SuccessResult)
+        // Make sure this is not an animated result.
+        assertFalse(actual.drawable is Animatable)
+        assertTrue(actual.drawable.toBitmap().isSimilarTo(expected))
+    }
+
+    class AnimatedCircleTransformation : AnimatedTransformation {
+        override fun transform(canvas: Canvas): PixelOpacity {
+            val path = Path()
+            path.fillType = Path.FillType.INVERSE_EVEN_ODD
+            val width = canvas.width
+            val height = canvas.height
+            val radius = width / 2f
+            path.addRoundRect(0f, 0f, width.toFloat(), height.toFloat(), radius, radius, Direction.CW)
+            val paint = Paint()
+            paint.isAntiAlias = true
+            paint.color = Color.TRANSPARENT
+            paint.xfermode = PorterDuffXfermode(SRC)
+            canvas.drawPath(path, paint)
+            return PixelOpacity.TRANSLUCENT
+        }
+    }
+}

--- a/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
+++ b/coil-gif/src/androidTest/java/coil/transform/AnimatedAndNormalTransformationTest.kt
@@ -10,6 +10,7 @@ import android.graphics.Path
 import android.graphics.Path.Direction
 import android.graphics.PorterDuff.Mode.SRC
 import android.graphics.PorterDuffXfermode
+import android.graphics.RectF
 import android.graphics.drawable.Animatable
 import android.os.Build.VERSION
 import androidx.core.graphics.drawable.toBitmap
@@ -93,7 +94,8 @@ class AnimatedAndNormalTransformationTest {
             val width = canvas.width
             val height = canvas.height
             val radius = width / 2f
-            path.addRoundRect(0f, 0f, width.toFloat(), height.toFloat(), radius, radius, Direction.CW)
+            val rect = RectF(0f, 0f, width.toFloat(), height.toFloat())
+            path.addRoundRect(rect, radius, radius, Direction.CW)
             val paint = Paint()
             paint.isAntiAlias = true
             paint.color = Color.TRANSPARENT


### PR DESCRIPTION
This allows animated transformations and normal transformations to
coexist on the same request.  If this flag is set to false:

- A normal bitmap result will have normal transformations applied to it
- An animated result will be left intact which allows
  animatedTransformations to apply.