### PR TITLE
Remove Options.allowConversionToBitmap.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -203,17 +203,13 @@ public final class coil/decode/InterruptibleSourceKt {
 
 public final class coil/decode/Options {
 	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)V
+	public synthetic fun <init> (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final synthetic fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
-	public final synthetic fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
-	public final fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
+	public final fun copy (Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;)Lcoil/decode/Options;
 	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
 	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
-	public static synthetic fun copy$default (Lcoil/decode/Options;Landroid/content/Context;Landroid/graphics/Bitmap$Config;Landroid/graphics/ColorSpace;Lcoil/size/Scale;ZZZZLokhttp3/Headers;Lcoil/request/Parameters;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;Lcoil/request/CachePolicy;ILjava/lang/Object;)Lcoil/decode/Options;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAllowConversionToBitmap ()Z
 	public final fun getAllowInexactSize ()Z
 	public final fun getAllowRgb565 ()Z
 	public final fun getColorSpace ()Landroid/graphics/ColorSpace;

--- a/coil-base/src/main/java/coil/decode/Options.kt
+++ b/coil-base/src/main/java/coil/decode/Options.kt
@@ -30,8 +30,6 @@ import okhttp3.Headers
  * @param premultipliedAlpha True if the color (RGB) channels of the decoded image should be pre-multiplied by the
  *  alpha channel. The default behavior is to enable pre-multiplication but in some environments it can be necessary
  *  to disable this feature to leave the source pixels unmodified.
- * @param allowConversionToBitmap True if animated result images will be converted to a Bitmap in order to run
- *  any requested transformations.
  * @param headers The header fields to use for any network requests.
  * @param parameters A map of custom parameters. These are used to pass custom data to a component.
  * @param memoryCachePolicy Determines if this request is allowed to read/write from/to memory.
@@ -46,7 +44,6 @@ class Options(
     val allowInexactSize: Boolean = false,
     val allowRgb565: Boolean = false,
     val premultipliedAlpha: Boolean = true,
-    val allowConversionToBitmap: Boolean = true,
     val headers: Headers = EMPTY_HEADERS,
     val parameters: Parameters = Parameters.EMPTY,
     val memoryCachePolicy: CachePolicy = CachePolicy.ENABLED,
@@ -62,14 +59,13 @@ class Options(
         allowInexactSize: Boolean = this.allowInexactSize,
         allowRgb565: Boolean = this.allowRgb565,
         premultipliedAlpha: Boolean = this.premultipliedAlpha,
-        allowConversionToBitmap: Boolean = this.allowConversionToBitmap,
         headers: Headers = this.headers,
         parameters: Parameters = this.parameters,
         memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
         diskCachePolicy: CachePolicy = this.diskCachePolicy,
         networkCachePolicy: CachePolicy = this.networkCachePolicy
-    ) = Options(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
-        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
+    ) = Options(context, config, colorSpace, scale, allowInexactSize, allowRgb565,
+        premultipliedAlpha, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -81,7 +77,6 @@ class Options(
             allowInexactSize == other.allowInexactSize &&
             allowRgb565 == other.allowRgb565 &&
             premultipliedAlpha == other.premultipliedAlpha &&
-            allowConversionToBitmap == other.allowConversionToBitmap &&
             headers == other.headers &&
             parameters == other.parameters &&
             memoryCachePolicy == other.memoryCachePolicy &&
@@ -97,7 +92,6 @@ class Options(
         result = 31 * result + allowInexactSize.hashCode()
         result = 31 * result + allowRgb565.hashCode()
         result = 31 * result + premultipliedAlpha.hashCode()
-        result = 31 * result + allowConversionToBitmap.hashCode()
         result = 31 * result + headers.hashCode()
         result = 31 * result + parameters.hashCode()
         result = 31 * result + memoryCachePolicy.hashCode()
@@ -109,9 +103,8 @@ class Options(
     override fun toString(): String {
         return "Options(context=$context, config=$config, colorSpace=$colorSpace, scale=$scale, " +
             "allowInexactSize=$allowInexactSize, allowRgb565=$allowRgb565, premultipliedAlpha=$premultipliedAlpha, " +
-            "allowConversionToBitmap=$allowConversionToBitmap, headers=$headers, parameters=$parameters, " +
-            "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
-            "networkCachePolicy=$networkCachePolicy)"
+            "headers=$headers, parameters=$parameters, memoryCachePolicy=$memoryCachePolicy, " +
+            "diskCachePolicy=$diskCachePolicy, networkCachePolicy=$networkCachePolicy)"
     }
 
     @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
@@ -132,54 +125,19 @@ class Options(
         diskCachePolicy = diskCachePolicy, networkCachePolicy = networkCachePolicy)
 
     @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
-    constructor(
-        context: Context,
-        config: Bitmap.Config,
-        colorSpace: ColorSpace?,
-        scale: Scale,
-        allowInexactSize: Boolean,
-        allowRgb565: Boolean,
-        premultipliedAlpha: Boolean,
-        headers: Headers,
-        parameters: Parameters,
-        memoryCachePolicy: CachePolicy,
-        diskCachePolicy: CachePolicy,
-        networkCachePolicy: CachePolicy
-    ) : this(context = context, config = config, colorSpace = colorSpace, scale = scale,
-        allowInexactSize = allowInexactSize, allowRgb565 = allowRgb565, premultipliedAlpha = premultipliedAlpha,
-        headers = headers, parameters = parameters, memoryCachePolicy = memoryCachePolicy,
+    fun copy(
+        context: Context = this.context,
+        config: Bitmap.Config = this.config,
+        colorSpace: ColorSpace? = this.colorSpace,
+        scale: Scale = this.scale,
+        allowInexactSize: Boolean = this.allowInexactSize,
+        allowRgb565: Boolean = this.allowRgb565,
+        headers: Headers = this.headers,
+        parameters: Parameters = this.parameters,
+        memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
+        diskCachePolicy: CachePolicy = this.diskCachePolicy,
+        networkCachePolicy: CachePolicy = this.networkCachePolicy
+    ) = copy(context = context, config = config, colorSpace = colorSpace, scale = scale, allowInexactSize = allowInexactSize,
+        allowRgb565 = allowRgb565, headers = headers, parameters = parameters, memoryCachePolicy = memoryCachePolicy,
         diskCachePolicy = diskCachePolicy, networkCachePolicy = networkCachePolicy)
-
-    @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
-    fun copy(
-        context: Context = this.context,
-        config: Bitmap.Config = this.config,
-        colorSpace: ColorSpace? = this.colorSpace,
-        scale: Scale = this.scale,
-        allowInexactSize: Boolean = this.allowInexactSize,
-        allowRgb565: Boolean = this.allowRgb565,
-        headers: Headers = this.headers,
-        parameters: Parameters = this.parameters,
-        memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
-        diskCachePolicy: CachePolicy = this.diskCachePolicy,
-        networkCachePolicy: CachePolicy = this.networkCachePolicy
-    ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
-        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
-
-    @Deprecated(message = "Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
-    fun copy(
-        context: Context = this.context,
-        config: Bitmap.Config = this.config,
-        colorSpace: ColorSpace? = this.colorSpace,
-        scale: Scale = this.scale,
-        allowInexactSize: Boolean = this.allowInexactSize,
-        allowRgb565: Boolean = this.allowRgb565,
-        premultipliedAlpha: Boolean = this.premultipliedAlpha,
-        headers: Headers = this.headers,
-        parameters: Parameters = this.parameters,
-        memoryCachePolicy: CachePolicy = this.memoryCachePolicy,
-        diskCachePolicy: CachePolicy = this.diskCachePolicy,
-        networkCachePolicy: CachePolicy = this.networkCachePolicy
-    ) = copy(context, config, colorSpace, scale, allowInexactSize, allowRgb565, premultipliedAlpha,
-        allowConversionToBitmap, headers, parameters, memoryCachePolicy, diskCachePolicy, networkCachePolicy)
 }

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -353,14 +353,14 @@ internal class EngineInterceptor(
                 drawableDecoder.convert(result.drawable, options.config, size, options.scale, options.allowInexactSize)
             }
         } else {
-            if (options.allowConversionToBitmap) {
+            if (request.allowConversionToBitmap) {
                 logger?.log(TAG, Log.INFO) {
                     "Converting drawable of type ${result.drawable::class.java.canonicalName} to apply transformations: $transformations"
                 }
                 drawableDecoder.convert(result.drawable, options.config, size, options.scale, options.allowInexactSize)
             } else {
                 logger?.log(TAG, Log.INFO) {
-                    "AllowConversionToBitmap=false, skipping transformations for type ${result.drawable::class.java.canonicalName}"
+                    "allowConversionToBitmap=false, skipping transformations for type ${result.drawable::class.java.canonicalName}"
                 }
                 return result
             }

--- a/coil-base/src/main/java/coil/memory/RequestService.kt
+++ b/coil-base/src/main/java/coil/memory/RequestService.kt
@@ -55,7 +55,6 @@ internal class RequestService(private val logger: Logger?) {
             allowInexactSize = request.allowInexactSize,
             allowRgb565 = allowRgb565,
             premultipliedAlpha = request.premultipliedAlpha,
-            allowConversionToBitmap = request.allowConversionToBitmap,
             headers = request.headers,
             parameters = request.parameters,
             memoryCachePolicy = request.memoryCachePolicy,

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -579,7 +579,7 @@ class ImageRequest private constructor(
         /**
          * Allow converting the result drawable to a bitmap to apply any [transformations].
          *
-         * If false, and the result drawable is not a [BitmapDrawable] any [transformations] will be ignored.
+         * If false and the result drawable is not a [BitmapDrawable] any [transformations] will be ignored.
          */
         fun allowConversionToBitmap(enable: Boolean) = apply {
             this.allowConversionToBitmap = enable

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -5,6 +5,7 @@ package coil.request
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.ColorSpace
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
@@ -112,6 +113,9 @@ class ImageRequest private constructor(
     /** @see Builder.bitmapConfig */
     val bitmapConfig: Bitmap.Config,
 
+    /** @see Builder.allowConversionToBitmap */
+    val allowConversionToBitmap: Boolean,
+
     /** @see Builder.allowHardware */
     val allowHardware: Boolean,
 
@@ -120,9 +124,6 @@ class ImageRequest private constructor(
 
     /** @see Builder.premultipliedAlpha */
     val premultipliedAlpha: Boolean,
-
-    /** @see Builder.allowConversionToBitmap */
-    val allowConversionToBitmap: Boolean,
 
     /** @see Builder.memoryCachePolicy */
     val memoryCachePolicy: CachePolicy,
@@ -181,10 +182,10 @@ class ImageRequest private constructor(
             transition == other.transition &&
             precision == other.precision &&
             bitmapConfig == other.bitmapConfig &&
+            allowConversionToBitmap == other.allowConversionToBitmap &&
             allowHardware == other.allowHardware &&
             allowRgb565 == other.allowRgb565 &&
             premultipliedAlpha == other.premultipliedAlpha &&
-            allowConversionToBitmap == other.allowConversionToBitmap &&
             memoryCachePolicy == other.memoryCachePolicy &&
             diskCachePolicy == other.diskCachePolicy &&
             networkCachePolicy == other.networkCachePolicy &&
@@ -218,10 +219,10 @@ class ImageRequest private constructor(
         result = 31 * result + transition.hashCode()
         result = 31 * result + precision.hashCode()
         result = 31 * result + bitmapConfig.hashCode()
+        result = 31 * result + allowConversionToBitmap.hashCode()
         result = 31 * result + allowHardware.hashCode()
         result = 31 * result + allowRgb565.hashCode()
         result = 31 * result + premultipliedAlpha.hashCode()
-        result = 31 * result + allowConversionToBitmap.hashCode()
         result = 31 * result + memoryCachePolicy.hashCode()
         result = 31 * result + diskCachePolicy.hashCode()
         result = 31 * result + networkCachePolicy.hashCode()
@@ -242,8 +243,8 @@ class ImageRequest private constructor(
             "colorSpace=$colorSpace, fetcher=$fetcher, decoder=$decoder, transformations=$transformations, " +
             "headers=$headers, parameters=$parameters, lifecycle=$lifecycle, sizeResolver=$sizeResolver, " +
             "scale=$scale, dispatcher=$dispatcher, transition=$transition, precision=$precision, " +
-            "bitmapConfig=$bitmapConfig, allowHardware=$allowHardware, allowRgb565=$allowRgb565, " +
-            "premultipliedAlpha=$premultipliedAlpha, allowConversionToBitmap=$allowConversionToBitmap, " +
+            "bitmapConfig=$bitmapConfig, allowConversionToBitmap=$allowConversionToBitmap, " +
+            "allowHardware=$allowHardware, allowRgb565=$allowRgb565, premultipliedAlpha=$premultipliedAlpha, " +
             "memoryCachePolicy=$memoryCachePolicy, diskCachePolicy=$diskCachePolicy, " +
             "networkCachePolicy=$networkCachePolicy, placeholderResId=$placeholderResId, " +
             "placeholderDrawable=$placeholderDrawable, errorResId=$errorResId, errorDrawable=$errorDrawable, " +
@@ -576,6 +577,15 @@ class ImageRequest private constructor(
         }
 
         /**
+         * Allow converting the result drawable to a bitmap to apply any [transformations].
+         *
+         * If false, and the result drawable is not a [BitmapDrawable] any [transformations] will be ignored.
+         */
+        fun allowConversionToBitmap(enable: Boolean) = apply {
+            this.allowConversionToBitmap = enable
+        }
+
+        /**
          * @see ImageLoader.Builder.allowHardware
          */
         fun allowHardware(enable: Boolean) = apply {
@@ -597,14 +607,6 @@ class ImageRequest private constructor(
          */
         fun premultipliedAlpha(enable: Boolean) = apply {
             this.premultipliedAlpha = enable
-        }
-
-        /**
-         * Enable/disable conversion to Bitmap in order to run any requested transformations.  Use this to disable
-         * static transformations in order to have animatedTransformations run on the unmodified result.
-         */
-        fun allowConversionToBitmap(allow: Boolean) = apply {
-            this.allowConversionToBitmap = allow
         }
 
         /**


### PR DESCRIPTION
Turns out we don't actually need to add this to `Options` - only `ImageRequest` (since it's not useful for `Fetcher`s/`Decoder`s).