### PR TITLE
Add CI step to cache emulator snapshots.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: ${{ matrix.api-level }}
+                  disable-animations: false
                   emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   force-avd-creation: false
                   script: echo "Generated AVD snapshot for caching."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,8 @@ jobs:
               with:
                   api-level: ${{ matrix.api-level }}
                   disable-animations: false
-                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   force-avd-creation: false
+                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   script: echo "Generated AVD snapshot for caching."
 
             - name: Instrumentation tests
@@ -92,8 +92,9 @@ jobs:
               with:
                   api-level: ${{ matrix.api-level }}
                   arch: x86
-                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  disable-animations: true
                   force-avd-creation: false
+                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   script: ./gradlew connectedDebugAndroidTest
 
     deploy-snapshot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,19 +63,36 @@ jobs:
               with:
                   distribution: 'adopt'
                   java-version: 11
-
-            # Restore the cache.
-            # Intentionally don't set 'restore-keys' so the cache never contains redundant dependencies.
             - uses: actions/cache@v2
               with:
                   path: ~/.gradle/caches
                   key: gradle-${{ runner.os }}-${{ hashFiles('**/**.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties', '**/buildSrc/src/main/kotlin/Library.kt') }}
+
+            - name: AVD cache
+              uses: actions/cache@v2
+              id: avd-cache
+              with:
+                  path: |
+                      ~/.android/avd/*
+                      ~/.android/adb*
+                  key: avd-${{ matrix.api-level }}
+
+            - name: AVD snapshot
+              if: steps.avd-cache.outputs.cache-hit != 'true'
+              uses: reactivecircus/android-emulator-runner@v2
+              with:
+                  api-level: ${{ matrix.api-level }}
+                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  force-avd-creation: false
+                  script: echo "Generated AVD snapshot for caching."
 
             - name: Instrumentation tests
               uses: reactivecircus/android-emulator-runner@v2
               with:
                   api-level: ${{ matrix.api-level }}
                   arch: x86
+                  emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+                  force-avd-creation: false
                   script: ./gradlew connectedDebugAndroidTest
 
     deploy-snapshot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
                   path: ~/.gradle/caches
                   key: gradle-${{ runner.os }}-${{ hashFiles('**/**.gradle.kts', '**/gradle/wrapper/gradle-wrapper.properties', '**/buildSrc/src/main/kotlin/Library.kt') }}
 
-            - name: AVD cache
+            - name: Cache AVD snapshot
               uses: actions/cache@v2
               id: avd-cache
               with:
@@ -77,7 +77,7 @@ jobs:
                       ~/.android/adb*
                   key: avd-${{ matrix.api-level }}
 
-            - name: AVD snapshot
+            - name: Create AVD snapshot
               if: steps.avd-cache.outputs.cache-hit != 'true'
               uses: reactivecircus/android-emulator-runner@v2
               with:


### PR DESCRIPTION
Speed up emulator start time. https://github.com/ReactiveCircus/android-emulator-runner/pull/159