### PR TITLE
Depend on compose.ui instead of compose.foundation.

### DIFF
--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -29,6 +29,7 @@ object Library {
     const val ANDROIDX_LIFECYCLE_VIEW_MODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:$LIFECYCLE_VERSION"
 
     const val COMPOSE_VERSION = "1.0.1"
+    const val COMPOSE_FOUNDATION = "androidx.compose.foundation:foundation:$COMPOSE_VERSION"
     const val COMPOSE_UI = "androidx.compose.ui:ui:$COMPOSE_VERSION"
     const val COMPOSE_UI_TEST_JUNIT = "androidx.compose.ui:ui-test-junit4:$COMPOSE_VERSION"
     const val COMPOSE_UI_TEST_MANIFEST = "androidx.compose.ui:ui-test-manifest:$COMPOSE_VERSION"

--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -29,7 +29,7 @@ object Library {
     const val ANDROIDX_LIFECYCLE_VIEW_MODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:$LIFECYCLE_VERSION"
 
     const val COMPOSE_VERSION = "1.0.1"
-    const val COMPOSE_FOUNDATION = "androidx.compose.foundation:foundation:$COMPOSE_VERSION"
+    const val COMPOSE_UI = "androidx.compose.ui:ui:$COMPOSE_VERSION"
     const val COMPOSE_UI_TEST_JUNIT = "androidx.compose.ui:ui-test-junit4:$COMPOSE_VERSION"
     const val COMPOSE_UI_TEST_MANIFEST = "androidx.compose.ui:ui-test-manifest:$COMPOSE_VERSION"
 

--- a/coil-compose-base/build.gradle.kts
+++ b/coil-compose-base/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     implementation(Library.ANDROIDX_CORE)
 
-    api(Library.COMPOSE_FOUNDATION)
+    api(Library.COMPOSE_UI)
 
     addTestDependencies(KotlinCompilerVersion.VERSION)
     addAndroidTestDependencies(KotlinCompilerVersion.VERSION)

--- a/coil-compose-base/build.gradle.kts
+++ b/coil-compose-base/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     addTestDependencies(KotlinCompilerVersion.VERSION)
     addAndroidTestDependencies(KotlinCompilerVersion.VERSION)
 
+    androidTestImplementation(Library.COMPOSE_FOUNDATION)
     androidTestImplementation(Library.COMPOSE_UI_TEST_JUNIT)
     androidTestImplementation(Library.COMPOSE_UI_TEST_MANIFEST)
 }

--- a/coil-compose-singleton/build.gradle.kts
+++ b/coil-compose-singleton/build.gradle.kts
@@ -26,5 +26,5 @@ dependencies {
 
     implementation(Library.ANDROIDX_CORE)
 
-    api(Library.COMPOSE_FOUNDATION)
+    api(Library.COMPOSE_UI)
 }


### PR DESCRIPTION
Migrates to `compose.ui` which is a subset of `compose.foundation`.