### PR TITLE
Disable deploy-snapshot action in forked repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         name: Deploy snapshot
         runs-on: ubuntu-latest
         timeout-minutes: 10
-        if: github.ref == 'refs/heads/main'
+        if: github.repository == 'coil-kt/coil' && github.ref == 'refs/heads/main'
         needs: [checks, unit-tests, instrumentation-tests]
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
See [Disable publish action in forked repository](https://github.com/square/kotlinpoet/pull/1119).