### PR TITLE
Add ImageResult to ImagePainter.state.

### DIFF
--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -46,13 +46,14 @@ public final class coil/compose/ImagePainter$State$Empty : coil/compose/ImagePai
 
 public final class coil/compose/ImagePainter$State$Error : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;)Lcoil/compose/ImagePainter$State$Error;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
+	public final fun component2 ()Lcoil/request/ErrorResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)Lcoil/compose/ImagePainter$State$Error;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;
+	public final fun getResult ()Lcoil/request/ErrorResult;
 	public final fun getThrowable ()Ljava/lang/Throwable;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -72,14 +73,15 @@ public final class coil/compose/ImagePainter$State$Loading : coil/compose/ImageP
 
 public final class coil/compose/ImagePainter$State$Success : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Lcoil/request/ImageResult$Metadata;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;)Lcoil/compose/ImagePainter$State$Success;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
+	public final fun component2 ()Lcoil/request/SuccessResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)Lcoil/compose/ImagePainter$State$Success;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetadata ()Lcoil/request/ImageResult$Metadata;
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;
+	public final fun getResult ()Lcoil/request/SuccessResult;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -46,11 +46,12 @@ public final class coil/compose/ImagePainter$State$Empty : coil/compose/ImagePai
 
 public final class coil/compose/ImagePainter$State$Error : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Lcoil/request/ErrorResult;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)Lcoil/compose/ImagePainter$State$Error;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun component3 ()Lcoil/request/ErrorResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;)Lcoil/compose/ImagePainter$State$Error;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;
 	public final fun getResult ()Lcoil/request/ErrorResult;
@@ -73,11 +74,12 @@ public final class coil/compose/ImagePainter$State$Loading : coil/compose/ImageP
 
 public final class coil/compose/ImagePainter$State$Success : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Lcoil/request/SuccessResult;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)Lcoil/compose/ImagePainter$State$Success;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
+	public final fun component2 ()Lcoil/request/ImageResult$Metadata;
+	public final fun component3 ()Lcoil/request/SuccessResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;)Lcoil/compose/ImagePainter$State$Success;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetadata ()Lcoil/request/ImageResult$Metadata;
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -46,12 +46,11 @@ public final class coil/compose/ImagePainter$State$Empty : coil/compose/ImagePai
 
 public final class coil/compose/ImagePainter$State$Error : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun component3 ()Lcoil/request/ErrorResult;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;)Lcoil/compose/ImagePainter$State$Error;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/Throwable;Lcoil/request/ErrorResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
+	public final fun component2 ()Lcoil/request/ErrorResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;)Lcoil/compose/ImagePainter$State$Error;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Error;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ErrorResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Error;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;
 	public final fun getResult ()Lcoil/request/ErrorResult;
@@ -74,12 +73,11 @@ public final class coil/compose/ImagePainter$State$Loading : coil/compose/ImageP
 
 public final class coil/compose/ImagePainter$State$Success : coil/compose/ImagePainter$State {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;)V
+	public fun <init> (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/painter/Painter;
-	public final fun component2 ()Lcoil/request/ImageResult$Metadata;
-	public final fun component3 ()Lcoil/request/SuccessResult;
-	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;)Lcoil/compose/ImagePainter$State$Success;
-	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/ImageResult$Metadata;Lcoil/request/SuccessResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
+	public final fun component2 ()Lcoil/request/SuccessResult;
+	public final fun copy (Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;)Lcoil/compose/ImagePainter$State$Success;
+	public static synthetic fun copy$default (Lcoil/compose/ImagePainter$State$Success;Landroidx/compose/ui/graphics/painter/Painter;Lcoil/request/SuccessResult;ILjava/lang/Object;)Lcoil/compose/ImagePainter$State$Success;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMetadata ()Lcoil/request/ImageResult$Metadata;
 	public fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;

--- a/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
@@ -294,18 +294,28 @@ class ImagePainter internal constructor(
         /** The request was successful. */
         data class Success(
             override val painter: Painter,
-            @Deprecated("Migrate to `result.metadata`.", ReplaceWith("result.metadata"))
-            val metadata: ImageResult.Metadata,
             val result: SuccessResult,
-        ) : State()
+        ) : State() {
+
+            @Deprecated(
+                message = "Migrate to `result.metadata`.",
+                replaceWith = ReplaceWith("result.metadata")
+            )
+            val metadata: ImageResult.Metadata get() = result.metadata
+        }
 
         /** The request failed due to [ErrorResult.throwable]. */
         data class Error(
             override val painter: Painter?,
-            @Deprecated("Migrate to `result.throwable`.", ReplaceWith("result.throwable"))
-            val throwable: Throwable,
             val result: ErrorResult,
-        ) : State()
+        ) : State() {
+
+            @Deprecated(
+                message = "Migrate to `result.throwable`.",
+                replaceWith = ReplaceWith("result.throwable")
+            )
+            val throwable: Throwable get() = result.throwable
+        }
     }
 }
 
@@ -377,12 +387,10 @@ private fun unsupportedData(name: String): Nothing {
 private fun ImageResult.toState() = when (this) {
     is SuccessResult -> State.Success(
         painter = drawable.toPainter(),
-        metadata = metadata,
         result = this
     )
     is ErrorResult -> State.Error(
         painter = drawable?.toPainter(),
-        throwable = throwable,
         result = this
     )
 }

--- a/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
@@ -1,5 +1,4 @@
 @file:SuppressLint("ComposableNaming")
-@file:Suppress("unused")
 
 package coil.compose
 

--- a/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
@@ -295,28 +295,18 @@ class ImagePainter internal constructor(
         /** The request was successful. */
         data class Success(
             override val painter: Painter,
+            @Deprecated("Migrate to `result.metadata`.", ReplaceWith("result.metadata"))
+            val metadata: ImageResult.Metadata,
             val result: SuccessResult,
-        ) : State() {
-
-            @Deprecated(
-                message = "Migrate to `result.metadata`.",
-                replaceWith = ReplaceWith("result.metadata")
-            )
-            val metadata: ImageResult.Metadata get() = result.metadata
-        }
+        ) : State()
 
         /** The request failed due to [ErrorResult.throwable]. */
         data class Error(
             override val painter: Painter?,
+            @Deprecated("Migrate to `result.throwable`.", ReplaceWith("result.throwable"))
+            val throwable: Throwable,
             val result: ErrorResult,
-        ) : State() {
-
-            @Deprecated(
-                message = "Migrate to `result.throwable`.",
-                replaceWith = ReplaceWith("result.throwable")
-            )
-            val throwable: Throwable get() = result.throwable
-        }
+        ) : State()
     }
 }
 
@@ -388,10 +378,12 @@ private fun unsupportedData(name: String): Nothing {
 private fun ImageResult.toState() = when (this) {
     is SuccessResult -> State.Success(
         painter = drawable.toPainter(),
+        metadata = metadata,
         result = this
     )
     is ErrorResult -> State.Error(
         painter = drawable?.toPainter(),
+        throwable = throwable,
         result = this
     )
 }

--- a/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
@@ -1,4 +1,5 @@
 @file:SuppressLint("ComposableNaming")
+@file:Suppress("unused")
 
 package coil.compose
 


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/858

This is technically a binary incompatible change, though it's for an experimental API. Notably, this changes the `component2` function's return value - we'll need to call this out prominently in the release notes.