### PR TITLE
Remove use of Java 8 method.

### DIFF
--- a/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/WeakMemoryCache.kt
@@ -4,7 +4,6 @@ import android.content.ComponentCallbacks2
 import android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
 import android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 import android.graphics.Bitmap
-import android.os.Build.VERSION.SDK_INT
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import coil.memory.MemoryCache.Key
@@ -169,11 +168,7 @@ internal class RealWeakMemoryCache(private val logger: Logger?) : WeakMemoryCach
                 }
             } else {
                 // Iterate over the list of values and delete individual entries that have been collected.
-                if (SDK_INT >= 24) {
-                    list.removeIf { it.bitmap.get() == null }
-                } else {
-                    list.removeIfIndices { it.bitmap.get() == null }
-                }
+                list.removeIfIndices { it.bitmap.get() == null }
 
                 if (list.isEmpty()) {
                     iterator.remove()

--- a/coil-base/src/main/java/coil/util/Collections.kt
+++ b/coil-base/src/main/java/coil/util/Collections.kt
@@ -72,12 +72,9 @@ internal inline fun <R, T> List<R>.firstNotNullIndices(transform: (R) -> T?): T?
  */
 internal inline fun <T> MutableList<T>.removeIfIndices(predicate: (T) -> Boolean) {
     var numDeleted = 0
-
     for (rawIndex in indices) {
         val index = rawIndex - numDeleted
-        val value = get(index)
-
-        if (predicate(value)) {
+        if (predicate(get(index))) {
             removeAt(index)
             numDeleted++
         }


### PR DESCRIPTION
Using `removeIf` here is a *very* small optimization. It's better to have consistency across all API levels and avoid potential desugaring issues.

Fixes: https://github.com/coil-kt/coil/issues/923