### PR TITLE
Fix cancellation propagation

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -122,7 +122,8 @@ internal class RealImageLoader(
 
     override suspend fun execute(request: ImageRequest): ImageResult {
         // Start executing the request on the main thread.
-        val job = scope.async {
+        // We need to pass parent context for proper cancellation propagation.
+        val job = scope.async(coroutineContext) {
             executeMain(request, REQUEST_TYPE_EXECUTE)
         }
 


### PR DESCRIPTION
Pass the proper parent coroutine context to the async job so that cancellation is properly passed down.

Fixes #933

Some tests are needed + Ensure if current propagation issue does not also touch enqueue()