### PR TITLE
Make ImageRequest.fetcherFactory public.

### DIFF
--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -630,8 +630,7 @@ class ImageRequest private constructor(
          * If this is null or is not set the [ImageLoader] will find an applicable fetcher in its
          * [ComponentRegistry].
          */
-        @PublishedApi
-        internal fun <T : Any> fetcherFactory(factory: Fetcher.Factory<T>, type: Class<T>) = apply {
+        fun <T : Any> fetcherFactory(factory: Fetcher.Factory<T>, type: Class<T>) = apply {
             this.fetcherFactory = factory to type
         }
 


### PR DESCRIPTION
This is to align with the same changes made to `ComponentRegistry` in Coil 1.4.0.