### PR TITLE
Remove lifecycle-common-java8

### DIFF
--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -21,7 +21,6 @@ object Library {
     const val ANDROIDX_APPCOMPAT_RESOURCES = "androidx.appcompat:appcompat-resources:$APPCOMPAT_VERSION"
 
     private const val LIFECYCLE_VERSION = "2.4.0"
-    const val ANDROIDX_LIFECYCLE_COMMON = "androidx.lifecycle:lifecycle-common-java8:$LIFECYCLE_VERSION"
     const val ANDROIDX_LIFECYCLE_RUNTIME = "androidx.lifecycle:lifecycle-runtime:$LIFECYCLE_VERSION"
     const val ANDROIDX_LIFECYCLE_VIEW_MODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:$LIFECYCLE_VERSION"
 

--- a/coil-base/build.gradle.kts
+++ b/coil-base/build.gradle.kts
@@ -29,8 +29,7 @@ dependencies {
     implementation(Library.ANDROIDX_CORE)
     implementation(Library.ANDROIDX_EXIF_INTERFACE)
 
-    api(Library.ANDROIDX_LIFECYCLE_COMMON)
-    implementation(Library.ANDROIDX_LIFECYCLE_RUNTIME)
+    api(Library.ANDROIDX_LIFECYCLE_RUNTIME)
 
     api(Library.OKHTTP)
     api(Library.OKIO)

--- a/coil-test/build.gradle.kts
+++ b/coil-test/build.gradle.kts
@@ -15,7 +15,6 @@ dependencies {
 
     implementation(Library.ANDROIDX_APPCOMPAT)
     implementation(Library.ANDROIDX_CORE)
-    implementation(Library.ANDROIDX_LIFECYCLE_COMMON)
 
     implementation(Library.MATERIAL)
 


### PR DESCRIPTION
Refer to [Lifecycle 2.4.0 release note](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0), `lifecycle-common-java8` has been merged into `lifecycle-common`, just `api` `lifecycle:lifecycle-runtime` should work.