### PR TITLE
Minor improvements

### DIFF
--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -28,7 +28,11 @@ internal class ResourceUriFetcher(
         val resId = data.pathSegments.lastOrNull()?.toIntOrNull() ?: throwInvalidUriException(data)
 
         val context = options.context
-        val resources = context.packageManager.getResourcesForApplication(packageName)
+        val resources = if (packageName == context.packageName) {
+            context.resources
+        } else {
+            context.packageManager.getResourcesForApplication(packageName)
+        }
         val path = TypedValue().apply { resources.getValue(resId, this, true) }.string
         val entryName = path.substring(path.lastIndexOf('/'))
         val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromUrl(entryName)


### PR DESCRIPTION
1. Decoding & transforming image tasks consume heavy CPU resources, it's CPU bound task so should use `Dispatchers.Default` as default. Proof: in the example app, go to the "MP4" screen and the app will be freezzing.
2. `ViewTargetRequestDelegate`: unregister lifecycle observer as soon as the request is complete, so itself will be eligible for GC. 