### PR TITLE
Use coroutines for cleanup operations in DiskLruCache.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -225,6 +225,7 @@ public abstract interface class coil/disk/DiskCache {
 public final class coil/disk/DiskCache$Builder {
 	public fun <init> (Landroid/content/Context;)V
 	public final fun build ()Lcoil/disk/DiskCache;
+	public final fun cleanupDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)Lcoil/disk/DiskCache$Builder;
 	public final fun directory (Ljava/io/File;)Lcoil/disk/DiskCache$Builder;
 	public final fun maxSizeBytes (J)Lcoil/disk/DiskCache$Builder;
 	public final fun maxSizePercent (D)Lcoil/disk/DiskCache$Builder;

--- a/coil-base/src/main/java/coil/disk/DiskCache.kt
+++ b/coil-base/src/main/java/coil/disk/DiskCache.kt
@@ -6,6 +6,8 @@ import android.content.Context
 import android.os.StatFs
 import androidx.annotation.FloatRange
 import coil.annotation.ExperimentalCoilApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import java.io.Closeable
 import java.io.File
 
@@ -106,6 +108,7 @@ interface DiskCache {
         private var minimumMaxSizeBytes = 10L * 1024 * 1024 // 10MB
         private var maximumMaxSizeBytes = 250L * 1024 * 1024 // 250MB
         private var maxSizeBytes = 0L
+        private var cleanupDispatcher = Dispatchers.IO
 
         /**
          * Set the [directory] where the cache stores its data.
@@ -154,6 +157,13 @@ interface DiskCache {
         }
 
         /**
+         * Set the [CoroutineDispatcher] that cache size trim operations will be executed on.
+         */
+        fun cleanupDispatcher(dispatcher: CoroutineDispatcher) = apply {
+            this.cleanupDispatcher = dispatcher
+        }
+
+        /**
          * Create a new [DiskCache] instance.
          */
         fun build(): DiskCache {
@@ -171,7 +181,8 @@ interface DiskCache {
             }
             return RealDiskCache(
                 maxSize = maxSize,
-                directory = directory
+                directory = directory,
+                cleanupDispatcher = cleanupDispatcher
             )
         }
     }

--- a/coil-base/src/main/java/coil/disk/RealDiskCache.kt
+++ b/coil-base/src/main/java/coil/disk/RealDiskCache.kt
@@ -2,6 +2,7 @@ package coil.disk
 
 import coil.disk.DiskCache.Editor
 import coil.disk.DiskCache.Snapshot
+import kotlinx.coroutines.CoroutineDispatcher
 import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path.Companion.toOkioPath
@@ -9,12 +10,14 @@ import java.io.File
 
 internal class RealDiskCache(
     override val maxSize: Long,
-    override val directory: File
+    override val directory: File,
+    cleanupDispatcher: CoroutineDispatcher
 ) : DiskCache {
 
     private val cache = DiskLruCache(
         fileSystem = FileSystem.SYSTEM,
         directory = directory.toOkioPath(),
+        cleanupDispatcher = cleanupDispatcher,
         maxSize = maxSize,
         appVersion = 1,
         valueCount = 2


### PR DESCRIPTION
Use `Dispatchers.IO` instead of creating a thread in `DiskLruCache`. We don't actually need `limitedParallism` as we can ensure there's at most one scheduled cleanup operation at one time.