### PR TITLE
Move deprecated ImagePainter functions to a separate file.

### DIFF
--- a/coil-base/src/main/java/coil/util/CoilUtils.kt
+++ b/coil-base/src/main/java/coil/util/CoilUtils.kt
@@ -12,7 +12,7 @@ import okhttp3.Cache
 object CoilUtils {
 
     /**
-     * Dispose the request attached to this view (if there is one).
+     * Dispose the request that's attached to this view (if there is one).
      *
      * NOTE: Typically you should use [Disposable.dispose] to cancel requests and clear resources,
      * however this method is provided for convenience.
@@ -25,7 +25,7 @@ object CoilUtils {
     }
 
     /**
-     * Get the [ImageResult] of the most recent executed image request attached to this view.
+     * Get the [ImageResult] of the most recent executed image request that's attached to this view.
      */
     @JvmStatic
     fun result(view: View): ImageResult? {

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -14,31 +14,6 @@ public final class coil/compose/AsyncImagePainter : androidx/compose/ui/graphics
 	public fun onRemembered ()V
 }
 
-public abstract interface class coil/compose/AsyncImagePainter$ExecuteCallback {
-	public static final field Companion Lcoil/compose/AsyncImagePainter$ExecuteCallback$Companion;
-	public static final field Default Lcoil/compose/AsyncImagePainter$ExecuteCallback;
-	public abstract fun invoke (Lcoil/compose/AsyncImagePainter$Snapshot;Lcoil/compose/AsyncImagePainter$Snapshot;)Z
-}
-
-public final class coil/compose/AsyncImagePainter$ExecuteCallback$Companion {
-}
-
-public final class coil/compose/AsyncImagePainter$Snapshot {
-	public static final field $stable I
-	public synthetic fun <init> (Lcoil/compose/AsyncImagePainter$State;Lcoil/request/ImageRequest;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcoil/compose/AsyncImagePainter$State;
-	public final fun component2 ()Lcoil/request/ImageRequest;
-	public final fun component3-NH-jbRc ()J
-	public final fun copy-cSwnlzA (Lcoil/compose/AsyncImagePainter$State;Lcoil/request/ImageRequest;J)Lcoil/compose/AsyncImagePainter$Snapshot;
-	public static synthetic fun copy-cSwnlzA$default (Lcoil/compose/AsyncImagePainter$Snapshot;Lcoil/compose/AsyncImagePainter$State;Lcoil/request/ImageRequest;JILjava/lang/Object;)Lcoil/compose/AsyncImagePainter$Snapshot;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getRequest ()Lcoil/request/ImageRequest;
-	public final fun getSize-NH-jbRc ()J
-	public final fun getState ()Lcoil/compose/AsyncImagePainter$State;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract class coil/compose/AsyncImagePainter$State {
 	public static final field $stable I
 	public abstract fun getPainter ()Landroidx/compose/ui/graphics/painter/Painter;
@@ -92,8 +67,6 @@ public final class coil/compose/AsyncImagePainter$State$Success : coil/compose/A
 
 public final class coil/compose/AsyncImagePainterKt {
 	public static final fun rememberAsyncImagePainter-ycFWDq0 (Ljava/lang/Object;Lcoil/ImageLoader;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lcoil/ImageLoader;Lcoil/compose/AsyncImagePainter$ExecuteCallback;Landroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/ImageLoader;Lcoil/compose/AsyncImagePainter$ExecuteCallback;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
 }
 
 public abstract interface class coil/compose/AsyncImageScope : androidx/compose/foundation/layout/BoxScope {
@@ -116,5 +89,14 @@ public final class coil/compose/ComposableSingletons$AsyncImageKt {
 	public static field lambda-1 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
 	public final fun getLambda-1$coil_compose_base_release ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class coil/compose/ImagePainterKt {
+	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lcoil/ImageLoader;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/ImageLoader;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 }
 

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import coil.ImageLoader
-import coil.compose.AsyncImagePainter.ExecuteCallback
 import coil.compose.AsyncImagePainter.State
 import coil.decode.DataSource
 import coil.request.ErrorResult
@@ -221,33 +220,6 @@ class AsyncImagePainter internal constructor(
             .first()
     }
 
-    @Deprecated(
-        message = "ExecuteCallback no longer has any effect. To skip waiting for size resolution " +
-            "use ImageRequest.Builder.size(OriginalSize).",
-        level = DeprecationLevel.ERROR
-    )
-    fun interface ExecuteCallback {
-
-        operator fun invoke(previous: Snapshot?, current: Snapshot): Boolean
-
-        companion object {
-            @JvmField val Default = ExecuteCallback { previous, current ->
-                previous?.request != current.request
-            }
-        }
-    }
-
-    @Deprecated(
-        message = "ExecuteCallback no longer has any effect. To skip waiting for size resolution " +
-            "use ImageRequest.Builder.size(OriginalSize).",
-        level = DeprecationLevel.ERROR
-    )
-    data class Snapshot(
-        val state: State,
-        val request: ImageRequest,
-        val size: Size,
-    )
-
     /**
      * The current state of the [AsyncImagePainter].
      */
@@ -364,53 +336,3 @@ internal fun requestOf(model: Any?): ImageRequest {
         return ImageRequest.Builder(LocalContext.current).data(model).build()
     }
 }
-
-@Deprecated(
-    message = "ImagePainter has been renamed to AsyncImagePainter.",
-    replaceWith = ReplaceWith(
-        expression = "AsyncImagePainter",
-        imports = ["coil.compose.AsyncImagePainter"]
-    )
-)
-typealias ImagePainter = AsyncImagePainter
-
-@Deprecated(
-    message = "ImagePainter has been renamed to AsyncImagePainter.",
-    replaceWith = ReplaceWith(
-        expression = "rememberAsyncImagePainter(" +
-            "ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build(), " +
-            "imageLoader)",
-        imports = [
-            "androidx.compose.ui.platform.LocalContext",
-            "coil.compose.rememberAsyncImagePainter",
-            "coil.request.ImageRequest",
-        ]
-    )
-)
-@Composable
-inline fun rememberImagePainter(
-    data: Any?,
-    imageLoader: ImageLoader,
-    onExecute: ExecuteCallback = ExecuteCallback.Default,
-    builder: ImageRequest.Builder.() -> Unit = {},
-) = rememberAsyncImagePainter(
-    model = ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build(),
-    imageLoader = imageLoader
-)
-
-@Deprecated(
-    message = "ImagePainter has been renamed to AsyncImagePainter.",
-    replaceWith = ReplaceWith(
-        expression = "rememberAsyncImagePainter(request, imageLoader)",
-        imports = ["coil.compose.rememberAsyncImagePainter"]
-    )
-)
-@Composable
-fun rememberImagePainter(
-    request: ImageRequest,
-    imageLoader: ImageLoader,
-    onExecute: ExecuteCallback = ExecuteCallback.Default
-) = rememberAsyncImagePainter(
-    model = request,
-    imageLoader = imageLoader
-)

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -1,4 +1,4 @@
-@file:Suppress("ComposableNaming", "DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER")
+@file:Suppress("ComposableNaming", "unused")
 
 package coil.compose
 

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -326,7 +326,7 @@ private val Size.isPositive get() = width >= 0.5 && height >= 0.5
 /** A simple mutable value holder that avoids recomposition. */
 private class ValueHolder<T>(@JvmField var value: T)
 
-/** Create an [ImageRequest] using the [model]. */
+/** Create an [ImageRequest] from the [model]. */
 @Composable
 @ReadOnlyComposable
 internal fun requestOf(model: Any?): ImageRequest {

--- a/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/ImagePainter.kt
@@ -1,0 +1,125 @@
+@file:Suppress("NOTHING_TO_INLINE", "unused", "UNUSED_PARAMETER")
+
+package coil.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalContext
+import coil.ImageLoader
+import coil.compose.AsyncImagePainter.State
+import coil.request.ImageRequest
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "AsyncImagePainter",
+        imports = ["coil.compose.AsyncImagePainter"]
+    )
+)
+typealias ImagePainter = AsyncImagePainter
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(data, imageLoader)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    imageLoader: ImageLoader,
+) = rememberAsyncImagePainter(data, imageLoader)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(data, imageLoader)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    imageLoader: ImageLoader,
+    onExecute: ExecuteCallback
+) = rememberAsyncImagePainter(data, imageLoader)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(ImageRequest.Builder(LocalContext.current)" +
+            ".data(data).apply(builder).build(), imageLoader)",
+        imports = [
+            "androidx.compose.ui.platform.LocalContext",
+            "coil.compose.rememberAsyncImagePainter",
+            "coil.request.ImageRequest",
+        ]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    imageLoader: ImageLoader,
+    builder: ImageRequest.Builder.() -> Unit,
+) = rememberAsyncImagePainter(
+    model = ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build(),
+    imageLoader = imageLoader
+)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(ImageRequest.Builder(LocalContext.current)" +
+            ".data(data).apply(builder).build(), imageLoader)",
+        imports = [
+            "androidx.compose.ui.platform.LocalContext",
+            "coil.compose.rememberAsyncImagePainter",
+            "coil.request.ImageRequest",
+        ]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    imageLoader: ImageLoader,
+    onExecute: ExecuteCallback,
+    builder: ImageRequest.Builder.() -> Unit,
+) = rememberAsyncImagePainter(
+    model = ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build(),
+    imageLoader = imageLoader
+)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(request, imageLoader)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    request: ImageRequest,
+    imageLoader: ImageLoader,
+) = rememberAsyncImagePainter(request, imageLoader)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(request, imageLoader)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    request: ImageRequest,
+    imageLoader: ImageLoader,
+    onExecute: ExecuteCallback,
+) = rememberAsyncImagePainter(request, imageLoader)
+
+private typealias ExecuteCallback = (Snapshot, Snapshot) -> Unit
+
+private typealias Snapshot = Triple<State, ImageRequest, Size>

--- a/coil-compose-singleton/api/coil-compose-singleton.api
+++ b/coil-compose-singleton/api/coil-compose-singleton.api
@@ -1,12 +1,3 @@
-public final class coil/compose/AsyncImagePainterSingletonKt {
-	public static final fun rememberAsyncImagePainter-8BXIMaA (Ljava/lang/Object;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-}
-
-public final class coil/compose/AsyncImageSingletonKt {
-	public static final fun AsyncImage-MvsnxeU (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
-	public static final fun AsyncImage-_kETKwk (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
-}
-
 public final class coil/compose/ImageLoaderProvidableCompositionLocal {
 	public static final synthetic fun box-impl (Landroidx/compose/runtime/ProvidableCompositionLocal;)Lcoil/compose/ImageLoaderProvidableCompositionLocal;
 	public static synthetic fun constructor-impl$default (Landroidx/compose/runtime/ProvidableCompositionLocal;ILkotlin/jvm/internal/DefaultConstructorMarker;)Landroidx/compose/runtime/ProvidableCompositionLocal;
@@ -23,16 +14,25 @@ public final class coil/compose/ImageLoaderProvidableCompositionLocal {
 	public final synthetic fun unbox-impl ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
-public final class coil/compose/ImagePainterSingletonKt {
+public final class coil/compose/LocalImageLoaderKt {
+	public static final fun getLocalImageLoader ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class coil/compose/SingletonAsyncImageKt {
+	public static final fun AsyncImage-MvsnxeU (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
+	public static final fun AsyncImage-_kETKwk (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class coil/compose/SingletonAsyncImagePainterKt {
+	public static final fun rememberAsyncImagePainter-8BXIMaA (Ljava/lang/Object;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
+}
+
+public final class coil/compose/SingletonImagePainterKt {
 	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 	public static final fun rememberImagePainter (Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
-}
-
-public final class coil/compose/LocalImageLoaderKt {
-	public static final fun getLocalImageLoader ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 

--- a/coil-compose-singleton/api/coil-compose-singleton.api
+++ b/coil-compose-singleton/api/coil-compose-singleton.api
@@ -1,7 +1,5 @@
 public final class coil/compose/AsyncImagePainterSingletonKt {
 	public static final fun rememberAsyncImagePainter-8BXIMaA (Ljava/lang/Object;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lcoil/compose/AsyncImagePainter$ExecuteCallback;Landroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberImagePainter (Ljava/lang/Object;Lcoil/compose/AsyncImagePainter$ExecuteCallback;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
 }
 
 public final class coil/compose/AsyncImageSingletonKt {
@@ -23,6 +21,15 @@ public final class coil/compose/ImageLoaderProvidableCompositionLocal {
 	public fun toString ()Ljava/lang/String;
 	public static fun toString-impl (Landroidx/compose/runtime/ProvidableCompositionLocal;)Ljava/lang/String;
 	public final synthetic fun unbox-impl ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class coil/compose/ImagePainterSingletonKt {
+	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Lcoil/request/ImageRequest;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberImagePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lcoil/compose/AsyncImagePainter;
 }
 
 public final class coil/compose/LocalImageLoaderKt {

--- a/coil-compose-singleton/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -8,8 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope.Companion.DefaultFilterQuality
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalContext
-import coil.compose.AsyncImagePainter.ExecuteCallback
 import coil.request.ImageRequest
 
 /**
@@ -30,40 +28,3 @@ fun rememberAsyncImagePainter(
     model: Any?,
     filterQuality: FilterQuality = DefaultFilterQuality,
 ): AsyncImagePainter = rememberAsyncImagePainter(model, LocalImageLoader.current, filterQuality)
-
-@Deprecated(
-    message = "ImagePainter has been renamed to AsyncImagePainter.",
-    replaceWith = ReplaceWith(
-        expression = "rememberAsyncImagePainter(" +
-            "ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build())",
-        imports = [
-            "androidx.compose.ui.platform.LocalContext",
-            "coil.compose.rememberAsyncImagePainter",
-            "coil.request.ImageRequest",
-        ]
-    )
-)
-@Composable
-inline fun rememberImagePainter(
-    data: Any?,
-    onExecute: ExecuteCallback = ExecuteCallback.Default,
-    builder: ImageRequest.Builder.() -> Unit = {},
-): AsyncImagePainter = rememberAsyncImagePainter(
-    model = ImageRequest.Builder(LocalContext.current)
-        .data(data)
-        .apply(builder)
-        .build()
-)
-
-@Deprecated(
-    message = "ImagePainter has been renamed to AsyncImagePainter.",
-    replaceWith = ReplaceWith(
-        expression = "rememberAsyncImagePainter(request)",
-        imports = ["coil.compose.rememberAsyncImagePainter"]
-    )
-)
-@Composable
-fun rememberImagePainter(
-    request: ImageRequest,
-    onExecute: ExecuteCallback = ExecuteCallback.Default,
-): AsyncImagePainter = rememberAsyncImagePainter(request)

--- a/coil-compose-singleton/src/main/java/coil/compose/ImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/ImagePainter.kt
@@ -1,0 +1,107 @@
+@file:JvmName("ImagePainterSingletonKt")
+@file:Suppress("NOTHING_TO_INLINE", "unused", "UNUSED_PARAMETER")
+
+package coil.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.LocalContext
+import coil.request.ImageRequest
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(data)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+) = rememberAsyncImagePainter(data)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(data)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    onExecute: ExecuteCallback,
+) = rememberAsyncImagePainter(data)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(" +
+            "ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build())",
+        imports = [
+            "androidx.compose.ui.platform.LocalContext",
+            "coil.compose.rememberAsyncImagePainter",
+            "coil.request.ImageRequest",
+        ]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    builder: ImageRequest.Builder.() -> Unit,
+) = rememberAsyncImagePainter(
+    model = ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build()
+)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(" +
+            "ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build())",
+        imports = [
+            "androidx.compose.ui.platform.LocalContext",
+            "coil.compose.rememberAsyncImagePainter",
+            "coil.request.ImageRequest",
+        ]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    data: Any?,
+    onExecute: ExecuteCallback,
+    builder: ImageRequest.Builder.() -> Unit,
+) = rememberAsyncImagePainter(
+    model = ImageRequest.Builder(LocalContext.current).data(data).apply(builder).build()
+)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(request)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    )
+)
+@Composable
+inline fun rememberImagePainter(
+    request: ImageRequest,
+) = rememberAsyncImagePainter(request)
+
+@Deprecated(
+    message = "ImagePainter has been renamed to AsyncImagePainter.",
+    replaceWith = ReplaceWith(
+        expression = "rememberAsyncImagePainter(request)",
+        imports = ["coil.compose.rememberAsyncImagePainter"]
+    ),
+    level = DeprecationLevel.ERROR // ExecuteCallback is no longer supported.
+)
+@Composable
+inline fun rememberImagePainter(
+    request: ImageRequest,
+    onExecute: ExecuteCallback,
+) = rememberAsyncImagePainter(request)
+
+private typealias ExecuteCallback = (Snapshot, Snapshot) -> Unit
+
+private typealias Snapshot = Triple<AsyncImagePainter.State, ImageRequest, Size>

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
@@ -1,4 +1,3 @@
-@file:JvmName("AsyncImageSingletonKt")
 @file:Suppress("unused")
 
 package coil.compose

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER")
+@file:Suppress("unused")
 
 package coil.compose
 

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
@@ -1,4 +1,3 @@
-@file:JvmName("AsyncImagePainterSingletonKt")
 @file:Suppress("DEPRECATION_ERROR", "unused", "UNUSED_PARAMETER")
 
 package coil.compose

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonImagePainter.kt
@@ -1,4 +1,3 @@
-@file:JvmName("ImagePainterSingletonKt")
 @file:Suppress("NOTHING_TO_INLINE", "unused", "UNUSED_PARAMETER")
 
 package coil.compose

--- a/coil-singleton/api/coil-singleton.api
+++ b/coil-singleton/api/coil-singleton.api
@@ -2,6 +2,7 @@ public final class coil/-SingletonExtensions {
 	public static final fun clear (Landroid/widget/ImageView;)V
 	public static final fun dispose (Landroid/widget/ImageView;)V
 	public static final fun getImageLoader (Landroid/content/Context;)Lcoil/ImageLoader;
+	public static final fun getMetadata (Landroid/widget/ImageView;)Lcoil/request/ImageResult;
 	public static final fun getResult (Landroid/widget/ImageView;)Lcoil/request/ImageResult;
 	public static final fun load (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;)Lcoil/request/Disposable;
 	public static synthetic fun load$default (Landroid/widget/ImageView;Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcoil/request/Disposable;

--- a/coil-singleton/src/main/java/coil/Extensions.kt
+++ b/coil-singleton/src/main/java/coil/Extensions.kt
@@ -64,14 +64,14 @@ inline fun ImageView.load(
 }
 
 /**
- * Dispose the request attached to this view (if there is one).
+ * Dispose the request that's attached to this view (if there is one).
  */
 inline fun ImageView.dispose() {
     CoilUtils.dispose(this)
 }
 
 /**
- * Get the [ImageResult] of the most recent executed image request attached to this view.
+ * Get the [ImageResult] of the most recently executed image request that's attached to this view.
  */
 inline val ImageView.result: ImageResult?
     get() = CoilUtils.result(this)

--- a/coil-singleton/src/main/java/coil/Extensions.kt
+++ b/coil-singleton/src/main/java/coil/Extensions.kt
@@ -13,9 +13,9 @@ import coil.request.Disposable
 import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.util.CoilUtils
+import okhttp3.HttpUrl
 import java.io.File
 import java.nio.ByteBuffer
-import okhttp3.HttpUrl
 
 /**
  * Get the singleton [ImageLoader].

--- a/coil-singleton/src/main/java/coil/Extensions.kt
+++ b/coil-singleton/src/main/java/coil/Extensions.kt
@@ -13,9 +13,9 @@ import coil.request.Disposable
 import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.util.CoilUtils
-import okhttp3.HttpUrl
 import java.io.File
 import java.nio.ByteBuffer
+import okhttp3.HttpUrl
 
 /**
  * Get the singleton [ImageLoader].
@@ -99,3 +99,14 @@ inline fun ImageView.loadAny(
     level = DeprecationLevel.ERROR // Temporary migration aid.
 )
 inline fun ImageView.clear() = dispose()
+
+@Deprecated(
+    message = "Migrate to 'result'.",
+    replaceWith = ReplaceWith(
+        expression = "result",
+        imports = ["coil.result"]
+    ),
+    level = DeprecationLevel.ERROR // Temporary migration aid.
+)
+inline val ImageView.metadata: ImageResult?
+    get() = CoilUtils.result(this)


### PR DESCRIPTION
This also:
- Improves the IDE `ReplaceWith` suggestions for `ImagePainter`.
- Removes `AsyncImagePainter.ExecuteCallback` and `AsyncImagePainter.Snapshot`, which no longer have any effect.