### PR TITLE
Refactor Size to support using the image's original size for each dimension.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -710,19 +710,16 @@ public final class coil/size/Dimension$Original : coil/size/Dimension {
 }
 
 public final class coil/size/Dimension$Pixels : coil/size/Dimension {
+	public final field px I
 	public fun <init> (I)V
-	public final fun component1 ()I
-	public final fun copy (I)Lcoil/size/Dimension$Pixels;
-	public static synthetic fun copy$default (Lcoil/size/Dimension$Pixels;IILjava/lang/Object;)Lcoil/size/Dimension$Pixels;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPixels ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class coil/size/Dimensions {
 	public static final fun create (I)Lcoil/size/Dimension$Pixels;
-	public static final fun pixelsOrElse (Lcoil/size/Dimension;Lkotlin/jvm/functions/Function0;)I
+	public static final fun pxOrElse (Lcoil/size/Dimension;Lkotlin/jvm/functions/Function0;)I
 }
 
 public final class coil/size/Precision : java/lang/Enum {

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -177,7 +177,6 @@ public final class coil/decode/DecodeResult {
 public final class coil/decode/DecodeUtils {
 	public static final field INSTANCE Lcoil/decode/DecodeUtils;
 	public static final fun calculateInSampleSize (IIIILcoil/size/Scale;)I
-	public static final fun computePixelSize (IILcoil/size/Size;Lcoil/size/Scale;)Lcoil/size/PixelSize;
 	public static final fun computeSizeMultiplier (DDDDLcoil/size/Scale;)D
 	public static final fun computeSizeMultiplier (FFFFLcoil/size/Scale;)F
 	public static final fun computeSizeMultiplier (IIIILcoil/size/Scale;)D
@@ -585,6 +584,7 @@ public final class coil/request/ImageRequest$Builder {
 	public static synthetic fun setParameter$default (Lcoil/request/ImageRequest$Builder;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcoil/request/ImageRequest$Builder;
 	public final fun size (I)Lcoil/request/ImageRequest$Builder;
 	public final fun size (II)Lcoil/request/ImageRequest$Builder;
+	public final fun size (Lcoil/size/Dimension;Lcoil/size/Dimension;)Lcoil/request/ImageRequest$Builder;
 	public final fun size (Lcoil/size/Size;)Lcoil/request/ImageRequest$Builder;
 	public final fun size (Lcoil/size/SizeResolver;)Lcoil/request/ImageRequest$Builder;
 	public final fun target (Landroid/widget/ImageView;)Lcoil/request/ImageRequest$Builder;
@@ -702,22 +702,27 @@ public final class coil/request/SuccessResult : coil/request/ImageResult {
 	public final fun isSampled ()Z
 }
 
-public final class coil/size/OriginalSize : coil/size/Size {
-	public static final field INSTANCE Lcoil/size/OriginalSize;
+public abstract class coil/size/Dimension {
+}
+
+public final class coil/size/Dimension$Original : coil/size/Dimension {
+	public static final field INSTANCE Lcoil/size/Dimension$Original;
+}
+
+public final class coil/size/Dimension$Pixels : coil/size/Dimension {
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lcoil/size/Dimension$Pixels;
+	public static synthetic fun copy$default (Lcoil/size/Dimension$Pixels;IILjava/lang/Object;)Lcoil/size/Dimension$Pixels;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPixels ()I
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class coil/size/PixelSize : coil/size/Size {
-	public fun <init> (II)V
-	public final fun component1 ()I
-	public final fun component2 ()I
-	public final fun copy (II)Lcoil/size/PixelSize;
-	public static synthetic fun copy$default (Lcoil/size/PixelSize;IIILjava/lang/Object;)Lcoil/size/PixelSize;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getHeight ()I
-	public final fun getWidth ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public final class coil/size/Dimensions {
+	public static final fun create (I)Lcoil/size/Dimension$Pixels;
+	public static final fun pixelsOrElse (Lcoil/size/Dimension;Lkotlin/jvm/functions/Function0;)I
 }
 
 public final class coil/size/Precision : java/lang/Enum {
@@ -735,7 +740,22 @@ public final class coil/size/Scale : java/lang/Enum {
 	public static fun values ()[Lcoil/size/Scale;
 }
 
-public abstract class coil/size/Size {
+public final class coil/size/Size {
+	public static final field Companion Lcoil/size/Size$Companion;
+	public static final field ORIGINAL Lcoil/size/Size;
+	public fun <init> (Lcoil/size/Dimension;Lcoil/size/Dimension;)V
+	public final fun component1 ()Lcoil/size/Dimension;
+	public final fun component2 ()Lcoil/size/Dimension;
+	public final fun copy (Lcoil/size/Dimension;Lcoil/size/Dimension;)Lcoil/size/Size;
+	public static synthetic fun copy$default (Lcoil/size/Size;Lcoil/size/Dimension;Lcoil/size/Dimension;ILjava/lang/Object;)Lcoil/size/Size;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()Lcoil/size/Dimension;
+	public final fun getWidth ()Lcoil/size/Dimension;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class coil/size/Size$Companion {
 }
 
 public abstract interface class coil/size/SizeResolver {
@@ -746,6 +766,13 @@ public abstract interface class coil/size/SizeResolver {
 
 public final class coil/size/SizeResolver$Companion {
 	public final fun create (Lcoil/size/Size;)Lcoil/size/SizeResolver;
+}
+
+public final class coil/size/Sizes {
+	public static final fun create (II)Lcoil/size/Size;
+	public static final fun createDeprecated (II)Lcoil/size/Size;
+	public static final fun getOriginalSize ()Lcoil/size/Size;
+	public static final fun isOriginal (Lcoil/size/Size;)Z
 }
 
 public abstract interface class coil/size/ViewSizeResolver : coil/size/SizeResolver {

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -707,6 +707,7 @@ public abstract class coil/size/Dimension {
 
 public final class coil/size/Dimension$Original : coil/size/Dimension {
 	public static final field INSTANCE Lcoil/size/Dimension$Original;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class coil/size/Dimension$Pixels : coil/size/Dimension {

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -767,9 +767,9 @@ public final class coil/size/SizeResolver$Companion {
 }
 
 public final class coil/size/Sizes {
+	public static final fun OriginalSize ()Lcoil/size/Size;
+	public static final fun PixelSize (II)Lcoil/size/Size;
 	public static final fun create (II)Lcoil/size/Size;
-	public static final fun createDeprecated (II)Lcoil/size/Size;
-	public static final fun getOriginalSize ()Lcoil/size/Size;
 	public static final fun isOriginal (Lcoil/size/Size;)Z
 }
 

--- a/coil-base/src/androidTest/java/coil/RealImageLoaderAndroidTest.kt
+++ b/coil-base/src/androidTest/java/coil/RealImageLoaderAndroidTest.kt
@@ -22,8 +22,8 @@ import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.NullRequestDataException
 import coil.request.SuccessResult
-import coil.size.PixelSize
 import coil.size.Precision
+import coil.size.Size
 import coil.util.TestActivity
 import coil.util.activity
 import coil.util.createMockWebServer
@@ -123,8 +123,8 @@ class RealImageLoaderAndroidTest {
     @Test
     fun resourceIntVector() {
         val data = R.drawable.ic_android
-        testEnqueue(data, PixelSize(100, 100))
-        testExecute(data, PixelSize(100, 100))
+        testEnqueue(data, Size(100, 100))
+        testExecute(data, Size(100, 100))
     }
 
     @Test
@@ -137,8 +137,8 @@ class RealImageLoaderAndroidTest {
     @Test
     fun resourceUriIntVector() {
         val data = "$SCHEME_ANDROID_RESOURCE://${context.packageName}/${R.drawable.ic_android}".toUri()
-        testEnqueue(data, PixelSize(100, 100))
-        testExecute(data, PixelSize(100, 100))
+        testEnqueue(data, Size(100, 100))
+        testExecute(data, Size(100, 100))
     }
 
     @Test
@@ -151,8 +151,8 @@ class RealImageLoaderAndroidTest {
     @Test
     fun resourceUriStringVector() {
         val data = "$SCHEME_ANDROID_RESOURCE://${context.packageName}/drawable/ic_android".toUri()
-        testEnqueue(data, PixelSize(100, 100))
-        testExecute(data, PixelSize(100, 100))
+        testEnqueue(data, Size(100, 100))
+        testExecute(data, Size(100, 100))
     }
 
     @Test
@@ -172,8 +172,8 @@ class RealImageLoaderAndroidTest {
     @Test
     fun assetUri() {
         val data = "$SCHEME_FILE:///$ASSET_FILE_PATH_ROOT/exif/large_metadata.jpg".toUri()
-        testEnqueue(data, PixelSize(75, 100))
-        testExecute(data, PixelSize(75, 100))
+        testEnqueue(data, Size(75, 100))
+        testExecute(data, Size(75, 100))
     }
 
     @Test
@@ -186,7 +186,7 @@ class RealImageLoaderAndroidTest {
     @Test
     fun drawable() {
         val data = context.getDrawableCompat(R.drawable.normal)
-        val expectedSize = PixelSize(1080, 1350)
+        val expectedSize = Size(1080, 1350)
         testEnqueue(data, expectedSize)
         testExecute(data, expectedSize)
     }
@@ -194,7 +194,7 @@ class RealImageLoaderAndroidTest {
     @Test
     fun bitmap() {
         val data = (context.getDrawableCompat(R.drawable.normal) as BitmapDrawable).bitmap
-        val expectedSize = PixelSize(1080, 1350)
+        val expectedSize = Size(1080, 1350)
         testEnqueue(data, expectedSize)
         testExecute(data, expectedSize)
     }
@@ -489,7 +489,7 @@ class RealImageLoaderAndroidTest {
         assertNull(result.diskCacheKey)
     }
 
-    private fun testEnqueue(data: Any, expectedSize: PixelSize = PixelSize(80, 100)) {
+    private fun testEnqueue(data: Any, expectedSize: Size = Size(80, 100)) {
         val imageView = activityRule.scenario.activity.imageView
         imageView.scaleType = ImageView.ScaleType.FIT_CENTER
 
@@ -516,7 +516,7 @@ class RealImageLoaderAndroidTest {
         assertEquals(expectedSize, drawable.bitmap.size)
     }
 
-    private fun testExecute(data: Any, expectedSize: PixelSize = PixelSize(80, 100)) {
+    private fun testExecute(data: Any, expectedSize: Size = Size(80, 100)) {
         val result = runBlocking {
             val request = ImageRequest.Builder(context)
                 .data(data)

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -9,8 +9,6 @@ import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
 import coil.size
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Scale
 import coil.size.Size
 import coil.util.assertIsSimilarTo
@@ -42,12 +40,12 @@ class BitmapFactoryDecoderTest {
     fun basic() {
         val (drawable, isSampled) = decode(
             assetName = "normal.jpg",
-            size = PixelSize(100, 100)
+            size = Size(100, 100)
         )
 
         assertTrue(isSampled)
         assertTrue(drawable is BitmapDrawable)
-        assertEquals(PixelSize(100, 125), drawable.bitmap.size)
+        assertEquals(Size(100, 125), drawable.bitmap.size)
         assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
     }
 
@@ -56,7 +54,7 @@ class BitmapFactoryDecoderTest {
         assertFailsWith<IllegalStateException> {
             decode(
                 assetName = "malformed.jpg",
-                size = PixelSize(100, 100)
+                size = Size(100, 100)
             )
         }
     }
@@ -65,24 +63,24 @@ class BitmapFactoryDecoderTest {
     fun resultIsSampledIfGreaterThanHalfSize() {
         val (drawable, isSampled) = decode(
             assetName = "normal.jpg",
-            size = PixelSize(600, 600)
+            size = Size(600, 600)
         )
 
         assertTrue(isSampled)
         assertTrue(drawable is BitmapDrawable)
-        assertEquals(PixelSize(600, 750), drawable.bitmap.size)
+        assertEquals(Size(600, 750), drawable.bitmap.size)
     }
 
     @Test
     fun originalSizeDimensionsAreResolvedCorrectly() {
-        val size = OriginalSize
+        val size = Size.ORIGINAL
         val normal = decodeBitmap("normal.jpg", size)
-        assertEquals(PixelSize(1080, 1350), normal.size)
+        assertEquals(Size(1080, 1350), normal.size)
     }
 
     @Test
     fun exifTransformationsAreAppliedCorrectly() {
-        val size = PixelSize(500, 500)
+        val size = Size(500, 500)
         val normal = decodeBitmap("normal.jpg", size)
 
         for (index in 1..8) {
@@ -93,7 +91,7 @@ class BitmapFactoryDecoderTest {
 
     @Test
     fun largeExifMetadata() {
-        val size = PixelSize(500, 500)
+        val size = Size(500, 500)
         val expected = decodeBitmap("exif/large_metadata_normalized.jpg", size)
         val actual = decodeBitmap("exif/large_metadata.jpg", size)
         expected.assertIsSimilarTo(actual)
@@ -107,7 +105,7 @@ class BitmapFactoryDecoderTest {
 
         // Ensure this completes and doesn't end up in an infinite loop.
         val normal = context.decodeBitmapAsset("exif/basic.heic")
-        val actual = decodeBitmap("exif/basic.heic", OriginalSize)
+        val actual = decodeBitmap("exif/basic.heic", Size.ORIGINAL)
         normal.assertIsSimilarTo(actual)
     }
 
@@ -117,12 +115,12 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             options = Options(
                 context = context,
-                size = PixelSize(1500, 1500),
+                size = Size(1500, 1500),
                 scale = Scale.FIT,
                 allowInexactSize = true
             )
         )
-        assertEquals(PixelSize(1080, 1350), result.size)
+        assertEquals(Size(1080, 1350), result.size)
     }
 
     @Test
@@ -131,12 +129,12 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             options = Options(
                 context = context,
-                size = PixelSize(1500, 1500),
+                size = Size(1500, 1500),
                 scale = Scale.FIT,
                 allowInexactSize = false
             )
         )
-        assertEquals(PixelSize(1200, 1500), result.size)
+        assertEquals(Size(1200, 1500), result.size)
     }
 
     @Test
@@ -145,12 +143,12 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             options = Options(
                 context = context,
-                size = PixelSize(500, 500),
+                size = Size(500, 500),
                 scale = Scale.FILL,
                 allowRgb565 = true
             )
         )
-        assertEquals(PixelSize(500, 625), result.size)
+        assertEquals(Size(500, 625), result.size)
         assertEquals(Bitmap.Config.RGB_565, result.config)
     }
 
@@ -160,12 +158,12 @@ class BitmapFactoryDecoderTest {
             assetName = "normal.jpg",
             options = Options(
                 context = context,
-                size = PixelSize(500, 500),
+                size = Size(500, 500),
                 scale = Scale.FILL,
                 allowRgb565 = false
             )
         )
-        assertEquals(PixelSize(500, 625), result.size)
+        assertEquals(Size(500, 625), result.size)
         assertEquals(Bitmap.Config.ARGB_8888, result.config)
     }
 
@@ -175,12 +173,12 @@ class BitmapFactoryDecoderTest {
             assetName = "normal_alpha.png",
             options = Options(
                 context = context,
-                size = PixelSize(400, 200),
+                size = Size(400, 200),
                 scale = Scale.FILL,
                 premultipliedAlpha = true
             )
         )
-        assertEquals(PixelSize(400, 200), result.size)
+        assertEquals(Size(400, 200), result.size)
         assertTrue(result.isPremultiplied)
     }
 
@@ -190,19 +188,19 @@ class BitmapFactoryDecoderTest {
             assetName = "normal_alpha.png",
             options = Options(
                 context = context,
-                size = PixelSize(400, 200),
+                size = Size(400, 200),
                 scale = Scale.FILL,
                 premultipliedAlpha = false
             )
         )
-        assertEquals(PixelSize(400, 200), result.size)
+        assertEquals(Size(400, 200), result.size)
         assertFalse(result.isPremultiplied)
     }
 
     @Test
     fun lossyWebP() {
-        val expected = decodeBitmap("normal.jpg", PixelSize(450, 675))
-        decodeBitmap("lossy.webp", PixelSize(450, 675)).assertIsSimilarTo(expected)
+        val expected = decodeBitmap("normal.jpg", Size(450, 675))
+        decodeBitmap("lossy.webp", Size(450, 675)).assertIsSimilarTo(expected)
     }
 
     @Test
@@ -210,11 +208,11 @@ class BitmapFactoryDecoderTest {
         // The emulator runs out of memory on pre-23.
         assumeTrue(SDK_INT >= 23)
 
-        val (drawable, isSampled) = decode("16_bit.png", PixelSize(250, 250))
+        val (drawable, isSampled) = decode("16_bit.png", Size(250, 250))
 
         assertTrue(isSampled)
         assertTrue(drawable is BitmapDrawable)
-        assertEquals(PixelSize(250, 250), drawable.bitmap.size)
+        assertEquals(Size(250, 250), drawable.bitmap.size)
 
         val expectedConfig = if (SDK_INT >= 26) Bitmap.Config.RGBA_F16 else Bitmap.Config.ARGB_8888
         assertEquals(expectedConfig, drawable.bitmap.config)
@@ -222,19 +220,19 @@ class BitmapFactoryDecoderTest {
 
     @Test
     fun largeJpeg() {
-        decodeBitmap("large.jpg", PixelSize(1080, 1920))
+        decodeBitmap("large.jpg", Size(1080, 1920))
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/368 */
     @Test
     fun largePng() {
         // Ensure that this doesn't cause an OOM exception - particularly on API 23 and below.
-        decodeBitmap("large.png", PixelSize(1080, 1920))
+        decodeBitmap("large.png", Size(1080, 1920))
     }
 
     @Test
     fun largeWebP() {
-        decodeBitmap("large.webp", PixelSize(1080, 1920))
+        decodeBitmap("large.webp", Size(1080, 1920))
     }
 
     @Test
@@ -242,7 +240,7 @@ class BitmapFactoryDecoderTest {
         // HEIC files are not supported before API 30.
         assumeTrue(SDK_INT >= 30)
 
-        decodeBitmap("large.heic", PixelSize(1080, 1920))
+        decodeBitmap("large.heic", Size(1080, 1920))
     }
 
     private fun decodeBitmap(assetName: String, size: Size): Bitmap =

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -9,6 +9,7 @@ import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
 import coil.size
+import coil.size.Dimension
 import coil.size.Scale
 import coil.size.Size
 import coil.util.assertIsSimilarTo
@@ -23,6 +24,7 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class BitmapFactoryDecoderTest {
@@ -44,7 +46,35 @@ class BitmapFactoryDecoderTest {
         )
 
         assertTrue(isSampled)
-        assertTrue(drawable is BitmapDrawable)
+        assertIs<BitmapDrawable>(drawable)
+        assertEquals(Size(100, 125), drawable.bitmap.size)
+        assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
+    }
+
+    @Test
+    fun unboundedWidth() {
+        val (drawable, isSampled) = decode(
+            assetName = "normal.jpg",
+            size = Size(Dimension.Original, Dimension(100)),
+            scale = Scale.FIT
+        )
+
+        assertTrue(isSampled)
+        assertIs<BitmapDrawable>(drawable)
+        assertEquals(Size(80, 100), drawable.bitmap.size)
+        assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
+    }
+
+    @Test
+    fun unboundedHeight() {
+        val (drawable, isSampled) = decode(
+            assetName = "normal.jpg",
+            size = Size(Dimension(100), Dimension.Original),
+            scale = Scale.FIT
+        )
+
+        assertTrue(isSampled)
+        assertIs<BitmapDrawable>(drawable)
         assertEquals(Size(100, 125), drawable.bitmap.size)
         assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
     }
@@ -67,7 +97,7 @@ class BitmapFactoryDecoderTest {
         )
 
         assertTrue(isSampled)
-        assertTrue(drawable is BitmapDrawable)
+        assertIs<BitmapDrawable>(drawable)
         assertEquals(Size(600, 750), drawable.bitmap.size)
     }
 
@@ -211,7 +241,7 @@ class BitmapFactoryDecoderTest {
         val (drawable, isSampled) = decode("16_bit.png", Size(250, 250))
 
         assertTrue(isSampled)
-        assertTrue(drawable is BitmapDrawable)
+        assertIs<BitmapDrawable>(drawable)
         assertEquals(Size(250, 250), drawable.bitmap.size)
 
         val expectedConfig = if (SDK_INT >= 26) Bitmap.Config.RGBA_F16 else Bitmap.Config.ARGB_8888
@@ -249,8 +279,8 @@ class BitmapFactoryDecoderTest {
     private fun decodeBitmap(assetName: String, options: Options): Bitmap =
         (decode(assetName, options).drawable as BitmapDrawable).bitmap
 
-    private fun decode(assetName: String, size: Size): DecodeResult =
-        decode(assetName, Options(context = context, size = size, scale = Scale.FILL))
+    private fun decode(assetName: String, size: Size, scale: Scale = Scale.FILL): DecodeResult =
+        decode(assetName, Options(context = context, size = size, scale = scale))
 
     private fun decode(assetName: String, options: Options): DecodeResult = runBlocking {
         val source = context.assets.open(assetName).source().buffer()

--- a/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/FileFetcherTest.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.request.Options
-import coil.size.PixelSize
+import coil.size.Size
 import coil.util.copyAssetToFile
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -25,7 +25,7 @@ class FileFetcherTest {
     @Test
     fun basic() {
         val file = context.copyAssetToFile("normal.jpg")
-        val options = Options(context, size = PixelSize(100, 100))
+        val options = Options(context, size = Size(100, 100))
         val fetcher = FileFetcher.Factory().create(file, options, ImageLoader(context))
 
         assertNotNull(fetcher)

--- a/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
+++ b/coil-base/src/androidTest/java/coil/fetch/ResourceUriFetcherTest.kt
@@ -12,8 +12,7 @@ import coil.base.test.R
 import coil.map.ResourceIntMapper
 import coil.map.ResourceUriMapper
 import coil.request.Options
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Size
 import coil.util.assertIsSimilarTo
 import coil.util.assumeTrue
 import coil.util.getDrawableCompat
@@ -40,7 +39,7 @@ class ResourceUriFetcherTest {
     @Test
     fun rasterDrawable() {
         val uri = "$SCHEME_ANDROID_RESOURCE://${context.packageName}/${R.drawable.normal}".toUri()
-        val options = Options(context, size = PixelSize(100, 100))
+        val options = Options(context, size = Size(100, 100))
 
         val result = runBlocking {
             fetcherFactory.create(uri, options, ImageLoader(context))?.fetch()
@@ -54,7 +53,7 @@ class ResourceUriFetcherTest {
     @Test
     fun vectorDrawable() {
         val uri = "$SCHEME_ANDROID_RESOURCE://${context.packageName}/${R.drawable.ic_android}".toUri()
-        val options = Options(context, size = PixelSize(100, 100))
+        val options = Options(context, size = Size(100, 100))
 
         val result = runBlocking {
             fetcherFactory.create(uri, options, ImageLoader(context))?.fetch()
@@ -70,7 +69,7 @@ class ResourceUriFetcherTest {
         // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable-xhdpi
         val resource = if (SDK_INT >= 23) "msg_bubble_incoming" else "ic_power_system"
         val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/$resource".toUri()
-        val options = Options(context, size = PixelSize(100, 100))
+        val options = Options(context, size = Size(100, 100))
         val uri = assertNotNull(ResourceUriMapper().map(rawUri, options))
 
         val result = runBlocking {
@@ -89,7 +88,7 @@ class ResourceUriFetcherTest {
 
         // https://android.googlesource.com/platform/packages/apps/Settings/+/master/res/drawable/ic_cancel.xml
         val rawUri = "$SCHEME_ANDROID_RESOURCE://com.android.settings/drawable/ic_cancel".toUri()
-        val options = Options(context, size = PixelSize(100, 100))
+        val options = Options(context, size = Size(100, 100))
         val uri = assertNotNull(ResourceUriMapper().map(rawUri, options))
 
         val result = runBlocking {
@@ -105,7 +104,7 @@ class ResourceUriFetcherTest {
     @Test
     fun colorAttributeIsApplied() = withTestActivity { activity ->
         val imageLoader = ImageLoader(context) // Intentionally use the application context.
-        val options = Options(context = activity, size = OriginalSize)
+        val options = Options(context = activity, size = Size.ORIGINAL)
         val result = runBlocking {
             val uri = assertNotNull(ResourceIntMapper().map(R.drawable.ic_tinted_vector, options))
             fetcherFactory.create(uri, options, imageLoader)?.fetch()

--- a/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
+++ b/coil-base/src/androidTest/java/coil/transform/CircleCropTransformationTest.kt
@@ -2,7 +2,7 @@ package coil.transform
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import coil.size.OriginalSize
+import coil.size.Size
 import coil.util.assertIsSimilarTo
 import coil.util.decodeBitmapAsset
 import kotlinx.coroutines.runBlocking
@@ -26,7 +26,7 @@ class CircleCropTransformationTest {
         val expected = context.decodeBitmapAsset("normal_small_circle.png")
 
         val actual = runBlocking {
-            transformation.transform(input, OriginalSize)
+            transformation.transform(input, Size.ORIGINAL)
         }
 
         actual.assertIsSimilarTo(expected)

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -12,7 +12,7 @@ import androidx.exifinterface.media.ExifInterface
 import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import coil.util.toDrawable
 import coil.util.toSoftware
 import kotlinx.coroutines.runInterruptible
@@ -88,8 +88,8 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
             }
             else -> {
                 val (width, height) = options.size
-                val dstWidth = width.pixelsOrElse { srcWidth }
-                val dstHeight = height.pixelsOrElse { srcHeight }
+                val dstWidth = width.pxOrElse { srcWidth }
+                val dstHeight = height.pxOrElse { srcHeight }
                 inSampleSize = DecodeUtils.calculateInSampleSize(
                     srcWidth = srcWidth,
                     srcHeight = srcHeight,

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -15,7 +15,6 @@ import coil.request.Options
 import coil.size.pixelsOrElse
 import coil.util.toDrawable
 import coil.util.toSoftware
-import java.io.InputStream
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -23,6 +22,7 @@ import okio.Buffer
 import okio.ForwardingSource
 import okio.Source
 import okio.buffer
+import java.io.InputStream
 import kotlin.math.roundToInt
 
 /** The base [Decoder] that uses [BitmapFactory] to decode a given [ImageSource]. */

--- a/coil-base/src/main/java/coil/decode/DecodeUtils.kt
+++ b/coil-base/src/main/java/coil/decode/DecodeUtils.kt
@@ -2,16 +2,12 @@ package coil.decode
 
 import android.graphics.BitmapFactory
 import androidx.annotation.Px
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Scale
-import coil.size.Size
 import okio.BufferedSource
 import okio.ByteString.Companion.encodeUtf8
 import kotlin.experimental.and
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.roundToInt
 
 /** A collection of useful utility methods for decoding images. */
 object DecodeUtils {
@@ -138,37 +134,6 @@ object DecodeUtils {
         return when (scale) {
             Scale.FILL -> max(widthPercent, heightPercent)
             Scale.FIT -> min(widthPercent, heightPercent)
-        }
-    }
-
-    /**
-     * Calculate the pixel size required to fit/fill the source dimensions inside the
-     * destination size while preserving aspect ratio.
-     */
-    @JvmStatic
-    fun computePixelSize(
-        srcWidth: Int,
-        srcHeight: Int,
-        dstSize: Size,
-        scale: Scale
-    ): PixelSize {
-        return when (dstSize) {
-            is OriginalSize -> {
-                PixelSize(srcWidth, srcHeight)
-            }
-            is PixelSize -> {
-                val multiplier = computeSizeMultiplier(
-                    srcWidth = srcWidth,
-                    srcHeight = srcHeight,
-                    dstWidth = dstSize.width,
-                    dstHeight = dstSize.height,
-                    scale = scale
-                )
-                PixelSize(
-                    width = (multiplier * srcWidth).roundToInt(),
-                    height = (multiplier * srcHeight).roundToInt()
-                )
-            }
         }
     }
 }

--- a/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
@@ -14,7 +14,7 @@ import coil.ImageLoader
 import coil.decode.DataSource
 import coil.decode.ImageSource
 import coil.request.Options
-import coil.size.PixelSize
+import coil.size.Dimension
 import okio.buffer
 import okio.source
 
@@ -74,7 +74,8 @@ internal class ContentUriFetcher(
     }
 
     private fun newMusicThumbnailSizeOptions(): Bundle? {
-        val (width, height) = options.size as? PixelSize ?: return null
+        val width = (options.size.width as? Dimension.Pixels)?.pixels ?: return null
+        val height = (options.size.height as? Dimension.Pixels)?.pixels ?: return null
         return Bundle(1).apply { putParcelable(EXTRA_SIZE, Point(width, height)) }
     }
 

--- a/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ContentUriFetcher.kt
@@ -74,8 +74,8 @@ internal class ContentUriFetcher(
     }
 
     private fun newMusicThumbnailSizeOptions(): Bundle? {
-        val width = (options.size.width as? Dimension.Pixels)?.pixels ?: return null
-        val height = (options.size.height as? Dimension.Pixels)?.pixels ?: return null
+        val width = (options.size.width as? Dimension.Pixels)?.px ?: return null
+        val height = (options.size.height as? Dimension.Pixels)?.px ?: return null
         return Bundle(1).apply { putParcelable(EXTRA_SIZE, Point(width, height)) }
     }
 

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -25,7 +25,7 @@ import coil.request.SuccessResult
 import coil.size.Dimension
 import coil.size.Size
 import coil.size.isOriginal
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import coil.transform.Transformation
 import coil.util.DrawableUtils
 import coil.util.Logger
@@ -36,9 +36,9 @@ import coil.util.closeQuietly
 import coil.util.foldIndices
 import coil.util.forEachIndices
 import coil.util.log
-import coil.util.pixelsString
 import coil.util.safeConfig
 import coil.util.toDrawable
+import coil.util.valueString
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -139,8 +139,8 @@ internal class EngineInterceptor(
             extras[MEMORY_CACHE_KEY_TRANSFORMATIONS] = transformations.toString()
 
             val size = options.size
-            if (size.width is Dimension.Pixels) extras[MEMORY_CACHE_KEY_WIDTH] = size.width.pixels.toString()
-            if (size.height is Dimension.Pixels) extras[MEMORY_CACHE_KEY_HEIGHT] = size.height.pixels.toString()
+            if (size.width is Dimension.Pixels) extras[MEMORY_CACHE_KEY_WIDTH] = size.width.px.toString()
+            if (size.height is Dimension.Pixels) extras[MEMORY_CACHE_KEY_HEIGHT] = size.height.px.toString()
         }
         return MemoryCache.Key(base, extras)
     }
@@ -189,8 +189,8 @@ internal class EngineInterceptor(
             else -> {
                 val cachedWidth = cacheKey.extras[MEMORY_CACHE_KEY_WIDTH]?.toInt() ?: cacheValue.bitmap.width
                 val cachedHeight = cacheKey.extras[MEMORY_CACHE_KEY_HEIGHT]?.toInt() ?: cacheValue.bitmap.height
-                val dstWidth = size.width.pixelsOrElse { cachedWidth }
-                val dstHeight = size.height.pixelsOrElse { cachedHeight }
+                val dstWidth = size.width.pxOrElse { cachedWidth }
+                val dstHeight = size.height.pxOrElse { cachedHeight }
                 val multiple = DecodeUtils.computeSizeMultiplier(
                     srcWidth = cachedWidth,
                     srcHeight = cachedHeight,
@@ -219,7 +219,7 @@ internal class EngineInterceptor(
                     logger?.log(TAG, Log.DEBUG) {
                         "${request.data}: Cached image's request size " +
                             "($cachedWidth, $cachedHeight) does not exactly match the requested size " +
-                            "(${size.width.pixelsString()}, ${size.height.pixelsString()}, ${request.scale})."
+                            "(${size.width.valueString()}, ${size.height.valueString()}, ${request.scale})."
                     }
                     return false
                 }
@@ -227,7 +227,7 @@ internal class EngineInterceptor(
                     logger?.log(TAG, Log.DEBUG) {
                         "${request.data}: Cached image's request size " +
                             "($cachedWidth, $cachedHeight) is smaller than the requested size " +
-                            "(${size.width.pixelsString()}, ${size.height.pixelsString()}, ${request.scale})."
+                            "(${size.width.valueString()}, ${size.height.valueString()}, ${request.scale})."
                     }
                     return false
                 }

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -44,11 +44,11 @@ import coil.util.getLifecycle
 import coil.util.orEmpty
 import coil.util.scale
 import coil.util.unsupported
-import java.io.File
-import java.nio.ByteBuffer
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import java.io.File
+import java.nio.ByteBuffer
 
 /**
  * An immutable value object that represents a request for an image.

--- a/coil-base/src/main/java/coil/request/ImageRequest.kt
+++ b/coil-base/src/main/java/coil/request/ImageRequest.kt
@@ -25,8 +25,7 @@ import coil.drawable.CrossfadeDrawable
 import coil.fetch.Fetcher
 import coil.memory.MemoryCache
 import coil.request.ImageRequest.Builder
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Dimension
 import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
@@ -45,11 +44,11 @@ import coil.util.getLifecycle
 import coil.util.orEmpty
 import coil.util.scale
 import coil.util.unsupported
+import java.io.File
+import java.nio.ByteBuffer
 import kotlinx.coroutines.CoroutineDispatcher
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import java.io.File
-import java.nio.ByteBuffer
 
 /**
  * An immutable value object that represents a request for an image.
@@ -575,7 +574,12 @@ class ImageRequest private constructor(
         /**
          * Set the requested width/height.
          */
-        fun size(@Px width: Int, @Px height: Int) = size(PixelSize(width, height))
+        fun size(@Px width: Int, @Px height: Int) = size(Size(width, height))
+
+        /**
+         * Set the requested width/height.
+         */
+        fun size(width: Dimension, height: Dimension) = size(Size(width, height))
 
         /**
          * Set the requested width/height.
@@ -606,7 +610,7 @@ class ImageRequest private constructor(
          * The default value is [Precision.AUTOMATIC], which uses the logic in [allowInexactSize]
          * to determine if output image's dimensions must match the input [size] and [scale] exactly.
          *
-         * NOTE: If [size] is [OriginalSize], the returned image's size will always be equal to or
+         * NOTE: If [size] is [Size.ORIGINAL], the returned image's size will always be equal to or
          * greater than the image's original size.
          *
          * @see Precision
@@ -978,7 +982,7 @@ class ImageRequest private constructor(
                     return ViewSizeResolver(view)
                 }
             }
-            return SizeResolver(OriginalSize)
+            return SizeResolver(Size.ORIGINAL)
         }
 
         private fun resolveScale(): Scale {

--- a/coil-base/src/main/java/coil/request/Options.kt
+++ b/coil-base/src/main/java/coil/request/Options.kt
@@ -7,7 +7,6 @@ import android.os.Build.VERSION.SDK_INT
 import coil.decode.BitmapFactoryDecoder
 import coil.decode.Decoder
 import coil.fetch.Fetcher
-import coil.size.OriginalSize
 import coil.size.Scale
 import coil.size.Size
 import coil.util.EMPTY_HEADERS
@@ -38,7 +37,7 @@ class Options(
     /**
      * The requested output size for the image request.
      */
-    val size: Size = OriginalSize,
+    val size: Size = Size.ORIGINAL,
 
     /**
      * The scaling algorithm for how to fit the source image's dimensions into the target's

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -35,7 +35,9 @@ sealed class Dimension {
      * i.e. if the image's original dimensions are 400x600 and this is used as the width, this
      * should be treated as 400 pixels.
      */
-    object Original : Dimension()
+    object Original : Dimension() {
+        override fun toString() = "Dimension.Original"
+    }
 }
 
 /**

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -16,7 +16,7 @@ sealed class Dimension {
     data class Pixels(@Px val pixels: Int) : Dimension() {
 
         init {
-            require(pixels > 0) { "value must be > 0." }
+            require(pixels > 0) { "pixels must be > 0." }
         }
     }
 

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -1,0 +1,44 @@
+@file:JvmName("Dimensions")
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE")
+
+package coil.size
+
+import androidx.annotation.Px
+
+/**
+ * Represents either the width or height of a [Size].
+ */
+sealed class Dimension {
+
+    /**
+     * Represents a fixed, positive number of pixels.
+     */
+    data class Pixels(@Px val pixels: Int) : Dimension() {
+
+        init {
+            require(pixels > 0) { "value must be > 0." }
+        }
+    }
+
+    /**
+     * Represents the original value of the source image.
+     *
+     * i.e. if the image's original dimensions are 400x600 and this is used as the width, this
+     * should be treated as 400 pixels.
+     */
+    object Original : Dimension()
+}
+
+/**
+ * Convenience function to create a [Dimension.Pixels].
+ */
+@JvmName("create")
+inline fun Dimension(@Px pixels: Int) = Dimension.Pixels(pixels)
+
+/**
+ * If this is a [Dimension.Pixels] value, return its number of pixels. Else, invoke and return
+ * the value from [block].
+ */
+inline fun Dimension.pixelsOrElse(block: () -> Int): Int {
+    return if (this is Dimension.Pixels) pixels else block()
+}

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -16,7 +16,7 @@ sealed class Dimension {
     class Pixels(@JvmField @Px val px: Int) : Dimension() {
 
         init {
-            require(px > 0) { "value must be > 0." }
+            require(px > 0) { "px must be > 0." }
         }
 
         override fun equals(other: Any?): Boolean {

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -13,11 +13,20 @@ sealed class Dimension {
     /**
      * Represents a fixed, positive number of pixels.
      */
-    data class Pixels(@Px val pixels: Int) : Dimension() {
+    class Pixels(@JvmField @Px val px: Int) : Dimension() {
 
         init {
-            require(pixels > 0) { "pixels must be > 0." }
+            require(px > 0) { "value must be > 0." }
         }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return other is Pixels && px == other.px
+        }
+
+        override fun hashCode() = px
+
+        override fun toString() = "Dimension.Pixels(px=$px)"
     }
 
     /**
@@ -39,6 +48,6 @@ inline fun Dimension(@Px pixels: Int) = Dimension.Pixels(pixels)
  * If this is a [Dimension.Pixels] value, return its number of pixels. Else, invoke and return
  * the value from [block].
  */
-inline fun Dimension.pixelsOrElse(block: () -> Int): Int {
-    return if (this is Dimension.Pixels) pixels else block()
+inline fun Dimension.pxOrElse(block: () -> Int): Int {
+    return if (this is Dimension.Pixels) px else block()
 }

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -54,6 +54,5 @@ inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
     message = "Migrate to 'coil.size.Size.ORIGINAL'.",
     replaceWith = ReplaceWith("Size.ORIGINAL", "coil.size.Size")
 )
-
 inline val OriginalSize: Size
     @JvmName("OriginalSize") get() = Size.ORIGINAL

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -47,11 +47,13 @@ typealias PixelSize = Size
     message = "Migrate to 'coil.size.Size'.",
     replaceWith = ReplaceWith("Size(width, height)", "coil.size.Size")
 )
-@JvmName("createDeprecated")
+@JvmName("PixelSize")
 inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
 
 @Deprecated(
     message = "Migrate to 'coil.size.Size.ORIGINAL'.",
     replaceWith = ReplaceWith("Size.ORIGINAL", "coil.size.Size")
 )
-inline val OriginalSize get() = Size.ORIGINAL
+
+inline val OriginalSize: Size
+    @JvmName("OriginalSize") get() = Size.ORIGINAL

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -1,5 +1,5 @@
 @file:JvmName("Sizes")
-@file:Suppress("FunctionName", "NOTHING_TO_INLINE")
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE", "unused")
 
 package coil.size
 

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -1,3 +1,6 @@
+@file:JvmName("Sizes")
+@file:Suppress("FunctionName", "NOTHING_TO_INLINE")
+
 package coil.size
 
 import androidx.annotation.Px
@@ -9,20 +12,46 @@ import coil.request.ImageRequest
  * @see ImageRequest.Builder.size
  * @see SizeResolver.size
  */
-sealed class Size
+data class Size(
+    val width: Dimension,
+    val height: Dimension,
+) {
 
-/** Represents the width and height of the source image. */
-object OriginalSize : Size() {
-    override fun toString() = "coil.size.OriginalSize"
-}
-
-/** A positive width and height in pixels. */
-data class PixelSize(
-    @Px val width: Int,
-    @Px val height: Int,
-) : Size() {
-
-    init {
-        require(width > 0 && height > 0) { "width and height must be > 0." }
+    companion object {
+        /**
+         * A [Size] whose width and height are equal to the original dimensions of the source image.
+         */
+        @JvmField val ORIGINAL = Size(Dimension.Original, Dimension.Original)
     }
 }
+
+/**
+ * Create a [Size] with pixel values for both width and height.
+ */
+@JvmName("create")
+fun Size(@Px width: Int, @Px height: Int) = Size(Dimension(width), Dimension(height))
+
+/**
+ * Return true if this size is equal to [Size.ORIGINAL]. Else, return false.
+ */
+val Size.isOriginal: Boolean
+    get() = this == Size.ORIGINAL
+
+@Deprecated(
+    message = "Migrate to 'coil.size.Size'.",
+    replaceWith = ReplaceWith("Size", "coil.size.Size")
+)
+typealias PixelSize = Size
+
+@Deprecated(
+    message = "Migrate to 'coil.size.Size'.",
+    replaceWith = ReplaceWith("Size(width, height)", "coil.size.Size")
+)
+@JvmName("createDeprecated")
+inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
+
+@Deprecated(
+    message = "Migrate to 'coil.size.Size.ORIGINAL'.",
+    replaceWith = ReplaceWith("Size.ORIGINAL", "coil.size.Size")
+)
+inline val OriginalSize get() = Size.ORIGINAL

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -64,56 +64,44 @@ interface ViewSizeResolver<T : View> : SizeResolver {
         }
     }
 
-    private fun getSize(): PixelSize? {
-        val width = getWidth().also { if (it <= 0) return null }
-        val height = getHeight().also { if (it <= 0) return null }
-        return PixelSize(width, height)
+    private fun getSize(): Size? {
+        val width = getWidth() ?: return null
+        val height = getHeight() ?: return null
+        return Size(width, height)
     }
 
-    private fun getWidth(): Int {
-        return getDimension(
-            paramSize = view.layoutParams?.width ?: -1,
-            viewSize = view.width,
-            paddingSize = if (subtractPadding) view.paddingLeft + view.paddingRight else 0,
-            isWidth = true
-        )
-    }
+    private fun getWidth() = getDimension(
+        paramSize = view.layoutParams?.width ?: -1,
+        viewSize = view.width,
+        paddingSize = if (subtractPadding) view.paddingLeft + view.paddingRight else 0
+    )
 
-    private fun getHeight(): Int {
-        return getDimension(
-            paramSize = view.layoutParams?.height ?: -1,
-            viewSize = view.height,
-            paddingSize = if (subtractPadding) view.paddingTop + view.paddingBottom else 0,
-            isWidth = false
-        )
-    }
+    private fun getHeight() = getDimension(
+        paramSize = view.layoutParams?.height ?: -1,
+        viewSize = view.height,
+        paddingSize = if (subtractPadding) view.paddingTop + view.paddingBottom else 0
+    )
 
-    private fun getDimension(
-        paramSize: Int,
-        viewSize: Int,
-        paddingSize: Int,
-        isWidth: Boolean
-    ): Int {
+    private fun getDimension(paramSize: Int, viewSize: Int, paddingSize: Int): Dimension? {
         // Assume the dimension will match the value in the view's layout params.
         val insetParamSize = paramSize - paddingSize
         if (insetParamSize > 0) {
-            return insetParamSize
+            return Dimension(insetParamSize)
         }
 
         // Fallback to the view's current size.
         val insetViewSize = viewSize - paddingSize
         if (insetViewSize > 0) {
-            return insetViewSize
+            return Dimension(insetViewSize)
         }
 
-        // If the dimension is set to WRAP_CONTENT, fall back to the size of the display.
+        // If the dimension is set to WRAP_CONTENT, fall back to the original size of the image.
         if (paramSize == ViewGroup.LayoutParams.WRAP_CONTENT) {
-            return view.context.resources.displayMetrics
-                .run { if (isWidth) widthPixels else heightPixels }
+            return Dimension.Original
         }
 
         // Unable to resolve the dimension's size.
-        return -1
+        return null
     }
 
     private fun ViewTreeObserver.removePreDrawListenerSafe(victim: ViewTreeObserver.OnPreDrawListener) {

--- a/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
@@ -17,7 +17,7 @@ import androidx.core.graphics.createBitmap
 import coil.decode.DecodeUtils
 import coil.size.Scale
 import coil.size.Size
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import coil.util.safeConfig
 import kotlin.math.roundToInt
 
@@ -50,8 +50,8 @@ class RoundedCornersTransformation(
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
-        val dstWidth = size.width.pixelsOrElse { input.width }
-        val dstHeight = size.height.pixelsOrElse { input.height }
+        val dstWidth = size.width.pxOrElse { input.width }
+        val dstHeight = size.height.pxOrElse { input.height }
         val multiplier = DecodeUtils.computeSizeMultiplier(
             srcWidth = input.width,
             srcHeight = input.height,

--- a/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
+++ b/coil-base/src/main/java/coil/transform/RoundedCornersTransformation.kt
@@ -15,10 +15,9 @@ import androidx.annotation.Px
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import coil.decode.DecodeUtils
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Scale
 import coil.size.Size
+import coil.size.pixelsOrElse
 import coil.util.safeConfig
 import kotlin.math.roundToInt
 
@@ -51,25 +50,17 @@ class RoundedCornersTransformation(
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
         val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
-        val outputWidth: Int
-        val outputHeight: Int
-        when (size) {
-            is PixelSize -> {
-                val multiplier = DecodeUtils.computeSizeMultiplier(
-                    srcWidth = input.width,
-                    srcHeight = input.height,
-                    dstWidth = size.width,
-                    dstHeight = size.height,
-                    scale = Scale.FILL
-                )
-                outputWidth = (size.width / multiplier).roundToInt()
-                outputHeight = (size.height / multiplier).roundToInt()
-            }
-            is OriginalSize -> {
-                outputWidth = input.width
-                outputHeight = input.height
-            }
-        }
+        val dstWidth = size.width.pixelsOrElse { input.width }
+        val dstHeight = size.height.pixelsOrElse { input.height }
+        val multiplier = DecodeUtils.computeSizeMultiplier(
+            srcWidth = input.width,
+            srcHeight = input.height,
+            dstWidth = dstWidth,
+            dstHeight = dstHeight,
+            scale = Scale.FILL
+        )
+        val outputWidth = (dstWidth / multiplier).roundToInt()
+        val outputHeight = (dstHeight / multiplier).roundToInt()
 
         val output = createBitmap(outputWidth, outputHeight, input.safeConfig)
         output.applyCanvas {

--- a/coil-base/src/main/java/coil/util/DrawableUtils.kt
+++ b/coil-base/src/main/java/coil/util/DrawableUtils.kt
@@ -13,7 +13,7 @@ import androidx.core.graphics.createBitmap
 import coil.decode.DecodeUtils
 import coil.size.Scale
 import coil.size.Size
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import kotlin.math.roundToInt
 
 internal object DrawableUtils {
@@ -52,8 +52,8 @@ internal object DrawableUtils {
         val multiplier = DecodeUtils.computeSizeMultiplier(
             srcWidth = srcWidth,
             srcHeight = srcHeight,
-            dstWidth = size.width.pixelsOrElse { srcWidth },
-            dstHeight = size.height.pixelsOrElse { srcHeight },
+            dstWidth = size.width.pxOrElse { srcWidth },
+            dstHeight = size.height.pxOrElse { srcHeight },
             scale = scale
         )
         val bitmapWidth = (multiplier * srcWidth).roundToInt()
@@ -79,8 +79,8 @@ internal object DrawableUtils {
         val multiplier = DecodeUtils.computeSizeMultiplier(
             srcWidth = bitmap.width,
             srcHeight = bitmap.height,
-            dstWidth = size.width.pixelsOrElse { bitmap.width },
-            dstHeight = size.height.pixelsOrElse { bitmap.height },
+            dstWidth = size.width.pxOrElse { bitmap.width },
+            dstHeight = size.height.pxOrElse { bitmap.height },
             scale = scale
         )
         return multiplier == 1.0

--- a/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
+++ b/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
@@ -9,7 +9,7 @@ import android.os.SystemClock
 import android.util.Log
 import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
-import coil.size.PixelSize
+import coil.size.Dimension
 import coil.size.Size
 import java.io.File
 
@@ -43,9 +43,9 @@ private class LimitedFileDescriptorHardwareBitmapService(
     private val logger: Logger?
 ) : HardwareBitmapService() {
 
-    override fun allowHardwareMainThread(size: Size): Boolean {
-        return size !is PixelSize ||
-            (size.width >= MIN_SIZE_DIMENSION && size.height >= MIN_SIZE_DIMENSION)
+    override fun allowHardwareMainThread(size: Size) = with(size) {
+        (width !is Dimension.Pixels || width.pixels > MIN_SIZE_DIMENSION) &&
+            (height !is Dimension.Pixels || height.pixels > MIN_SIZE_DIMENSION)
     }
 
     override fun allowHardwareWorkerThread(): Boolean {

--- a/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
+++ b/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
@@ -44,8 +44,8 @@ private class LimitedFileDescriptorHardwareBitmapService(
 ) : HardwareBitmapService() {
 
     override fun allowHardwareMainThread(size: Size) = with(size) {
-        (width !is Dimension.Pixels || width.pixels > MIN_SIZE_DIMENSION) &&
-            (height !is Dimension.Pixels || height.pixels > MIN_SIZE_DIMENSION)
+        (width !is Dimension.Pixels || width.px > MIN_SIZE_DIMENSION) &&
+            (height !is Dimension.Pixels || height.px > MIN_SIZE_DIMENSION)
     }
 
     override fun allowHardwareWorkerThread(): Boolean {

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -34,15 +34,16 @@ import coil.memory.MemoryCache
 import coil.request.DefaultRequestOptions
 import coil.request.Parameters
 import coil.request.ViewTargetRequestManager
+import coil.size.Dimension
 import coil.size.Scale
 import coil.transform.Transformation
+import java.io.Closeable
+import java.io.File
+import java.util.Optional
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okhttp3.Headers
-import java.io.Closeable
-import java.io.File
-import java.util.Optional
 import kotlin.coroutines.CoroutineContext
 
 internal val View.requestManager: ViewTargetRequestManager
@@ -193,6 +194,10 @@ internal fun DiskCache.Editor.abortQuietly() {
     try {
         abort()
     } catch (_: Exception) {}
+}
+
+internal fun Dimension.pixelsString(): String {
+    return if (this is Dimension.Pixels) pixels.toString() else toString()
 }
 
 internal fun unsupported(): Nothing = error("Unsupported")

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -37,13 +37,13 @@ import coil.request.ViewTargetRequestManager
 import coil.size.Dimension
 import coil.size.Scale
 import coil.transform.Transformation
-import java.io.Closeable
-import java.io.File
-import java.util.Optional
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import okhttp3.Headers
+import java.io.Closeable
+import java.io.File
+import java.util.Optional
 import kotlin.coroutines.CoroutineContext
 
 internal val View.requestManager: ViewTargetRequestManager

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -196,8 +196,8 @@ internal fun DiskCache.Editor.abortQuietly() {
     } catch (_: Exception) {}
 }
 
-internal fun Dimension.pixelsString(): String {
-    return if (this is Dimension.Pixels) pixels.toString() else toString()
+internal fun Dimension.valueString(): String {
+    return if (this is Dimension.Pixels) px.toString() else toString()
 }
 
 internal fun unsupported(): Nothing = error("Unsupported")

--- a/coil-base/src/sharedTest/java/coil/SharedTestFunctions.kt
+++ b/coil-base/src/sharedTest/java/coil/SharedTestFunctions.kt
@@ -1,7 +1,7 @@
 package coil
 
 import android.graphics.Bitmap
-import coil.size.PixelSize
+import coil.size.Size
 
-val Bitmap.size: PixelSize
-    get() = PixelSize(width, height)
+val Bitmap.size: Size
+    get() = Size(width, height)

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -532,8 +532,8 @@ class EngineInterceptorTest {
                 put(MEMORY_CACHE_KEY_TRANSFORMATIONS, transformationString)
             }
             val (width, height) = size
-            if (width is Dimension.Pixels) put(MEMORY_CACHE_KEY_WIDTH, width.pixels.toString())
-            if (height is Dimension.Pixels) put(MEMORY_CACHE_KEY_HEIGHT, height.pixels.toString())
+            if (width is Dimension.Pixels) put(MEMORY_CACHE_KEY_WIDTH, width.px.toString())
+            if (height is Dimension.Pixels) put(MEMORY_CACHE_KEY_HEIGHT, height.px.toString())
             putAll(parameters.cacheKeys())
         }
         return Key(key, extras)

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -24,8 +24,7 @@ import coil.request.Options
 import coil.request.Parameters
 import coil.request.RequestService
 import coil.size
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Dimension
 import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
@@ -61,7 +60,7 @@ class EngineInterceptorTest {
     fun `computeMemoryCacheKey - null key`() {
         val interceptor = newInterceptor(key = null)
         val request = createRequest(context)
-        val options = Options(context, size = OriginalSize)
+        val options = Options(context, size = Size.ORIGINAL)
         val key = runBlocking {
             interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
         }
@@ -73,7 +72,7 @@ class EngineInterceptorTest {
     fun `computeMemoryCacheKey - simple key`() {
         val interceptor = newInterceptor()
         val request = createRequest(context)
-        val options = Options(context, size = OriginalSize)
+        val options = Options(context, size = Size.ORIGINAL)
         val actual = runBlocking {
             interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
         }
@@ -88,7 +87,7 @@ class EngineInterceptorTest {
         val request = createRequest(context) {
             parameters(parameters)
         }
-        val options = Options(context, size = OriginalSize)
+        val options = Options(context, size = Size.ORIGINAL)
         val actual = runBlocking {
             interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
         }
@@ -103,7 +102,7 @@ class EngineInterceptorTest {
         val request = createRequest(context) {
             transformations(transformations)
         }
-        val size = PixelSize(123, 332)
+        val size = Size(123, 332)
         val options = Options(context, size = size)
         val actual = runBlocking {
             interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
@@ -121,7 +120,7 @@ class EngineInterceptorTest {
             parameters(parameters)
             transformations(transformations)
         }
-        val options = Options(context, size = OriginalSize)
+        val options = Options(context, size = Size.ORIGINAL)
         val actual = runBlocking {
             interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
         }
@@ -142,37 +141,37 @@ class EngineInterceptorTest {
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(200, 200)
+            size = Size(200, 200)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(150, 50)
+            size = Size(150, 50)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(100, 100)
+            size = Size(100, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(50, 100)
+            size = Size(50, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(50, 50)
+            size = Size(50, 50)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 400, height = 200),
             isSampled = true,
             request = request,
-            size = PixelSize(400, 200)
+            size = Size(400, 200)
         ))
     }
 
@@ -189,37 +188,37 @@ class EngineInterceptorTest {
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(200, 200)
+            size = Size(200, 200)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(150, 50)
+            size = Size(150, 50)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(100, 100)
+            size = Size(100, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(50, 100)
+            size = Size(50, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = cached,
             isSampled = true,
             request = request,
-            size = PixelSize(50, 50)
+            size = Size(50, 50)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 200, height = 400),
             isSampled = true,
             request = request,
-            size = PixelSize(400, 800)
+            size = Size(400, 800)
         ))
     }
 
@@ -234,7 +233,7 @@ class EngineInterceptorTest {
                 precision(Precision.INEXACT)
                 scale(Scale.FILL)
             },
-            size = PixelSize(200, 200)
+            size = Size(200, 200)
         )
         assertTrue(isValid)
     }
@@ -251,7 +250,7 @@ class EngineInterceptorTest {
                     allowHardware(false)
                     scale(Scale.FILL)
                 },
-                size = PixelSize(100, 100)
+                size = Size(100, 100)
             )
         }
 
@@ -271,7 +270,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FILL)
             },
-            size = PixelSize(50, 50)
+            size = Size(50, 50)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -280,7 +279,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(50, 50)
+            size = Size(50, 50)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -289,7 +288,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FILL)
             },
-            size = PixelSize(100, 50)
+            size = Size(100, 50)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -298,7 +297,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(100, 50)
+            size = Size(100, 50)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -307,7 +306,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FILL)
             },
-            size = PixelSize(100, 100)
+            size = Size(100, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -316,7 +315,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(100, 100)
+            size = Size(100, 100)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 400, height = 200),
@@ -325,7 +324,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FILL)
             },
-            size = PixelSize(400, 200)
+            size = Size(400, 200)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 200, height = 400),
@@ -334,7 +333,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(400, 800)
+            size = Size(400, 800)
         ))
     }
 
@@ -348,7 +347,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(245, 600)
+            size = Size(245, 600)
         ))
         assertTrue(interceptor.isCachedValueValid(
             cached = createBitmap(width = 244, height = 600),
@@ -357,7 +356,7 @@ class EngineInterceptorTest {
                 precision(Precision.INEXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(245, 600)
+            size = Size(245, 600)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 243, height = 595),
@@ -366,7 +365,7 @@ class EngineInterceptorTest {
                 precision(Precision.EXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(245, 600)
+            size = Size(245, 600)
         ))
         assertFalse(interceptor.isCachedValueValid(
             cached = createBitmap(width = 243, height = 595),
@@ -375,7 +374,7 @@ class EngineInterceptorTest {
                 precision(Precision.INEXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(245, 600)
+            size = Size(245, 600)
         ))
         // Regression test: https://github.com/coil-kt/coil/issues/817
         assertTrue(interceptor.isCachedValueValid(
@@ -385,7 +384,7 @@ class EngineInterceptorTest {
                 precision(Precision.INEXACT)
                 scale(Scale.FIT)
             },
-            size = PixelSize(176, 176)
+            size = Size(176, 176)
         ))
     }
 
@@ -395,7 +394,7 @@ class EngineInterceptorTest {
         val key = newMemoryCacheKey(
             key = "key",
             transformations = listOf(CircleCropTransformation()),
-            size = PixelSize(1000, 500) // The size of the previous request.
+            size = Size(1000, 500) // The size of the previous request.
         )
         val value = Value(
             bitmap = createBitmap(width = 200, height = 200), // The small cached bitmap.
@@ -407,28 +406,28 @@ class EngineInterceptorTest {
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
-            size = PixelSize(650, 400)
+            size = Size(650, 400)
         ))
 
         assertTrue(interceptor.isCachedValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
-            size = PixelSize(1000, 500)
+            size = Size(1000, 500)
         ))
 
         assertFalse(interceptor.isCachedValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
-            size = PixelSize(1500, 1000)
+            size = Size(1500, 1000)
         ))
 
         assertFalse(interceptor.isCachedValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
-            size = PixelSize(800, 500)
+            size = Size(800, 500)
         ))
     }
 
@@ -443,7 +442,7 @@ class EngineInterceptorTest {
     fun `applyTransformations - transformations convert drawable to bitmap`() {
         val interceptor = newInterceptor()
         val drawable = ColorDrawable(Color.BLACK)
-        val size = PixelSize(100, 100)
+        val size = Size(100, 100)
         val result = runBlocking {
             interceptor.transform(
                 result = ExecuteResult(
@@ -476,7 +475,7 @@ class EngineInterceptorTest {
                     diskCacheKey = null
                 ),
                 request = createRequest(context) { transformations(emptyList()) },
-                options = Options(context, size = PixelSize(100, 100)),
+                options = Options(context, size = Size(100, 100)),
                 eventListener = EventListener.NONE
             )
         }
@@ -522,7 +521,7 @@ class EngineInterceptorTest {
     private fun newMemoryCacheKey(
         key: String = TEST_KEY,
         transformations: List<Transformation> = emptyList(),
-        size: Size = OriginalSize,
+        size: Size = Size.ORIGINAL,
         parameters: Parameters = Parameters.EMPTY
     ): Key {
         val extras = buildMap<String, String> {
@@ -532,10 +531,9 @@ class EngineInterceptorTest {
                 }
                 put(MEMORY_CACHE_KEY_TRANSFORMATIONS, transformationString)
             }
-            if (size is PixelSize) {
-                put(MEMORY_CACHE_KEY_WIDTH, size.width.toString())
-                put(MEMORY_CACHE_KEY_HEIGHT, size.height.toString())
-            }
+            val (width, height) = size
+            if (width is Dimension.Pixels) put(MEMORY_CACHE_KEY_WIDTH, width.pixels.toString())
+            if (height is Dimension.Pixels) put(MEMORY_CACHE_KEY_HEIGHT, height.pixels.toString())
             putAll(parameters.cacheKeys())
         }
         return Key(key, extras)

--- a/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
+++ b/coil-base/src/test/java/coil/intercept/RealInterceptorChainTest.kt
@@ -11,8 +11,6 @@ import coil.lifecycle.FakeLifecycle
 import coil.memory.MemoryCache
 import coil.request.ImageRequest
 import coil.request.ImageResult
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Size
 import coil.transform.CircleCropTransformation
 import coil.util.createRequest
@@ -79,7 +77,7 @@ class RealInterceptorChainTest {
     fun `interceptor cannot modify sizeResolver`() {
         val request = createRequest(context)
         val interceptor = Interceptor { chain ->
-            chain.proceed(chain.request.newBuilder().size(PixelSize(100, 100)).build())
+            chain.proceed(chain.request.newBuilder().size(Size(100, 100)).build())
         }
         assertFailsWith<IllegalStateException> {
             testChain(request, listOf(interceptor))
@@ -113,28 +111,28 @@ class RealInterceptorChainTest {
 
     @Test
     fun `withSize is passed to subsequent interceptors`() {
-        var size: Size = PixelSize(100, 100)
+        var size = Size(100, 100)
         val request = createRequest(context) {
             size(size)
         }
         val interceptor1 = Interceptor { chain ->
             assertEquals(size, chain.size)
-            size = PixelSize(123, 456)
+            size = Size(123, 456)
             chain.withSize(size).proceed(chain.request)
         }
         val interceptor2 = Interceptor { chain ->
             assertEquals(size, chain.size)
-            size = PixelSize(1728, 400)
+            size = Size(1728, 400)
             chain.withSize(size).proceed(chain.request)
         }
         val interceptor3 = Interceptor { chain ->
             assertEquals(size, chain.size)
-            size = OriginalSize
+            size = Size.ORIGINAL
             chain.withSize(size).proceed(chain.request)
         }
         val result = testChain(request, listOf(interceptor1, interceptor2, interceptor3))
 
-        assertEquals(OriginalSize, size)
+        assertEquals(Size.ORIGINAL, size)
         assertSame(request, result.request)
     }
 
@@ -144,7 +142,7 @@ class RealInterceptorChainTest {
             interceptors = interceptors + FakeInterceptor(),
             index = 0,
             request = request,
-            size = PixelSize(100, 100),
+            size = Size(100, 100),
             eventListener = EventListener.NONE,
             isPlaceholderCached = false
         )

--- a/coil-base/src/test/java/coil/request/ImageRequestTest.kt
+++ b/coil-base/src/test/java/coil/request/ImageRequestTest.kt
@@ -8,10 +8,9 @@ import android.widget.ImageView.ScaleType.MATRIX
 import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.lifecycle.FakeLifecycle
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Precision
 import coil.size.Scale
+import coil.size.Size
 import coil.size.ViewSizeResolver
 import coil.transition.CrossfadeTransition
 import coil.transition.Transition
@@ -197,10 +196,10 @@ class ImageRequestTest {
             .build()
 
         runBlocking {
-            assertEquals(OriginalSize, request1.sizeResolver.size())
-            assertEquals(OriginalSize, request2.sizeResolver.size())
-            assertEquals(PixelSize(100, 100), request3.sizeResolver.size())
-            assertEquals(PixelSize(100, 100), request4.sizeResolver.size())
+            assertEquals(Size.ORIGINAL, request1.sizeResolver.size())
+            assertEquals(Size.ORIGINAL, request2.sizeResolver.size())
+            assertEquals(Size(100, 100), request3.sizeResolver.size())
+            assertEquals(Size(100, 100), request4.sizeResolver.size())
         }
     }
 }

--- a/coil-base/src/test/java/coil/request/RequestServiceTest.kt
+++ b/coil-base/src/test/java/coil/request/RequestServiceTest.kt
@@ -112,7 +112,7 @@ class RequestServiceTest {
     }
 
     @Test
-    fun `allowInexactSize - PixelSizeResolver explicit`() {
+    fun `allowInexactSize - SizeResolver explicit`() {
         val request = createRequest(context) {
             size(100, 100)
         }

--- a/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
+++ b/coil-base/src/test/java/coil/size/ViewSizeResolverTest.kt
@@ -48,7 +48,7 @@ class ViewSizeResolverTest {
             resolver.size()
         }
 
-        assertEquals(PixelSize(80, 80), size)
+        assertEquals(Size(80, 80), size)
     }
 
     @Test
@@ -61,7 +61,7 @@ class ViewSizeResolverTest {
             resolver.size()
         }
 
-        assertEquals(PixelSize(100, 100), size)
+        assertEquals(Size(100, 100), size)
     }
 
     @Test
@@ -85,12 +85,11 @@ class ViewSizeResolverTest {
         val size = runBlocking {
             deferred.await()
         }
-        assertEquals(PixelSize(120, 120), size)
+        assertEquals(Size(120, 120), size)
     }
 
     @Test
-    fun `wrap_content is resolved to the size of the display`() {
-        val expectedWidth = view.context.resources.displayMetrics.widthPixels
+    fun `wrap_content is resolved to the size of the image`() {
         val deferred = scope.async(Dispatchers.Main.immediate) {
             resolver.size()
         }
@@ -103,6 +102,6 @@ class ViewSizeResolverTest {
         val size = runBlocking {
             deferred.await()
         }
-        assertEquals(PixelSize(expectedWidth, 100), size)
+        assertEquals(Size(Dimension.Original, Dimension(100)), size)
     }
 }

--- a/coil-base/src/test/java/coil/util/DrawableUtilsTest.kt
+++ b/coil-base/src/test/java/coil/util/DrawableUtilsTest.kt
@@ -3,8 +3,8 @@ package coil.util
 import android.graphics.Bitmap
 import android.graphics.drawable.VectorDrawable
 import coil.size
-import coil.size.PixelSize
 import coil.size.Scale
+import coil.size.Size
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -15,7 +15,7 @@ class DrawableUtilsTest {
 
     @Test
     fun `vector with hardware config is converted correctly`() {
-        val size = PixelSize(200, 200)
+        val size = Size(200, 200)
         val input = object : VectorDrawable() {
             override fun getIntrinsicWidth() = 100
             override fun getIntrinsicHeight() = 100
@@ -34,7 +34,7 @@ class DrawableUtilsTest {
 
     @Test
     fun `unimplemented intrinsic size does not crash`() {
-        val size = PixelSize(200, 200)
+        val size = Size(200, 200)
         val input = object : VectorDrawable() {
             override fun getIntrinsicWidth() = -1
             override fun getIntrinsicHeight() = -1
@@ -59,13 +59,13 @@ class DrawableUtilsTest {
         }
         val output = DrawableUtils.convertToBitmap(
             drawable = input,
-            size = PixelSize(200, 200),
+            size = Size(200, 200),
             config = Bitmap.Config.ARGB_8888,
             scale = Scale.FIT,
             allowInexactSize = true
         )
 
         assertEquals(Bitmap.Config.ARGB_8888, output.config)
-        assertEquals(PixelSize(100, 200), output.size)
+        assertEquals(Size(100, 200), output.size)
     }
 }

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -1,6 +1,5 @@
 package coil.compose
 
-import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -21,7 +20,6 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope.Companion.DefaultFilterQuality
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Constraints.Companion.Infinity
@@ -30,8 +28,7 @@ import coil.compose.AsyncImagePainter.State
 import coil.compose.AsyncImageScope.Companion.DefaultContent
 import coil.decode.DecodeUtils
 import coil.request.ImageRequest
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Dimension
 import coil.size.Scale
 import coil.size.SizeResolver
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -239,8 +236,7 @@ private fun updateRequest(request: ImageRequest, contentScale: ContentScale): Im
     return request.newBuilder()
         .apply {
             if (request.defined.sizeResolver == null) {
-                val context = LocalContext.current
-                size(remember(context) { ConstraintsSizeResolver(context) })
+                size(remember { ConstraintsSizeResolver() })
             }
             if (request.defined.scale == null) {
                 scale(contentScale.toScale())
@@ -288,7 +284,15 @@ private fun Constraints.constrain(width: Float, height: Float) = Size(
     height = height.coerceIn(minHeight.toFloat(), maxHeight.toFloat())
 )
 
-private class ConstraintsSizeResolver(private val context: Context) : SizeResolver {
+@Stable
+private fun Constraints.toSize(): CoilSize {
+    if (isZero) return CoilSize.ORIGINAL
+    val width = if (hasBoundedWidth) Dimension(maxWidth) else Dimension.Original
+    val height = if (hasBoundedHeight) Dimension(maxHeight) else Dimension.Original
+    return CoilSize(width, height)
+}
+
+private class ConstraintsSizeResolver : SizeResolver {
 
     private val constraints = MutableStateFlow<Constraints?>(null)
 
@@ -296,19 +300,6 @@ private class ConstraintsSizeResolver(private val context: Context) : SizeResolv
 
     fun setConstraints(constraints: Constraints) {
         this.constraints.value = constraints
-    }
-
-    private fun Constraints.toSize(): CoilSize {
-        if (isZero) return OriginalSize
-
-        val hasBoundedWidth = hasBoundedWidth
-        val hasBoundedHeight = hasBoundedHeight
-        return when {
-            hasBoundedWidth && hasBoundedHeight -> PixelSize(maxWidth, maxHeight)
-            hasBoundedWidth -> PixelSize(maxWidth, context.resources.displayMetrics.heightPixels)
-            hasBoundedHeight -> PixelSize(context.resources.displayMetrics.widthPixels, maxHeight)
-            else -> OriginalSize
-        }
     }
 }
 

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -171,7 +171,6 @@ interface AsyncImageScope : BoxScope {
     val colorFilter: ColorFilter?
 
     companion object {
-
         /**
          * The default content composable only draws [AsyncImageContent] for all
          * [AsyncImagePainter] states.

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -54,8 +54,8 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
-import coil.size.Size as CoilSize
 import kotlin.math.roundToInt
+import coil.size.Size as CoilSize
 
 /**
  * Return an [AsyncImagePainter] that executes an [ImageRequest] asynchronously and

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -38,8 +38,6 @@ import coil.request.ErrorResult
 import coil.request.ImageRequest
 import coil.request.ImageResult
 import coil.request.SuccessResult
-import coil.size.OriginalSize
-import coil.size.PixelSize
 import coil.size.Precision
 import coil.size.SizeResolver
 import coil.transition.CrossfadeTransition
@@ -56,6 +54,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import coil.size.Size as CoilSize
 import kotlin.math.roundToInt
 
 /**
@@ -212,8 +211,8 @@ class AsyncImagePainter internal constructor(
         override suspend fun size() = drawSize
             .mapNotNull { size ->
                 when {
-                    size.isUnspecified -> OriginalSize
-                    size.isPositive -> PixelSize(size.width.roundToInt(), size.height.roundToInt())
+                    size.isUnspecified -> CoilSize.ORIGINAL
+                    size.isPositive -> CoilSize(size.width.roundToInt(), size.height.roundToInt())
                     else -> null
                 }
             }

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -13,7 +13,7 @@ import coil.request.animatedTransformation
 import coil.request.animationEndCallback
 import coil.request.animationStartCallback
 import coil.request.repeatCount
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import coil.util.animatable2CallbackOf
 import coil.util.asPostProcessor
 import coil.util.isHardware
@@ -60,8 +60,8 @@ class ImageDecoderDecoder @JvmOverloads constructor(
                 decoderSource.decodeDrawable { info, _ ->
                     val srcWidth = info.size.width.coerceAtLeast(1)
                     val srcHeight = info.size.height.coerceAtLeast(1)
-                    val dstWidth = options.size.width.pixelsOrElse { srcWidth }
-                    val dstHeight = options.size.height.pixelsOrElse { srcHeight }
+                    val dstWidth = options.size.width.pxOrElse { srcWidth }
+                    val dstHeight = options.size.height.pxOrElse { srcHeight }
                     if (srcWidth != dstWidth || srcHeight != dstHeight) {
                         val multiplier = DecodeUtils.computeSizeMultiplier(
                             srcWidth = srcWidth,

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -17,12 +17,12 @@ import coil.size.pixelsOrElse
 import coil.util.animatable2CallbackOf
 import coil.util.asPostProcessor
 import coil.util.isHardware
-import java.nio.ByteBuffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import okio.BufferedSource
 import okio.buffer
+import java.nio.ByteBuffer
 import kotlin.math.roundToInt
 
 /**

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -5,8 +5,6 @@ import android.graphics.drawable.AnimatedImageDrawable
 import android.os.Build.VERSION.SDK_INT
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.decodeDrawable
-import androidx.core.util.component1
-import androidx.core.util.component2
 import coil.ImageLoader
 import coil.drawable.ScaleDrawable
 import coil.fetch.SourceResult
@@ -15,16 +13,16 @@ import coil.request.animatedTransformation
 import coil.request.animationEndCallback
 import coil.request.animationStartCallback
 import coil.request.repeatCount
-import coil.size.PixelSize
+import coil.size.pixelsOrElse
 import coil.util.animatable2CallbackOf
 import coil.util.asPostProcessor
 import coil.util.isHardware
+import java.nio.ByteBuffer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import okio.BufferedSource
 import okio.buffer
-import java.nio.ByteBuffer
 import kotlin.math.roundToInt
 
 /**
@@ -60,14 +58,16 @@ class ImageDecoderDecoder @JvmOverloads constructor(
                 }
 
                 decoderSource.decodeDrawable { info, _ ->
-                    val size = options.size
-                    if (size is PixelSize) {
-                        val (srcWidth, srcHeight) = info.size
+                    val srcWidth = info.size.width.coerceAtLeast(1)
+                    val srcHeight = info.size.height.coerceAtLeast(1)
+                    val dstWidth = options.size.width.pixelsOrElse { srcWidth }
+                    val dstHeight = options.size.height.pixelsOrElse { srcHeight }
+                    if (srcWidth != dstWidth || srcHeight != dstHeight) {
                         val multiplier = DecodeUtils.computeSizeMultiplier(
                             srcWidth = srcWidth,
                             srcHeight = srcHeight,
-                            dstWidth = size.width,
-                            dstHeight = size.height,
+                            dstWidth = dstWidth,
+                            dstHeight = dstHeight,
                             scale = options.scale
                         )
 

--- a/coil-sample/src/main/java/coil/sample/Utils.kt
+++ b/coil-sample/src/main/java/coil/sample/Utils.kt
@@ -4,6 +4,7 @@ package coil.sample
 
 import android.content.Context
 import android.graphics.Color
+import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -16,7 +17,6 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.recyclerview.widget.AsyncDifferConfig
 import androidx.recyclerview.widget.DiffUtil
-import coil.size.PixelSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import kotlin.random.Random
@@ -37,8 +37,8 @@ inline fun WindowInsets.toCompat(): WindowInsetsCompat {
     return WindowInsetsCompat.toWindowInsetsCompat(this)
 }
 
-fun Context.getDisplaySize(): PixelSize {
-    return resources.displayMetrics.run { PixelSize(widthPixels, heightPixels) }
+fun Context.getDisplaySize(): Size {
+    return resources.displayMetrics.run { Size(widthPixels, heightPixels) }
 }
 
 fun Int.dp(context: Context): Float {

--- a/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
+++ b/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
@@ -6,8 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
-import coil.size.PixelSize
 import coil.size.Scale
+import coil.size.Size
 import coil.util.assertIsSimilarTo
 import coil.util.decodeBitmapAsset
 import kotlinx.coroutines.runBlocking
@@ -79,7 +79,7 @@ class SvgDecoderTest {
         val (drawable, isSampled) = runBlocking {
             val options = Options(
                 context = context,
-                size = PixelSize(400, 250), // coil_logo.svg's intrinsic dimensions are 200x200.
+                size = Size(400, 250), // coil_logo.svg's intrinsic dimensions are 200x200.
                 scale = Scale.FIT
             )
             assertNotNull(decoderFactory.create(source.asSourceResult(), options, ImageLoader(context))?.decode())
@@ -98,7 +98,7 @@ class SvgDecoderTest {
         val (drawable, isSampled) = runBlocking {
             val options = Options(
                 context = context,
-                size = PixelSize(326, 50),
+                size = Size(326, 50),
                 scale = Scale.FILL
             )
             assertNotNull(decoderFactory.create(source.asSourceResult(), options, ImageLoader(context))?.decode())

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -81,7 +81,7 @@ class SvgDecoder @JvmOverloads constructor(
 
     private fun Dimension.pixelsOrElse(value: Float): Float {
         return if (this is Dimension.Pixels) {
-            pixels.toFloat()
+            this.px.toFloat()
         } else {
             if (value > 0) value else DEFAULT_SIZE
         }

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -7,14 +7,14 @@ import androidx.core.graphics.drawable.toDrawable
 import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Dimension
 import coil.util.indexOf
 import coil.util.toSoftware
 import com.caverock.androidsvg.SVG
 import kotlinx.coroutines.runInterruptible
 import okio.BufferedSource
 import okio.ByteString.Companion.encodeUtf8
+import kotlin.math.roundToInt
 
 /**
  * A [Decoder] that uses [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) to decode SVG files.
@@ -33,49 +33,33 @@ class SvgDecoder @JvmOverloads constructor(
 
         val svgWidth: Float
         val svgHeight: Float
+        val viewBox: RectF? = svg.documentViewBox
+        if (useViewBoundsAsIntrinsicSize && viewBox != null) {
+            svgWidth = viewBox.width()
+            svgHeight = viewBox.height()
+        } else {
+            svgWidth = svg.documentWidth
+            svgHeight = svg.documentHeight
+        }
+
         val bitmapWidth: Int
         val bitmapHeight: Int
-        val viewBox: RectF? = svg.documentViewBox
-        when (val size = options.size) {
-            is PixelSize -> {
-                if (useViewBoundsAsIntrinsicSize && viewBox != null) {
-                    svgWidth = viewBox.width()
-                    svgHeight = viewBox.height()
-                } else {
-                    svgWidth = svg.documentWidth
-                    svgHeight = svg.documentHeight
-                }
-
-                if (svgWidth > 0 && svgHeight > 0) {
-                    val multiplier = DecodeUtils.computeSizeMultiplier(
-                        srcWidth = svgWidth,
-                        srcHeight = svgHeight,
-                        dstWidth = size.width.toFloat(),
-                        dstHeight = size.height.toFloat(),
-                        scale = options.scale
-                    )
-                    bitmapWidth = (multiplier * svgWidth).toInt()
-                    bitmapHeight = (multiplier * svgHeight).toInt()
-                } else {
-                    bitmapWidth = size.width
-                    bitmapHeight = size.height
-                }
-            }
-            is OriginalSize -> {
-                svgWidth = svg.documentWidth
-                svgHeight = svg.documentHeight
-
-                if (svgWidth > 0 && svgHeight > 0) {
-                    bitmapWidth = svgWidth.toInt()
-                    bitmapHeight = svgHeight.toInt()
-                } else if (useViewBoundsAsIntrinsicSize && viewBox != null) {
-                    bitmapWidth = viewBox.width().toInt()
-                    bitmapHeight = viewBox.height().toInt()
-                } else {
-                    bitmapWidth = DEFAULT_SIZE
-                    bitmapHeight = DEFAULT_SIZE
-                }
-            }
+        val size = options.size
+        val dstWidth = size.width.pixelsOrElse(svgWidth)
+        val dstHeight = size.height.pixelsOrElse(svgHeight)
+        if (svgWidth > 0 && svgHeight > 0) {
+            val multiplier = DecodeUtils.computeSizeMultiplier(
+                srcWidth = svgWidth,
+                srcHeight = svgHeight,
+                dstWidth = dstWidth,
+                dstHeight = dstHeight,
+                scale = options.scale
+            )
+            bitmapWidth = (multiplier * svgWidth).toInt()
+            bitmapHeight = (multiplier * svgHeight).toInt()
+        } else {
+            bitmapWidth = dstWidth.roundToInt()
+            bitmapHeight = dstHeight.roundToInt()
         }
 
         // Set the SVG's view box to enable scaling if it is not set.
@@ -93,6 +77,14 @@ class SvgDecoder @JvmOverloads constructor(
             drawable = bitmap.toDrawable(options.context.resources),
             isSampled = true // SVGs can always be re-decoded at a higher resolution.
         )
+    }
+
+    private fun Dimension.pixelsOrElse(value: Float): Float {
+        return if (this is Dimension.Pixels) {
+            pixels.toFloat()
+        } else {
+            if (value > 0) value else DEFAULT_SIZE
+        }
     }
 
     class Factory @JvmOverloads constructor(
@@ -123,7 +115,7 @@ class SvgDecoder @JvmOverloads constructor(
 
     private companion object {
         private const val MIME_TYPE_SVG = "image/svg+xml"
-        private const val DEFAULT_SIZE = 512
+        private const val DEFAULT_SIZE = 512f
         private const val SVG_TAG_SEARCH_THRESHOLD_BYTES = 1024L
         private val SVG_TAG = "<svg ".encodeUtf8()
         private val LEFT_ANGLE_BRACKET = "<".encodeUtf8()

--- a/coil-video/src/androidTest/java/coil/decode/VideoFrameDecoderTest.kt
+++ b/coil-video/src/androidTest/java/coil/decode/VideoFrameDecoderTest.kt
@@ -7,7 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import coil.decode.VideoFrameDecoder.Companion.VIDEO_FRAME_MICROS_KEY
 import coil.request.Options
 import coil.request.Parameters
-import coil.size.PixelSize
+import coil.size.Size
 import coil.util.assertIsSimilarTo
 import coil.util.assumeTrue
 import coil.util.decodeBitmapAsset
@@ -91,7 +91,7 @@ class VideoFrameDecoderTest {
                     source = context.assets.open("video_rotated.mp4").source().buffer(),
                     context = context
                 ),
-                options = Options(context, size = PixelSize(150, 150))
+                options = Options(context, size = Size(150, 150))
             ).decode()
         }
 

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -16,9 +16,9 @@ import coil.fetch.SourceResult
 import coil.request.Options
 import coil.request.videoFrameMicros
 import coil.request.videoFrameOption
-import coil.size.OriginalSize
-import coil.size.PixelSize
+import coil.size.Dimension.Pixels
 import coil.size.Size
+import coil.size.pixelsOrElse
 import coil.util.use
 import kotlin.math.roundToInt
 
@@ -39,43 +39,39 @@ class VideoFrameDecoder(
 
         // Resolve the dimensions to decode the video frame at accounting
         // for the source's aspect ratio and the target's size.
-        var srcWidth = 0
-        var srcHeight = 0
-        val destSize = when (val size = options.size) {
-            is PixelSize -> {
-                val rotation = retriever.extractMetadata(METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0
-                if (rotation == 90 || rotation == 270) {
-                    srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
-                    srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
-                } else {
-                    srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
-                    srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
-                }
-
-                if (srcWidth > 0 && srcHeight > 0) {
-                    val rawScale = DecodeUtils.computeSizeMultiplier(
-                        srcWidth = srcWidth,
-                        srcHeight = srcHeight,
-                        dstWidth = size.width,
-                        dstHeight = size.height,
-                        scale = options.scale
-                    )
-                    val scale = if (options.allowInexactSize) rawScale.coerceAtMost(1.0) else rawScale
-                    val width = (scale * srcWidth).roundToInt()
-                    val height = (scale * srcHeight).roundToInt()
-                    PixelSize(width, height)
-                } else {
-                    // We were unable to decode the video's dimensions.
-                    // Fall back to decoding the video frame at the original size.
-                    // We'll scale the resulting bitmap after decoding if necessary.
-                    OriginalSize
-                }
-            }
-            is OriginalSize -> OriginalSize
+        var srcWidth: Int
+        var srcHeight: Int
+        val rotation = retriever.extractMetadata(METADATA_KEY_VIDEO_ROTATION)?.toIntOrNull() ?: 0
+        if (rotation == 90 || rotation == 270) {
+            srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
+            srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
+        } else {
+            srcWidth = retriever.extractMetadata(METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull() ?: 0
+            srcHeight = retriever.extractMetadata(METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull() ?: 0
         }
 
-        val rawBitmap: Bitmap? = if (SDK_INT >= 27 && destSize is PixelSize) {
-            retriever.getScaledFrameAtTime(frameMicros, option, destSize.width, destSize.height)
+        val dstSize = if (srcWidth > 0 && srcHeight > 0) {
+            val rawScale = DecodeUtils.computeSizeMultiplier(
+                srcWidth = srcWidth,
+                srcHeight = srcHeight,
+                dstWidth = options.size.width.pixelsOrElse { srcWidth },
+                dstHeight = options.size.height.pixelsOrElse { srcHeight },
+                scale = options.scale
+            )
+            val scale = if (options.allowInexactSize) rawScale.coerceAtMost(1.0) else rawScale
+            val width = (scale * srcWidth).roundToInt()
+            val height = (scale * srcHeight).roundToInt()
+            Size(width, height)
+        } else {
+            // We were unable to decode the video's dimensions.
+            // Fall back to decoding the video frame at the original size.
+            // We'll scale the resulting bitmap after decoding if necessary.
+            Size.ORIGINAL
+        }
+
+        val (dstWidth, dstHeight) = dstSize
+        val rawBitmap: Bitmap? = if (SDK_INT >= 27 && dstWidth is Pixels && dstHeight is Pixels) {
+            retriever.getScaledFrameAtTime(frameMicros, option, dstWidth.pixels, dstHeight.pixels)
         } else {
             retriever.getFrameAtTime(frameMicros, option)?.also {
                 srcWidth = it.width
@@ -87,10 +83,16 @@ class VideoFrameDecoder(
         // https://developer.android.com/guide/topics/media/media-formats#video-formats
         checkNotNull(rawBitmap) { "Failed to decode frame at $frameMicros microseconds." }
 
-        val bitmap = normalizeBitmap(rawBitmap, destSize, options)
+        val bitmap = normalizeBitmap(rawBitmap, dstSize, options)
 
         val isSampled = if (srcWidth > 0 && srcHeight > 0) {
-            DecodeUtils.computeSizeMultiplier(srcWidth, srcHeight, bitmap.width, bitmap.height, options.scale) < 1.0
+            DecodeUtils.computeSizeMultiplier(
+                srcWidth = srcWidth,
+                srcHeight = srcHeight,
+                dstWidth = bitmap.width,
+                dstHeight = bitmap.height,
+                scale = options.scale
+            ) < 1.0
         } else {
             // We were unable to determine the original size of the video. Assume it is sampled.
             true
@@ -114,27 +116,15 @@ class VideoFrameDecoder(
         }
 
         // Slow path: re-render the bitmap with the correct size + config.
-        val scale: Float
-        val dstWidth: Int
-        val dstHeight: Int
-        when (size) {
-            is PixelSize -> {
-                scale = DecodeUtils.computeSizeMultiplier(
-                    srcWidth = inBitmap.width,
-                    srcHeight = inBitmap.height,
-                    dstWidth = size.width,
-                    dstHeight = size.height,
-                    scale = options.scale
-                ).toFloat()
-                dstWidth = (scale * inBitmap.width).roundToInt()
-                dstHeight = (scale * inBitmap.height).roundToInt()
-            }
-            is OriginalSize -> {
-                scale = 1f
-                dstWidth = inBitmap.width
-                dstHeight = inBitmap.height
-            }
-        }
+        val scale = DecodeUtils.computeSizeMultiplier(
+            srcWidth = inBitmap.width,
+            srcHeight = inBitmap.height,
+            dstWidth = size.width.pixelsOrElse { inBitmap.width },
+            dstHeight = size.height.pixelsOrElse { inBitmap.height },
+            scale = options.scale
+        ).toFloat()
+        val dstWidth = (scale * inBitmap.width).roundToInt()
+        val dstHeight = (scale * inBitmap.height).roundToInt()
         val safeConfig = when {
             SDK_INT >= 26 && options.config == Bitmap.Config.HARDWARE -> Bitmap.Config.ARGB_8888
             else -> options.config
@@ -151,12 +141,21 @@ class VideoFrameDecoder(
     }
 
     private fun isConfigValid(bitmap: Bitmap, options: Options): Boolean {
-        return SDK_INT < 26 || bitmap.config != Bitmap.Config.HARDWARE || options.config == Bitmap.Config.HARDWARE
+        return SDK_INT < 26 ||
+            bitmap.config != Bitmap.Config.HARDWARE ||
+            options.config == Bitmap.Config.HARDWARE
     }
 
     private fun isSizeValid(bitmap: Bitmap, options: Options, size: Size): Boolean {
-        return options.allowInexactSize || size is OriginalSize ||
-            size == DecodeUtils.computePixelSize(bitmap.width, bitmap.height, size, options.scale)
+        if (options.allowInexactSize) return true
+        val multiplier = DecodeUtils.computeSizeMultiplier(
+            srcWidth = bitmap.width,
+            srcHeight = bitmap.height,
+            dstWidth = size.width.pixelsOrElse { bitmap.width },
+            dstHeight = size.height.pixelsOrElse { bitmap.height },
+            scale = options.scale
+        )
+        return multiplier == 1.0
     }
 
     class Factory : Decoder.Factory {

--- a/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil/decode/VideoFrameDecoder.kt
@@ -18,7 +18,7 @@ import coil.request.videoFrameMicros
 import coil.request.videoFrameOption
 import coil.size.Dimension.Pixels
 import coil.size.Size
-import coil.size.pixelsOrElse
+import coil.size.pxOrElse
 import coil.util.use
 import kotlin.math.roundToInt
 
@@ -54,8 +54,8 @@ class VideoFrameDecoder(
             val rawScale = DecodeUtils.computeSizeMultiplier(
                 srcWidth = srcWidth,
                 srcHeight = srcHeight,
-                dstWidth = options.size.width.pixelsOrElse { srcWidth },
-                dstHeight = options.size.height.pixelsOrElse { srcHeight },
+                dstWidth = options.size.width.pxOrElse { srcWidth },
+                dstHeight = options.size.height.pxOrElse { srcHeight },
                 scale = options.scale
             )
             val scale = if (options.allowInexactSize) rawScale.coerceAtMost(1.0) else rawScale
@@ -71,7 +71,7 @@ class VideoFrameDecoder(
 
         val (dstWidth, dstHeight) = dstSize
         val rawBitmap: Bitmap? = if (SDK_INT >= 27 && dstWidth is Pixels && dstHeight is Pixels) {
-            retriever.getScaledFrameAtTime(frameMicros, option, dstWidth.pixels, dstHeight.pixels)
+            retriever.getScaledFrameAtTime(frameMicros, option, dstWidth.px, dstHeight.px)
         } else {
             retriever.getFrameAtTime(frameMicros, option)?.also {
                 srcWidth = it.width
@@ -119,8 +119,8 @@ class VideoFrameDecoder(
         val scale = DecodeUtils.computeSizeMultiplier(
             srcWidth = inBitmap.width,
             srcHeight = inBitmap.height,
-            dstWidth = size.width.pixelsOrElse { inBitmap.width },
-            dstHeight = size.height.pixelsOrElse { inBitmap.height },
+            dstWidth = size.width.pxOrElse { inBitmap.width },
+            dstHeight = size.height.pxOrElse { inBitmap.height },
             scale = options.scale
         ).toFloat()
         val dstWidth = (scale * inBitmap.width).roundToInt()
@@ -151,8 +151,8 @@ class VideoFrameDecoder(
         val multiplier = DecodeUtils.computeSizeMultiplier(
             srcWidth = bitmap.width,
             srcHeight = bitmap.height,
-            dstWidth = size.width.pixelsOrElse { bitmap.width },
-            dstHeight = size.height.pixelsOrElse { bitmap.height },
+            dstWidth = size.width.pxOrElse { bitmap.width },
+            dstHeight = size.height.pxOrElse { bitmap.height },
             scale = options.scale
         )
         return multiplier == 1.0


### PR DESCRIPTION
This fixes issues like https://github.com/coil-kt/coil/issues/599 and overall makes having one unbounded dimension more consistent with when both dimensions are unbounded.