### PR TITLE
Extract EngineInterceptor memory cache functions into MemoryCacheService.

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -3,12 +3,12 @@
     <option name="myName" value="Project Default" />
     <inspection_tool class="BlockingMethodInNonBlockingContext" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="FunctionWithLambdaExpressionBody" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="LiftReturnOrAssignment" enabled="false" level="INFO" enabled_by_default="false" />
     <inspection_tool class="MemberVisibilityCanBePrivate" enabled="false" level="INFO" enabled_by_default="false" />
     <inspection_tool class="ObjectPropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="SuspiciousCollectionReassignment" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="TestFunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="TrailingComma" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="UnusedProperty" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -712,8 +712,6 @@ public final class coil/size/-Dimensions {
 
 public final class coil/size/-Sizes {
 	public static final fun OriginalSize ()Lcoil/size/Size;
-	public static final fun PixelSize (II)Lcoil/size/Size;
-	public static final fun Size (II)Lcoil/size/Size;
 	public static final fun isOriginal (Lcoil/size/Size;)Z
 }
 
@@ -751,6 +749,9 @@ public final class coil/size/Scale : java/lang/Enum {
 public final class coil/size/Size {
 	public static final field Companion Lcoil/size/Size$Companion;
 	public static final field ORIGINAL Lcoil/size/Size;
+	public fun <init> (II)V
+	public fun <init> (ILcoil/size/Dimension;)V
+	public fun <init> (Lcoil/size/Dimension;I)V
 	public fun <init> (Lcoil/size/Dimension;Lcoil/size/Dimension;)V
 	public final fun component1 ()Lcoil/size/Dimension;
 	public final fun component2 ()Lcoil/size/Dimension;

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -705,6 +705,18 @@ public final class coil/request/SuccessResult : coil/request/ImageResult {
 	public final fun isSampled ()Z
 }
 
+public final class coil/size/-Dimensions {
+	public static final fun Dimension (I)Lcoil/size/Dimension$Pixels;
+	public static final fun pxOrElse (Lcoil/size/Dimension;Lkotlin/jvm/functions/Function0;)I
+}
+
+public final class coil/size/-Sizes {
+	public static final fun OriginalSize ()Lcoil/size/Size;
+	public static final fun PixelSize (II)Lcoil/size/Size;
+	public static final fun Size (II)Lcoil/size/Size;
+	public static final fun isOriginal (Lcoil/size/Size;)Z
+}
+
 public abstract class coil/size/Dimension {
 }
 
@@ -719,11 +731,6 @@ public final class coil/size/Dimension$Pixels : coil/size/Dimension {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class coil/size/Dimensions {
-	public static final fun create (I)Lcoil/size/Dimension$Pixels;
-	public static final fun pxOrElse (Lcoil/size/Dimension;Lkotlin/jvm/functions/Function0;)I
 }
 
 public final class coil/size/Precision : java/lang/Enum {
@@ -765,13 +772,6 @@ public abstract interface class coil/size/SizeResolver {
 
 public final class coil/size/SizeResolvers {
 	public static final fun create (Lcoil/size/Size;)Lcoil/size/SizeResolver;
-}
-
-public final class coil/size/Sizes {
-	public static final fun OriginalSize ()Lcoil/size/Size;
-	public static final fun PixelSize (II)Lcoil/size/Size;
-	public static final fun create (II)Lcoil/size/Size;
-	public static final fun isOriginal (Lcoil/size/Size;)Z
 }
 
 public abstract interface class coil/size/ViewSizeResolver : coil/size/SizeResolver {

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -60,8 +60,8 @@ internal class EngineInterceptor(
             eventListener.mapEnd(request, mappedData)
 
             // Check the memory cache.
-            val cacheKey = memoryCacheService.newKey(request, mappedData, options, eventListener)
-            val cacheValue = cacheKey?.let { memoryCacheService.getValue(request, it, size) }
+            val cacheKey = memoryCacheService.newCacheKey(request, mappedData, options, eventListener)
+            val cacheValue = cacheKey?.let { memoryCacheService.getCacheValue(request, it, size) }
 
             // Fast path: return the value from the memory cache.
             if (cacheValue != null) {
@@ -74,7 +74,7 @@ internal class EngineInterceptor(
                 val result = execute(request, mappedData, options, eventListener)
 
                 // Write the result to the memory cache.
-                val isCached = memoryCacheService.setValue(cacheKey, request, result)
+                val isCached = memoryCacheService.setCacheValue(cacheKey, request, result)
 
                 // Return the result.
                 SuccessResult(

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -60,7 +60,7 @@ internal class EngineInterceptor(
             eventListener.mapEnd(request, mappedData)
 
             // Check the memory cache.
-            val cacheKey = memoryCacheService.getKey(request, mappedData, options, eventListener)
+            val cacheKey = memoryCacheService.newKey(request, mappedData, options, eventListener)
             val cacheValue = cacheKey?.let { memoryCacheService.getValue(request, it, size) }
 
             // Fast path: return the value from the memory cache.
@@ -74,7 +74,7 @@ internal class EngineInterceptor(
                 val result = execute(request, mappedData, options, eventListener)
 
                 // Write the result to the memory cache.
-                val isCached = memoryCacheService.setValue(cacheKey, request, result, options.size)
+                val isCached = memoryCacheService.setValue(cacheKey, request, result)
 
                 // Return the result.
                 SuccessResult(

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NAME_SHADOWING")
-
 package coil.intercept
 
 import android.graphics.Bitmap
@@ -102,10 +100,10 @@ internal class EngineInterceptor(
     private suspend inline fun execute(
         request: ImageRequest,
         mappedData: Any,
-        options: Options,
+        _options: Options,
         eventListener: EventListener
     ): ExecuteResult {
-        var options = options
+        var options = _options
         var components = imageLoader.components
         var fetchResult: FetchResult? = null
         val executeResult = try {

--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -254,16 +254,23 @@ internal class EngineInterceptor(
         // Fast path: return the existing bitmap.
         if (drawable is BitmapDrawable) {
             val bitmap = drawable.bitmap
-            if (bitmap.safeConfig in VALID_TRANSFORMATION_CONFIGS) {
+            val config = bitmap.safeConfig
+            if (config in VALID_TRANSFORMATION_CONFIGS) {
                 return bitmap
+            } else {
+                logger?.log(TAG, Log.INFO) {
+                    "Converting bitmap with config $config " +
+                        "to apply transformations: $transformations."
+                }
+            }
+        } else {
+            logger?.log(TAG, Log.INFO) {
+                "Converting drawable of type ${drawable::class.java.canonicalName} " +
+                    "to apply transformations: $transformations."
             }
         }
 
         // Slow path: draw the drawable on a canvas.
-        logger?.log(TAG, Log.INFO) {
-            val type = drawable::class.java.canonicalName
-            "Converting drawable of type $type to apply transformations: $transformations."
-        }
         return DrawableUtils.convertToBitmap(
             drawable = drawable,
             config = options.config,

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -36,7 +36,7 @@ internal class MemoryCacheService(
 ) {
 
     /** Create a [MemoryCache.Key] for this request. */
-    fun newKey(
+    fun newCacheKey(
         request: ImageRequest,
         mappedData: Any,
         options: Options,
@@ -70,19 +70,19 @@ internal class MemoryCacheService(
     }
 
     /** Get the [MemoryCache.Value] for this request. */
-    fun getValue(
+    fun getCacheValue(
         request: ImageRequest,
         cacheKey: MemoryCache.Key,
         size: Size
     ): MemoryCache.Value? {
         if (!request.memoryCachePolicy.readEnabled) return null
         val cacheValue = imageLoader.memoryCache?.get(cacheKey)
-        return cacheValue?.takeIf { isValueValid(request, cacheKey, it, size) }
+        return cacheValue?.takeIf { isCacheValueValid(request, cacheKey, it, size) }
     }
 
     /** Return 'true' if [cacheValue] satisfies the [request]. */
     @VisibleForTesting
-    internal fun isValueValid(
+    internal fun isCacheValueValid(
         request: ImageRequest,
         cacheKey: MemoryCache.Key,
         cacheValue: MemoryCache.Value,
@@ -184,7 +184,7 @@ internal class MemoryCacheService(
     }
 
     /** Write [drawable] to the memory cache. Return 'true' if it was added to the cache. */
-    fun setValue(
+    fun setCacheValue(
         cacheKey: MemoryCache.Key?,
         request: ImageRequest,
         result: ExecuteResult

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -171,7 +171,7 @@ internal class MemoryCacheService(
         }
 
         // The cached value must be larger than the requested size if the cached value is sampled.
-        if (multiplier >= 1.0 && isSampled) {
+        if (multiplier > 1.0 && isSampled) {
             logger?.log(TAG, Log.DEBUG) {
                 "${request.data}: Cached image's request size " +
                     "($srcWidth, $srcHeight) is smaller than the requested size " +

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -129,6 +129,7 @@ internal class MemoryCacheService(
             return transformationSize == size.toString()
         }
 
+        // Compute the scaling factor between the source dimensions and the requested dimensions.
         val srcWidth = cacheValue.bitmap.width
         val srcHeight = cacheValue.bitmap.height
         val dstWidth = size.width.pxOrElse(isSampled, request.scale, srcWidth)

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -69,12 +69,12 @@ internal class MemoryCacheService(
     ): MemoryCache.Value? {
         if (!request.memoryCachePolicy.readEnabled) return null
         val candidate = imageLoader.memoryCache?.get(cacheKey)
-        return candidate?.takeIf { valueSatisfiesRequest(request, it, size) }
+        return candidate?.takeIf { isValueValid(request, it, size) }
     }
 
     /** Return 'true' if [cacheValue] satisfies the [request]. */
     @VisibleForTesting
-    internal fun valueSatisfiesRequest(
+    internal fun isValueValid(
         request: ImageRequest,
         cacheValue: MemoryCache.Value,
         size: Size

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -153,7 +153,11 @@ internal class MemoryCacheService(
                 return true
             }
         } else {
-            if (abs(dstWidth - srcWidth) <= 1 && abs(dstHeight - srcHeight) <= 1) {
+            val widthMatches = (dstWidth == Int.MIN_VALUE || dstWidth == Int.MAX_VALUE) ||
+                abs(dstWidth - srcWidth) <= 1
+            val heightMatches = (dstHeight == Int.MIN_VALUE || dstHeight == Int.MAX_VALUE) ||
+                abs(dstHeight - srcHeight) <= 1
+            if (widthMatches && heightMatches) {
                 return true
             }
         }

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -133,8 +133,8 @@ internal class MemoryCacheService(
         // Compute the scaling factor between the source dimensions and the requested dimensions.
         val srcWidth = cacheValue.bitmap.width
         val srcHeight = cacheValue.bitmap.height
-        val dstWidth = size.width.pxOrElse(isSampled, request.scale, srcWidth)
-        val dstHeight = size.height.pxOrElse(isSampled, request.scale, srcHeight)
+        val dstWidth = size.width.pxOrMinMax(request.scale)
+        val dstHeight = size.height.pxOrMinMax(request.scale)
         val multiplier = DecodeUtils.computeSizeMultiplier(
             srcWidth = srcWidth,
             srcHeight = srcHeight,
@@ -218,8 +218,7 @@ internal class MemoryCacheService(
         isPlaceholderCached = chain.isPlaceholderCached,
     )
 
-    private fun Dimension.pxOrElse(isSampled: Boolean, scale: Scale, srcPx: Int) = pxOrElse {
-        if (!isSampled) return srcPx
+    private fun Dimension.pxOrMinMax(scale: Scale) = pxOrElse {
         when (scale) {
             Scale.FIT -> Int.MAX_VALUE
             Scale.FILL -> Int.MIN_VALUE

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -1,0 +1,230 @@
+package coil.memory
+
+import android.graphics.drawable.BitmapDrawable
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import coil.EventListener
+import coil.ImageLoader
+import coil.decode.DataSource
+import coil.decode.DecodeUtils
+import coil.intercept.EngineInterceptor.ExecuteResult
+import coil.intercept.Interceptor
+import coil.request.ImageRequest
+import coil.request.Options
+import coil.request.RequestService
+import coil.request.SuccessResult
+import coil.size.Dimension
+import coil.size.Scale
+import coil.size.Size
+import coil.size.isOriginal
+import coil.size.pxOrElse
+import coil.util.Logger
+import coil.util.allowInexactSize
+import coil.util.forEachIndexedIndices
+import coil.util.isPlaceholderCached
+import coil.util.log
+import coil.util.pxString
+import coil.util.safeConfig
+import coil.util.toDrawable
+import kotlin.math.abs
+
+internal class MemoryCacheService(
+    private val imageLoader: ImageLoader,
+    private val requestService: RequestService,
+    private val logger: Logger?,
+) {
+
+    /** Get the [MemoryCache.Key] for this request. */
+    fun getKey(
+        request: ImageRequest,
+        mappedData: Any,
+        options: Options,
+        eventListener: EventListener
+    ): MemoryCache.Key? {
+        // Fast path: an explicit memory cache key has been set.
+        request.memoryCacheKey?.let { return it }
+
+        // Slow path: create a new memory cache key.
+        eventListener.keyStart(request, mappedData)
+        val base = imageLoader.components.key(mappedData, options)
+        eventListener.keyEnd(request, base)
+        if (base == null) return null
+
+        val extras = mutableMapOf<String, String>()
+        if (request.transformations.isNotEmpty()) {
+            request.transformations.forEachIndexedIndices { index, transformation ->
+                extras["coil#transformation_$index"] = transformation.cacheKey
+            }
+            extras["coil#request_size"] = options.size.toString()
+        }
+        extras.putAll(request.parameters.cacheKeys())
+        return MemoryCache.Key(base, extras)
+    }
+
+    /** Get the [MemoryCache.Value] for this request. */
+    fun getValue(
+        request: ImageRequest,
+        cacheKey: MemoryCache.Key,
+        size: Size
+    ): MemoryCache.Value? {
+        if (!request.memoryCachePolicy.readEnabled) return null
+        val candidate = imageLoader.memoryCache?.get(cacheKey)
+        return candidate?.takeIf { valueSatisfiesRequest(request, it, size) }
+    }
+
+    /** Return 'true' if [cacheValue] satisfies the [request]. */
+    @VisibleForTesting
+    internal fun valueSatisfiesRequest(
+        request: ImageRequest,
+        cacheValue: MemoryCache.Value,
+        size: Size
+    ): Boolean {
+        // Ensure we don't return a hardware bitmap if the request doesn't allow it.
+        if (!requestService.isConfigValidForHardware(request, cacheValue.bitmap.safeConfig)) {
+            logger?.log(TAG, Log.DEBUG) {
+                "${request.data}: Cached bitmap is hardware-backed, " +
+                    "which is incompatible with the request."
+            }
+            return false
+        }
+
+        // Ensure the size of the cached bitmap is valid for the request.
+        return isSizeValid(cacheValue, request, size)
+    }
+
+    /** Return 'true' if [cacheValue]'s size satisfies the [request]. */
+    private fun isSizeValid(
+        cacheValue: MemoryCache.Value,
+        request: ImageRequest,
+        size: Size
+    ): Boolean {
+        // The cached value must not be sampled if the image's original size is requested.
+        if (size.isOriginal) {
+            if (cacheValue.isSampled) {
+                logger?.log(TAG, Log.DEBUG) {
+                    "${request.data}: Requested original size, but cached image is sampled."
+                }
+                return false
+            } else {
+                return true
+            }
+        }
+
+        val srcWidth = cacheValue.bitmap.width
+        val srcHeight = cacheValue.bitmap.height
+        val dstWidth = size.width.pxOrElse {
+            when {
+                !cacheValue.isSampled -> srcWidth
+                else -> when (request.scale) {
+                    Scale.FIT -> Int.MAX_VALUE
+                    Scale.FILL -> Int.MIN_VALUE
+                }
+            }
+        }
+        val dstHeight = size.height.pxOrElse {
+            when {
+                !cacheValue.isSampled -> srcHeight
+                else -> when (request.scale) {
+                    Scale.FIT -> Int.MAX_VALUE
+                    Scale.FILL -> Int.MIN_VALUE
+                }
+            }
+        }
+        val multiplier = DecodeUtils.computeSizeMultiplier(
+            srcWidth = srcWidth,
+            srcHeight = srcHeight,
+            dstWidth = dstWidth,
+            dstHeight = dstHeight,
+            scale = request.scale
+        )
+
+        // Short circuit the size check if the size is at most 1 pixel off in either dimension.
+        // This accounts for the fact that downsampling can often produce images with dimensions
+        // at most one pixel off due to rounding.
+        if (request.allowInexactSize) {
+            val downsampleMultiplier = multiplier.coerceAtMost(1.0)
+            if ((size.width is Dimension.Original || abs(dstWidth - (downsampleMultiplier * srcWidth)) <= 1) ||
+                (size.height is Dimension.Original || abs(dstHeight - (downsampleMultiplier * srcHeight)) <= 1)) {
+                return true
+            }
+        } else {
+            if (abs(dstWidth - srcWidth) <= 1 && abs(dstHeight - srcHeight) <= 1) {
+                return true
+            }
+        }
+
+        // The cached value must be equal to the requested size if exact size is requested.
+        if (multiplier != 1.0 && !request.allowInexactSize) {
+            logger?.log(TAG, Log.DEBUG) {
+                "${request.data}: Cached image's request size " +
+                    "($srcWidth, $srcHeight) does not exactly match the requested size " +
+                    "(${size.width.pxString()}, ${size.height.pxString()}, ${request.scale})."
+            }
+            return false
+        }
+
+        // The cached value must be larger than the requested size if the cached value is sampled.
+        if (multiplier >= 1.0 && cacheValue.isSampled) {
+            logger?.log(TAG, Log.DEBUG) {
+                "${request.data}: Cached image's request size " +
+                    "($srcWidth, $srcHeight) is smaller than the requested size " +
+                    "(${size.width.pxString()}, ${size.height.pxString()}, ${request.scale})."
+            }
+            return false
+        }
+
+        return true
+    }
+
+    /** Write [drawable] to the memory cache. Return 'true' if it was added to the cache. */
+    fun setValue(
+        cacheKey: MemoryCache.Key?,
+        request: ImageRequest,
+        result: ExecuteResult,
+        size: Size
+    ): Boolean {
+        if (!request.memoryCachePolicy.writeEnabled) return false
+        val memoryCache = imageLoader.memoryCache
+        if (memoryCache == null || cacheKey == null) return false
+        val bitmap = (result.drawable as? BitmapDrawable)?.bitmap ?: return false
+
+        // Create and set the memory cache value.
+        val extras = mutableMapOf<String, Any>()
+        extras[EXTRA_REQUEST_WIDTH] = size.width
+        extras[EXTRA_REQUEST_HEIGHT] = size.height
+        extras[EXTRA_IS_SAMPLED] = result.isSampled
+        result.diskCacheKey?.let { extras[EXTRA_DISK_CACHE_KEY] = it }
+        memoryCache[cacheKey] = MemoryCache.Value(bitmap, extras)
+        return true
+    }
+
+    /** Create a [SuccessResult] from the given [cacheKey] and [cacheValue]. */
+    fun newResult(
+        chain: Interceptor.Chain,
+        request: ImageRequest,
+        cacheKey: MemoryCache.Key,
+        cacheValue: MemoryCache.Value
+    ) = SuccessResult(
+        drawable = cacheValue.bitmap.toDrawable(request.context),
+        request = request,
+        dataSource = DataSource.MEMORY_CACHE,
+        memoryCacheKey = cacheKey,
+        diskCacheKey = cacheValue.diskCacheKey,
+        isSampled = cacheValue.isSampled,
+        isPlaceholderCached = chain.isPlaceholderCached,
+    )
+
+    private val MemoryCache.Value.isSampled: Boolean
+        get() = (extras[EXTRA_IS_SAMPLED] as? Boolean) ?: false
+
+    private val MemoryCache.Value.diskCacheKey: String?
+        get() = extras[EXTRA_DISK_CACHE_KEY] as? String
+
+    companion object {
+        private const val TAG = "MemoryCacheService"
+        @VisibleForTesting internal const val EXTRA_REQUEST_WIDTH = "coil#request_width"
+        @VisibleForTesting internal const val EXTRA_REQUEST_HEIGHT = "coil#request_height"
+        @VisibleForTesting internal const val EXTRA_IS_SAMPLED = "coil#is_sampled"
+        @VisibleForTesting internal const val EXTRA_DISK_CACHE_KEY = "coil#disk_cache_key"
+    }
+}

--- a/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCacheService.kt
@@ -21,6 +21,7 @@ import coil.size.pxOrElse
 import coil.util.Logger
 import coil.util.allowInexactSize
 import coil.util.forEachIndexedIndices
+import coil.util.isMinOrMax
 import coil.util.isPlaceholderCached
 import coil.util.log
 import coil.util.pxString
@@ -153,11 +154,8 @@ internal class MemoryCacheService(
                 return true
             }
         } else {
-            val widthMatches = (dstWidth == Int.MIN_VALUE || dstWidth == Int.MAX_VALUE) ||
-                abs(dstWidth - srcWidth) <= 1
-            val heightMatches = (dstHeight == Int.MIN_VALUE || dstHeight == Int.MAX_VALUE) ||
-                abs(dstHeight - srcHeight) <= 1
-            if (widthMatches && heightMatches) {
+            if ((dstWidth.isMinOrMax() || abs(dstWidth - srcWidth) <= 1) &&
+                (dstHeight.isMinOrMax() || abs(dstHeight - srcHeight) <= 1)) {
                 return true
             }
         }

--- a/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/StrongMemoryCache.kt
@@ -30,7 +30,7 @@ internal interface StrongMemoryCache {
     fun trimMemory(level: Int)
 }
 
-/** A [StrongMemoryCache] implementation that caches nothing and only delegates [set]s to a [WeakMemoryCache]. */
+/** A [StrongMemoryCache] implementation that caches nothing. */
 internal class EmptyStrongMemoryCache(
     private val weakMemoryCache: WeakMemoryCache
 ) : StrongMemoryCache {

--- a/coil-base/src/main/java/coil/size/Dimension.kt
+++ b/coil-base/src/main/java/coil/size/Dimension.kt
@@ -1,4 +1,4 @@
-@file:JvmName("Dimensions")
+@file:JvmName("-Dimensions")
 @file:Suppress("NOTHING_TO_INLINE")
 
 package coil.size
@@ -43,8 +43,7 @@ sealed class Dimension {
 /**
  * Convenience function to create a [Dimension.Pixels].
  */
-@JvmName("create")
-inline fun Dimension(@Px pixels: Int) = Dimension.Pixels(pixels)
+inline fun Dimension(@Px px: Int) = Dimension.Pixels(px)
 
 /**
  * If this is a [Dimension.Pixels] value, return its number of pixels. Else, invoke and return

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -17,6 +17,15 @@ data class Size(
     val height: Dimension,
 ) {
 
+    /** Create a [Size] with a pixel value for width. */
+    constructor(@Px width: Int, height: Dimension) : this(Dimension(width), height)
+
+    /** Create a [Size] with a pixel value for height. */
+    constructor(width: Dimension, @Px height: Int) : this(width, Dimension(height))
+
+    /** Create a [Size] with pixel values for both width and height. */
+    constructor(@Px width: Int, @Px height: Int) : this(Dimension(width), Dimension(height))
+
     companion object {
         /**
          * A [Size] whose width and height are equal to the original dimensions of the source image.
@@ -24,11 +33,6 @@ data class Size(
         @JvmField val ORIGINAL = Size(Dimension.Original, Dimension.Original)
     }
 }
-
-/**
- * Create a [Size] with pixel values for both width and height.
- */
-fun Size(@Px width: Int, @Px height: Int) = Size(Dimension(width), Dimension(height))
 
 /**
  * Return true if this size is equal to [Size.ORIGINAL]. Else, return false.
@@ -41,13 +45,6 @@ val Size.isOriginal: Boolean
     replaceWith = ReplaceWith("Size", "coil.size.Size")
 )
 typealias PixelSize = Size
-
-@Deprecated(
-    message = "Migrate to 'coil.size.Size'.",
-    replaceWith = ReplaceWith("Size(width, height)", "coil.size.Size")
-)
-@JvmName("PixelSize")
-inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
 
 @Deprecated(
     message = "Migrate to 'coil.size.Size.ORIGINAL'.",

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -53,4 +53,5 @@ inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
     message = "Migrate to 'coil.size.Size.ORIGINAL'.",
     replaceWith = ReplaceWith("Size.ORIGINAL", "coil.size.Size")
 )
-inline val OriginalSize get() = Size.ORIGINAL
+inline val OriginalSize: Size
+    @JvmName("OriginalSize") get() = Size.ORIGINAL

--- a/coil-base/src/main/java/coil/size/Size.kt
+++ b/coil-base/src/main/java/coil/size/Size.kt
@@ -1,4 +1,4 @@
-@file:JvmName("Sizes")
+@file:JvmName("-Sizes")
 @file:Suppress("NOTHING_TO_INLINE", "unused")
 
 package coil.size
@@ -28,7 +28,6 @@ data class Size(
 /**
  * Create a [Size] with pixel values for both width and height.
  */
-@JvmName("create")
 fun Size(@Px width: Int, @Px height: Int) = Size(Dimension(width), Dimension(height))
 
 /**
@@ -54,5 +53,4 @@ inline fun PixelSize(@Px width: Int, @Px height: Int) = Size(width, height)
     message = "Migrate to 'coil.size.Size.ORIGINAL'.",
     replaceWith = ReplaceWith("Size.ORIGINAL", "coil.size.Size")
 )
-inline val OriginalSize: Size
-    @JvmName("OriginalSize") get() = Size.ORIGINAL
+inline val OriginalSize get() = Size.ORIGINAL

--- a/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
+++ b/coil-base/src/main/java/coil/size/ViewSizeResolver.kt
@@ -85,24 +85,24 @@ interface ViewSizeResolver<T : View> : SizeResolver {
     )
 
     private fun getDimension(paramSize: Int, viewSize: Int, paddingSize: Int): Dimension? {
+        // If the dimension is set to WRAP_CONTENT, use the original dimension of the image.
+        if (paramSize == ViewGroup.LayoutParams.WRAP_CONTENT) {
+            return Dimension.Original
+        }
+
         // Assume the dimension will match the value in the view's layout params.
         val insetParamSize = paramSize - paddingSize
         if (insetParamSize > 0) {
             return Dimension(insetParamSize)
         }
 
-        // Fallback to the view's current size.
+        // Fallback to the view's current dimension.
         val insetViewSize = viewSize - paddingSize
         if (insetViewSize > 0) {
             return Dimension(insetViewSize)
         }
 
-        // If the dimension is set to WRAP_CONTENT, fall back to the original size of the image.
-        if (paramSize == ViewGroup.LayoutParams.WRAP_CONTENT) {
-            return Dimension.Original
-        }
-
-        // Unable to resolve the dimension's size.
+        // Unable to resolve the dimension's value.
         return null
     }
 

--- a/coil-base/src/main/java/coil/util/Bitmaps.kt
+++ b/coil-base/src/main/java/coil/util/Bitmaps.kt
@@ -5,7 +5,6 @@ package coil.util
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.drawable.BitmapDrawable
 import android.os.Build.VERSION.SDK_INT
 import androidx.core.graphics.drawable.toDrawable
 
@@ -43,8 +42,7 @@ internal val Bitmap.Config.isHardware: Boolean
 internal val Bitmap.safeConfig: Bitmap.Config
     get() = config ?: Bitmap.Config.ARGB_8888
 
-internal inline fun Bitmap.toDrawable(context: Context): BitmapDrawable =
-    toDrawable(context.resources)
+internal inline fun Bitmap.toDrawable(context: Context) = toDrawable(context.resources)
 
 /** Convert null and [Bitmap.Config.HARDWARE] configs to [Bitmap.Config.ARGB_8888]. */
 internal fun Bitmap.Config?.toSoftware(): Bitmap.Config {

--- a/coil-base/src/main/java/coil/util/Collections.kt
+++ b/coil-base/src/main/java/coil/util/Collections.kt
@@ -15,6 +15,16 @@ internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
 }
 
 /**
+ * Functionally the same as [Iterable.forEachIndexed] except it generates
+ * an index-based loop that doesn't use an [Iterator].
+ */
+internal inline fun <T> List<T>.forEachIndexedIndices(action: (Int, T) -> Unit) {
+    for (i in indices) {
+        action(i, get(i))
+    }
+}
+
+/**
  * Functionally the same as [Iterable.fold] except it generates
  * an index-based loop that doesn't use an [Iterator].
  */

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -209,6 +209,8 @@ internal val Interceptor.Chain.isPlaceholderCached: Boolean
 internal val Interceptor.Chain.eventListener: EventListener
     get() = if (this is RealInterceptorChain) eventListener else EventListener.NONE
 
+internal fun Int.isMinOrMax() = this == Int.MIN_VALUE || this == Int.MAX_VALUE
+
 internal fun unsupported(): Nothing = error("Unsupported")
 
 /** A simple [Optional] replacement. */

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -156,8 +156,8 @@ internal inline val Any.identityHashCode: Int
     get() = System.identityHashCode(this)
 
 @OptIn(ExperimentalStdlibApi::class)
-internal inline val CoroutineContext.dispatcher: CoroutineDispatcher
-    get() = get(CoroutineDispatcher) ?: error("Current context doesn't contain CoroutineDispatcher in it: $this")
+internal val CoroutineContext.dispatcher: CoroutineDispatcher?
+    get() = get(CoroutineDispatcher)
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal fun <T> Deferred<T>.getCompletedOrNull(): T? {
@@ -196,7 +196,7 @@ internal fun DiskCache.Editor.abortQuietly() {
     } catch (_: Exception) {}
 }
 
-internal fun Dimension.valueString(): String {
+internal fun Dimension.pxString(): String {
     return if (this is Dimension.Pixels) px.toString() else toString()
 }
 

--- a/coil-base/src/main/java/coil/util/Utils.kt
+++ b/coil-base/src/main/java/coil/util/Utils.kt
@@ -24,12 +24,15 @@ import android.widget.ImageView.ScaleType.FIT_END
 import android.widget.ImageView.ScaleType.FIT_START
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import coil.ComponentRegistry
+import coil.EventListener
 import coil.ImageLoader
 import coil.base.R
 import coil.decode.DataSource
 import coil.decode.Decoder
 import coil.disk.DiskCache
 import coil.fetch.Fetcher
+import coil.intercept.Interceptor
+import coil.intercept.RealInterceptorChain
 import coil.memory.MemoryCache
 import coil.request.DefaultRequestOptions
 import coil.request.Parameters
@@ -199,6 +202,12 @@ internal fun DiskCache.Editor.abortQuietly() {
 internal fun Dimension.pxString(): String {
     return if (this is Dimension.Pixels) px.toString() else toString()
 }
+
+internal val Interceptor.Chain.isPlaceholderCached: Boolean
+    get() = this is RealInterceptorChain && isPlaceholderCached
+
+internal val Interceptor.Chain.eventListener: EventListener
+    get() = if (this is RealInterceptorChain) eventListener else EventListener.NONE
 
 internal fun unsupported(): Nothing = error("Unsupported")
 

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -1,7 +1,6 @@
 package coil.intercept
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
@@ -10,28 +9,14 @@ import coil.EventListener
 import coil.ImageLoader
 import coil.RealImageLoader
 import coil.decode.DataSource
-import coil.intercept.EngineInterceptor.Companion.EXTRA_IS_SAMPLED
-import coil.intercept.EngineInterceptor.Companion.MEMORY_CACHE_KEY_HEIGHT
-import coil.intercept.EngineInterceptor.Companion.MEMORY_CACHE_KEY_TRANSFORMATIONS
-import coil.intercept.EngineInterceptor.Companion.MEMORY_CACHE_KEY_WIDTH
-import coil.intercept.EngineInterceptor.Companion.TRANSFORMATIONS_DELIMITER
 import coil.intercept.EngineInterceptor.ExecuteResult
 import coil.key.Keyer
-import coil.memory.MemoryCache.Key
-import coil.memory.MemoryCache.Value
-import coil.request.ImageRequest
 import coil.request.Options
-import coil.request.Parameters
 import coil.request.RequestService
 import coil.size
-import coil.size.Dimension
-import coil.size.Precision
-import coil.size.Scale
 import coil.size.Size
 import coil.transform.CircleCropTransformation
-import coil.transform.Transformation
 import coil.util.SystemCallbacks
-import coil.util.createBitmap
 import coil.util.createRequest
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -39,11 +24,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 class EngineInterceptorTest {
@@ -54,388 +36,6 @@ class EngineInterceptorTest {
     fun before() {
         context = ApplicationProvider.getApplicationContext()
     }
-
-    @Test
-    fun `computeMemoryCacheKey - null key`() {
-        val interceptor = newInterceptor(key = null)
-        val request = createRequest(context)
-        val options = Options(context, size = Size.ORIGINAL)
-        val key = runBlocking {
-            interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
-        }
-
-        assertNull(key)
-    }
-
-    @Test
-    fun `computeMemoryCacheKey - simple key`() {
-        val interceptor = newInterceptor()
-        val request = createRequest(context)
-        val options = Options(context, size = Size.ORIGINAL)
-        val actual = runBlocking {
-            interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
-        }
-
-        assertEquals(newMemoryCacheKey(), actual)
-    }
-
-    @Test
-    fun `computeMemoryCacheKey - params only`() {
-        val interceptor = newInterceptor()
-        val parameters = createFakeParameters()
-        val request = createRequest(context) {
-            parameters(parameters)
-        }
-        val options = Options(context, size = Size.ORIGINAL)
-        val actual = runBlocking {
-            interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
-        }
-
-        assertEquals(newMemoryCacheKey(parameters = parameters), actual)
-    }
-
-    @Test
-    fun `computeMemoryCacheKey - transformations only`() {
-        val interceptor = newInterceptor()
-        val transformations = createFakeTransformations()
-        val request = createRequest(context) {
-            transformations(transformations)
-        }
-        val size = Size(123, 332)
-        val options = Options(context, size = size)
-        val actual = runBlocking {
-            interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
-        }
-
-        assertEquals(newMemoryCacheKey(transformations = transformations, size = size), actual)
-    }
-
-    @Test
-    fun `computeMemoryCacheKey - complex key`() {
-        val interceptor = newInterceptor(key = TEST_KEY)
-        val parameters = createFakeParameters()
-        val transformations = createFakeTransformations()
-        val request = createRequest(context) {
-            parameters(parameters)
-            transformations(transformations)
-        }
-        val options = Options(context, size = Size.ORIGINAL)
-        val actual = runBlocking {
-            interceptor.getMemoryCacheKey(request, Unit, options, EventListener.NONE)
-        }
-
-        assertEquals(newMemoryCacheKey(transformations = transformations, parameters = parameters), actual)
-    }
-
-    @Test
-    fun `isCachedValueValid - fill`() {
-        val interceptor = newInterceptor()
-        val request = createRequest(context) {
-            size(100, 100)
-            precision(Precision.INEXACT)
-            scale(Scale.FILL)
-        }
-        val cached = createBitmap()
-        assertFalse(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(200, 200)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(150, 50)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(100, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(50, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(50, 50)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 400, height = 200),
-            isSampled = true,
-            request = request,
-            size = Size(400, 200)
-        ))
-    }
-
-    @Test
-    fun `isCachedValueValid - fit`() {
-        val interceptor = newInterceptor()
-        val request = createRequest(context) {
-            size(100, 100)
-            precision(Precision.INEXACT)
-            scale(Scale.FIT)
-        }
-        val cached = createBitmap()
-        assertFalse(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(200, 200)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(150, 50)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(100, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(50, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = true,
-            request = request,
-            size = Size(50, 50)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 200, height = 400),
-            isSampled = true,
-            request = request,
-            size = Size(400, 800)
-        ))
-    }
-
-    @Test
-    fun `isCachedValueValid - small not sampled cached drawable is valid`() {
-        val interceptor = newInterceptor()
-        val cached = createBitmap()
-        val isValid = interceptor.isCachedValueValid(
-            cached = cached,
-            isSampled = false,
-            request = createRequest(context) {
-                precision(Precision.INEXACT)
-                scale(Scale.FILL)
-            },
-            size = Size(200, 200)
-        )
-        assertTrue(isValid)
-    }
-
-    @Test
-    fun `isCachedValueValid - allowHardware=false prevents using cached hardware bitmap`() {
-        val interceptor = newInterceptor()
-        fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
-            val cached = createBitmap(config = config)
-            return interceptor.isCachedValueValid(
-                cached = cached,
-                isSampled = true,
-                request = createRequest(context) {
-                    allowHardware(false)
-                    scale(Scale.FILL)
-                },
-                size = Size(100, 100)
-            )
-        }
-
-        assertFalse(isBitmapConfigValid(Bitmap.Config.HARDWARE))
-        assertTrue(isBitmapConfigValid(Bitmap.Config.RGBA_F16))
-        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888))
-        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565))
-    }
-
-    @Test
-    fun `isCachedValueValid - exact precision`() {
-        val interceptor = newInterceptor()
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FILL)
-            },
-            size = Size(50, 50)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(50, 50)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FILL)
-            },
-            size = Size(100, 50)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(100, 50)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FILL)
-            },
-            size = Size(100, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 100, height = 100),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(100, 100)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 400, height = 200),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FILL)
-            },
-            size = Size(400, 200)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 200, height = 400),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(400, 800)
-        ))
-    }
-
-    @Test
-    fun `isCachedValueValid - one pixel off`() {
-        val interceptor = newInterceptor()
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 244, height = 600),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(245, 600)
-        ))
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 244, height = 600),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.INEXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(245, 600)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 243, height = 595),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.EXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(245, 600)
-        ))
-        assertFalse(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 243, height = 595),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.INEXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(245, 600)
-        ))
-        // Regression test: https://github.com/coil-kt/coil/issues/817
-        assertTrue(interceptor.isCachedValueValid(
-            cached = createBitmap(width = 175, height = 117),
-            isSampled = true,
-            request = createRequest(context) {
-                precision(Precision.INEXACT)
-                scale(Scale.FIT)
-            },
-            size = Size(176, 176)
-        ))
-    }
-
-    @Test
-    fun `isCachedValueValid - transformation that reduces size of output bitmap`() {
-        val interceptor = newInterceptor()
-        val key = newMemoryCacheKey(
-            key = "key",
-            transformations = listOf(CircleCropTransformation()),
-            size = Size(1000, 500) // The size of the previous request.
-        )
-        val value = Value(
-            bitmap = createBitmap(width = 200, height = 200), // The small cached bitmap.
-            extras = mapOf(EXTRA_IS_SAMPLED to true)
-        )
-        val request = createRequest(context)
-
-        assertTrue(interceptor.isMemoryCacheValueValid(
-            cacheKey = key,
-            cacheValue = value,
-            request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
-            size = Size(650, 400)
-        ))
-
-        assertTrue(interceptor.isMemoryCacheValueValid(
-            cacheKey = key,
-            cacheValue = value,
-            request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
-            size = Size(1000, 500)
-        ))
-
-        assertFalse(interceptor.isMemoryCacheValueValid(
-            cacheKey = key,
-            cacheValue = value,
-            request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
-            size = Size(1500, 1000)
-        ))
-
-        assertFalse(interceptor.isMemoryCacheValueValid(
-            cacheKey = key,
-            cacheValue = value,
-            request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
-            size = Size(800, 500)
-        ))
-    }
-
-    private fun EngineInterceptor.isCachedValueValid(
-        cached: Bitmap,
-        isSampled: Boolean,
-        request: ImageRequest,
-        size: Size
-    ) = isCachedValueValid(Key("key"), Value(cached, mapOf(EXTRA_IS_SAMPLED to isSampled)), request, size)
 
     @Test
     fun `applyTransformations - transformations convert drawable to bitmap`() {
@@ -450,7 +50,9 @@ class EngineInterceptorTest {
                     dataSource = DataSource.MEMORY,
                     diskCacheKey = null
                 ),
-                request = createRequest(context) { transformations(CircleCropTransformation()) },
+                request = createRequest(context) {
+                    transformations(CircleCropTransformation())
+                },
                 options = Options(context, size = size),
                 eventListener = EventListener.NONE
             )
@@ -473,34 +75,15 @@ class EngineInterceptorTest {
                     dataSource = DataSource.MEMORY,
                     diskCacheKey = null
                 ),
-                request = createRequest(context) { transformations(emptyList()) },
+                request = createRequest(context) {
+                    transformations(emptyList())
+                },
                 options = Options(context, size = Size(100, 100)),
                 eventListener = EventListener.NONE
             )
         }
 
         assertSame(drawable, result.drawable)
-    }
-
-    private fun createFakeTransformations(): List<Transformation> {
-        return listOf(
-            object : Transformation {
-                override val cacheKey = "key1"
-                override suspend fun transform(input: Bitmap, size: Size) = fail()
-            },
-            object : Transformation {
-                override val cacheKey = "key2"
-                override suspend fun transform(input: Bitmap, size: Size) = fail()
-            }
-        )
-    }
-
-    private fun createFakeParameters(): Parameters {
-        return Parameters.Builder()
-            .set("key1", "no_cache", cacheKey = null)
-            .set("key2", "cached2")
-            .set("key3", "cached3")
-            .build()
     }
 
     private fun newInterceptor(key: String? = TEST_KEY): EngineInterceptor {
@@ -515,27 +98,6 @@ class EngineInterceptorTest {
             requestService = RequestService(imageLoader, systemCallbacks, null),
             logger = null
         )
-    }
-
-    private fun newMemoryCacheKey(
-        key: String = TEST_KEY,
-        transformations: List<Transformation> = emptyList(),
-        size: Size = Size.ORIGINAL,
-        parameters: Parameters = Parameters.EMPTY
-    ): Key {
-        val extras = buildMap<String, String> {
-            if (transformations.isNotEmpty()) {
-                val transformationString = transformations.joinToString(separator = "") {
-                    it.cacheKey + TRANSFORMATIONS_DELIMITER
-                }
-                put(MEMORY_CACHE_KEY_TRANSFORMATIONS, transformationString)
-            }
-            val (width, height) = size
-            if (width is Dimension.Pixels) put(MEMORY_CACHE_KEY_WIDTH, width.px.toString())
-            if (height is Dimension.Pixels) put(MEMORY_CACHE_KEY_HEIGHT, height.px.toString())
-            putAll(parameters.cacheKeys())
-        }
-        return Key(key, extras)
     }
 
     companion object {

--- a/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
+++ b/coil-base/src/test/java/coil/intercept/EngineInterceptorTest.kt
@@ -46,7 +46,6 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
-@OptIn(ExperimentalStdlibApi::class)
 class EngineInterceptorTest {
 
     private lateinit var context: Context
@@ -402,28 +401,28 @@ class EngineInterceptorTest {
         )
         val request = createRequest(context)
 
-        assertTrue(interceptor.isCachedValueValid(
+        assertTrue(interceptor.isMemoryCacheValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
             size = Size(650, 400)
         ))
 
-        assertTrue(interceptor.isCachedValueValid(
+        assertTrue(interceptor.isMemoryCacheValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
             size = Size(1000, 500)
         ))
 
-        assertFalse(interceptor.isCachedValueValid(
+        assertFalse(interceptor.isMemoryCacheValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
             size = Size(1500, 1000)
         ))
 
-        assertFalse(interceptor.isCachedValueValid(
+        assertFalse(interceptor.isMemoryCacheValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -392,7 +392,7 @@ class MemoryCacheServiceTest {
         )
         val request = createRequest(context)
 
-        assertTrue(service.isCacheValueValid(
+        assertFalse(service.isCacheValueValid(
             cacheKey = key,
             cacheValue = value,
             request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -421,10 +421,28 @@ class MemoryCacheServiceTest {
         ))
     }
 
+    @Test
+    fun `isCacheValueValid - Size_ORIGINAL`() {
+        val service = newService()
+
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 200, height = 400),
+            isSampled = true,
+            request = createRequest(context),
+            size = Size.ORIGINAL
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 200, height = 400),
+            isSampled = false,
+            request = createRequest(context),
+            size = Size.ORIGINAL
+        ))
+    }
+
     private fun MemoryCacheService.isCacheValueValid(
+        request: ImageRequest,
         cached: Bitmap,
         isSampled: Boolean,
-        request: ImageRequest,
         size: Size
     ) = isCacheValueValid(
         request = request,

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -486,7 +486,7 @@ class MemoryCacheServiceTest {
     }
 
     private fun MemoryCacheService.isCacheValueValid(
-        request: ImageRequest = createRequest(context),
+        request: ImageRequest,
         cached: Bitmap,
         isSampled: Boolean,
         size: Size

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -1,0 +1,490 @@
+package coil.coil.memory
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.test.core.app.ApplicationProvider
+import coil.EventListener
+import coil.ImageLoader
+import coil.RealImageLoader
+import coil.key.Keyer
+import coil.memory.MemoryCache
+import coil.memory.MemoryCacheService
+import coil.memory.MemoryCacheService.Companion.EXTRA_IS_SAMPLED
+import coil.memory.MemoryCacheService.Companion.EXTRA_TRANSFORMATION_INDEX
+import coil.memory.MemoryCacheService.Companion.EXTRA_TRANSFORMATION_SIZE
+import coil.request.ImageRequest
+import coil.request.Options
+import coil.request.Parameters
+import coil.request.RequestService
+import coil.size.Precision
+import coil.size.Scale
+import coil.size.Size
+import coil.transform.CircleCropTransformation
+import coil.transform.Transformation
+import coil.util.SystemCallbacks
+import coil.util.createBitmap
+import coil.util.createRequest
+import coil.util.forEachIndexedIndices
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+@RunWith(RobolectricTestRunner::class)
+class MemoryCacheServiceTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun before() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `computeMemoryCacheKey - null key`() {
+        val service = newService(key = null)
+        val request = createRequest(context)
+        val options = Options(context, size = Size.ORIGINAL)
+        val key = runBlocking {
+            service.newCacheKey(request, Unit, options, EventListener.NONE)
+        }
+
+        assertNull(key)
+    }
+
+    @Test
+    fun `computeMemoryCacheKey - simple key`() {
+        val service = newService()
+        val request = createRequest(context)
+        val options = Options(context, size = Size.ORIGINAL)
+        val actual = runBlocking {
+            service.newCacheKey(request, Unit, options, EventListener.NONE)
+        }
+
+        assertEquals(newMemoryCacheKey(), actual)
+    }
+
+    @Test
+    fun `computeMemoryCacheKey - params only`() {
+        val service = newService()
+        val parameters = createFakeParameters()
+        val request = createRequest(context) {
+            parameters(parameters)
+        }
+        val options = Options(context, size = Size.ORIGINAL)
+        val actual = runBlocking {
+            service.newCacheKey(request, Unit, options, EventListener.NONE)
+        }
+
+        assertEquals(newMemoryCacheKey(parameters = parameters), actual)
+    }
+
+    @Test
+    fun `computeMemoryCacheKey - transformations only`() {
+        val service = newService()
+        val transformations = createFakeTransformations()
+        val request = createRequest(context) {
+            transformations(transformations)
+        }
+        val size = Size(123, 332)
+        val options = Options(context, size = size)
+        val actual = runBlocking {
+            service.newCacheKey(request, Unit, options, EventListener.NONE)
+        }
+
+        assertEquals(newMemoryCacheKey(transformations = transformations, size = size), actual)
+    }
+
+    @Test
+    fun `computeMemoryCacheKey - complex key`() {
+        val service = newService(key = TEST_KEY)
+        val parameters = createFakeParameters()
+        val transformations = createFakeTransformations()
+        val request = createRequest(context) {
+            parameters(parameters)
+            transformations(transformations)
+        }
+        val options = Options(context, size = Size.ORIGINAL)
+        val actual = runBlocking {
+            service.newCacheKey(request, Unit, options, EventListener.NONE)
+        }
+
+        assertEquals(newMemoryCacheKey(transformations = transformations, parameters = parameters), actual)
+    }
+
+    @Test
+    fun `isCachedValueValid - fill`() {
+        val service = newService()
+        val request = createRequest(context) {
+            size(100, 100)
+            precision(Precision.INEXACT)
+            scale(Scale.FILL)
+        }
+        val cached = createBitmap()
+        assertFalse(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(200, 200)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(150, 50)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(100, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(50, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(50, 50)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            request = request,
+            size = Size(400, 200)
+        ))
+    }
+
+    @Test
+    fun `isCachedValueValid - fit`() {
+        val service = newService()
+        val request = createRequest(context) {
+            size(100, 100)
+            precision(Precision.INEXACT)
+            scale(Scale.FIT)
+        }
+        val cached = createBitmap()
+        assertFalse(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(200, 200)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(150, 50)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(100, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(50, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = cached,
+            isSampled = true,
+            request = request,
+            size = Size(50, 50)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 200, height = 400),
+            isSampled = true,
+            request = request,
+            size = Size(400, 800)
+        ))
+    }
+
+    @Test
+    fun `isCachedValueValid - small not sampled cached drawable is valid`() {
+        val service = newService()
+        val cached = createBitmap()
+        val isValid = service.isCacheValueValid(
+            cached = cached,
+            isSampled = false,
+            request = createRequest(context) {
+                precision(Precision.INEXACT)
+                scale(Scale.FILL)
+            },
+            size = Size(200, 200)
+        )
+        assertTrue(isValid)
+    }
+
+    @Test
+    fun `isCachedValueValid - allowHardware=false prevents using cached hardware bitmap`() {
+        val service = newService()
+        fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
+            val cached = createBitmap(config = config)
+            return service.isCacheValueValid(
+                cached = cached,
+                isSampled = true,
+                request = createRequest(context) {
+                    allowHardware(false)
+                    scale(Scale.FILL)
+                },
+                size = Size(100, 100)
+            )
+        }
+
+        assertFalse(isBitmapConfigValid(Bitmap.Config.HARDWARE))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGBA_F16))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.ARGB_8888))
+        assertTrue(isBitmapConfigValid(Bitmap.Config.RGB_565))
+    }
+
+    @Test
+    fun `isCachedValueValid - exact precision`() {
+        val service = newService()
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FILL)
+            },
+            size = Size(50, 50)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(50, 50)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FILL)
+            },
+            size = Size(100, 50)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(100, 50)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FILL)
+            },
+            size = Size(100, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 100, height = 100),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(100, 100)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FILL)
+            },
+            size = Size(400, 200)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 200, height = 400),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(400, 800)
+        ))
+    }
+
+    @Test
+    fun `isCachedValueValid - one pixel off`() {
+        val service = newService()
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 244, height = 600),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(245, 600)
+        ))
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 244, height = 600),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.INEXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(245, 600)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 243, height = 595),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.EXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(245, 600)
+        ))
+        assertFalse(service.isCacheValueValid(
+            cached = createBitmap(width = 243, height = 595),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.INEXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(245, 600)
+        ))
+        // Regression test: https://github.com/coil-kt/coil/issues/817
+        assertTrue(service.isCacheValueValid(
+            cached = createBitmap(width = 175, height = 117),
+            isSampled = true,
+            request = createRequest(context) {
+                precision(Precision.INEXACT)
+                scale(Scale.FIT)
+            },
+            size = Size(176, 176)
+        ))
+    }
+
+    @Test
+    fun `isCachedValueValid - transformation that reduces size of output bitmap`() {
+        val service = newService()
+        val key = newMemoryCacheKey(
+            key = "key",
+            transformations = listOf(CircleCropTransformation()),
+            size = Size(1000, 500) // The size of the previous request.
+        )
+        val value = MemoryCache.Value(
+            bitmap = createBitmap(width = 200, height = 200), // The small cached bitmap.
+            extras = mapOf(EXTRA_IS_SAMPLED to true)
+        )
+        val request = createRequest(context)
+
+        assertTrue(service.isCacheValueValid(
+            cacheKey = key,
+            cacheValue = value,
+            request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
+            size = Size(650, 400)
+        ))
+
+        assertTrue(service.isCacheValueValid(
+            cacheKey = key,
+            cacheValue = value,
+            request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
+            size = Size(1000, 500)
+        ))
+
+        assertFalse(service.isCacheValueValid(
+            cacheKey = key,
+            cacheValue = value,
+            request = request.newBuilder().precision(Precision.INEXACT).scale(Scale.FIT).build(),
+            size = Size(1500, 1000)
+        ))
+
+        assertFalse(service.isCacheValueValid(
+            cacheKey = key,
+            cacheValue = value,
+            request = request.newBuilder().precision(Precision.EXACT).scale(Scale.FIT).build(),
+            size = Size(800, 500)
+        ))
+    }
+
+    private fun MemoryCacheService.isCacheValueValid(
+        cached: Bitmap,
+        isSampled: Boolean,
+        request: ImageRequest,
+        size: Size
+    ): Boolean = isCacheValueValid(
+        request = request,
+        cacheKey = MemoryCache.Key("key"),
+        cacheValue = MemoryCache.Value(cached, mapOf(EXTRA_IS_SAMPLED to isSampled)),
+        size = size
+    )
+
+    private fun createFakeTransformations(): List<Transformation> {
+        return listOf(
+            object : Transformation {
+                override val cacheKey = "key1"
+                override suspend fun transform(input: Bitmap, size: Size) = fail()
+            },
+            object : Transformation {
+                override val cacheKey = "key2"
+                override suspend fun transform(input: Bitmap, size: Size) = fail()
+            }
+        )
+    }
+
+    private fun createFakeParameters(): Parameters {
+        return Parameters.Builder()
+            .set("key1", "no_cache", cacheKey = null)
+            .set("key2", "cached2")
+            .set("key3", "cached3")
+            .build()
+    }
+
+    private fun newService(key: String? = TEST_KEY): MemoryCacheService {
+        val imageLoader = ImageLoader.Builder(context)
+            .components {
+                add(Keyer { _: Any, _ -> key })
+            }
+            .build()
+        val systemCallbacks = SystemCallbacks(imageLoader as RealImageLoader, context, true)
+        return MemoryCacheService(
+            imageLoader = imageLoader,
+            requestService = RequestService(imageLoader, systemCallbacks, null),
+            logger = null
+        )
+    }
+
+    private fun newMemoryCacheKey(
+        key: String = TEST_KEY,
+        transformations: List<Transformation> = emptyList(),
+        size: Size = Size.ORIGINAL,
+        parameters: Parameters = Parameters.EMPTY
+    ): MemoryCache.Key {
+        val extras = parameters.cacheKeys().toMutableMap()
+        if (transformations.isNotEmpty()) {
+            transformations.forEachIndexedIndices { index, transformation ->
+                extras[EXTRA_TRANSFORMATION_INDEX + index] = transformation.cacheKey
+            }
+            extras[EXTRA_TRANSFORMATION_SIZE] = size.toString()
+        }
+        return MemoryCache.Key(key, extras)
+    }
+
+    companion object {
+        private const val TEST_KEY = "test_key"
+    }
+}

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -426,7 +426,7 @@ class MemoryCacheServiceTest {
         isSampled: Boolean,
         request: ImageRequest,
         size: Size
-    ): Boolean = isCacheValueValid(
+    ) = isCacheValueValid(
         request = request,
         cacheKey = MemoryCache.Key("key"),
         cacheValue = MemoryCache.Value(cached, mapOf(EXTRA_IS_SAMPLED to isSampled)),

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -16,6 +16,7 @@ import coil.request.ImageRequest
 import coil.request.Options
 import coil.request.Parameters
 import coil.request.RequestService
+import coil.size.Dimension
 import coil.size.Precision
 import coil.size.Scale
 import coil.size.Size
@@ -439,8 +440,53 @@ class MemoryCacheServiceTest {
         ))
     }
 
+    @Test
+    fun `isCacheValueValid - Dimension_Original`() {
+        val service = newService()
+        val request = createRequest(context) {
+            precision(Precision.INEXACT)
+        }
+
+        assertTrue(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            size = Size(400, Dimension.Original)
+        ))
+        assertTrue(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            size = Size(Dimension.Original, 200)
+        ))
+        assertFalse(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            size = Size(450, Dimension.Original)
+        ))
+        assertFalse(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = true,
+            size = Size(Dimension.Original, 250)
+        ))
+        assertTrue(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = false,
+            size = Size(450, Dimension.Original)
+        ))
+        assertTrue(service.isCacheValueValid(
+            request = request,
+            cached = createBitmap(width = 400, height = 200),
+            isSampled = false,
+            size = Size(Dimension.Original, 250)
+        ))
+    }
+
     private fun MemoryCacheService.isCacheValueValid(
-        request: ImageRequest,
+        request: ImageRequest = createRequest(context),
         cached: Bitmap,
         isSampled: Boolean,
         size: Size

--- a/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
+++ b/coil-base/src/test/java/coil/memory/MemoryCacheServiceTest.kt
@@ -47,7 +47,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `computeMemoryCacheKey - null key`() {
+    fun `newCacheKey - null key`() {
         val service = newService(key = null)
         val request = createRequest(context)
         val options = Options(context, size = Size.ORIGINAL)
@@ -59,7 +59,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `computeMemoryCacheKey - simple key`() {
+    fun `newCacheKey - simple key`() {
         val service = newService()
         val request = createRequest(context)
         val options = Options(context, size = Size.ORIGINAL)
@@ -71,7 +71,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `computeMemoryCacheKey - params only`() {
+    fun `newCacheKey - params only`() {
         val service = newService()
         val parameters = createFakeParameters()
         val request = createRequest(context) {
@@ -86,7 +86,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `computeMemoryCacheKey - transformations only`() {
+    fun `newCacheKey - transformations only`() {
         val service = newService()
         val transformations = createFakeTransformations()
         val request = createRequest(context) {
@@ -102,7 +102,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `computeMemoryCacheKey - complex key`() {
+    fun `newCacheKey - complex key`() {
         val service = newService(key = TEST_KEY)
         val parameters = createFakeParameters()
         val transformations = createFakeTransformations()
@@ -119,7 +119,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - fill`() {
+    fun `isCacheValueValid - fill`() {
         val service = newService()
         val request = createRequest(context) {
             size(100, 100)
@@ -166,7 +166,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - fit`() {
+    fun `isCacheValueValid - fit`() {
         val service = newService()
         val request = createRequest(context) {
             size(100, 100)
@@ -213,7 +213,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - small not sampled cached drawable is valid`() {
+    fun `isCacheValueValid - small not sampled cached drawable is valid`() {
         val service = newService()
         val cached = createBitmap()
         val isValid = service.isCacheValueValid(
@@ -229,7 +229,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - allowHardware=false prevents using cached hardware bitmap`() {
+    fun `isCacheValueValid - allowHardware=false prevents using cached hardware bitmap`() {
         val service = newService()
         fun isBitmapConfigValid(config: Bitmap.Config): Boolean {
             val cached = createBitmap(config = config)
@@ -251,7 +251,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - exact precision`() {
+    fun `isCacheValueValid - exact precision`() {
         val service = newService()
         assertFalse(service.isCacheValueValid(
             cached = createBitmap(width = 100, height = 100),
@@ -328,7 +328,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - one pixel off`() {
+    fun `isCacheValueValid - one pixel off`() {
         val service = newService()
         assertTrue(service.isCacheValueValid(
             cached = createBitmap(width = 244, height = 600),
@@ -379,7 +379,7 @@ class MemoryCacheServiceTest {
     }
 
     @Test
-    fun `isCachedValueValid - transformation that reduces size of output bitmap`() {
+    fun `isCacheValueValid - transformation that reduces size of output bitmap`() {
         val service = newService()
         val key = newMemoryCacheKey(
             key = "key",


### PR DESCRIPTION
This also fixes `isCacheValueValid` for sizes where one dimension is `Dimension.Original` and adds regression tests.