### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ allprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
 
     extensions.configure<KtlintExtension>("ktlint") {
-        version by "0.43.0"
+        version by "0.43.1"
         disabledRules by setOf("indent", "max-line-length", "parameter-list-wrapping")
     }
 

--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -9,8 +9,8 @@ object Library {
 
     const val ANDROIDX_ACTIVITY = "androidx.activity:activity-ktx:1.4.0"
     const val ANDROIDX_ANNOTATION = "androidx.annotation:annotation:1.3.0"
-    const val ANDROIDX_COLLECTION = "androidx.collection:collection:1.1.0"
-    const val ANDROIDX_CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:2.1.1"
+    const val ANDROIDX_COLLECTION = "androidx.collection:collection:1.2.0"
+    const val ANDROIDX_CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:2.1.2"
     const val ANDROIDX_CORE = "androidx.core:core-ktx:1.7.0"
     const val ANDROIDX_EXIF_INTERFACE = "androidx.exifinterface:exifinterface:1.3.3"
     const val ANDROIDX_RECYCLER_VIEW = "androidx.recyclerview:recyclerview:1.2.1"
@@ -54,5 +54,5 @@ object Library {
 
     const val OKHTTP_MOCK_WEB_SERVER = "com.squareup.okhttp3:mockwebserver:$OKHTTP_VERSION"
 
-    const val ROBOLECTRIC = "org.robolectric:robolectric:4.6.1"
+    const val ROBOLECTRIC = "org.robolectric:robolectric:4.7.3"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
And the [Compose 1.1.0-beta04](https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.1.0-beta04) is out, add the support for Kotlin 1.6.0, should we follow this version ?