### PR TITLE
Remove inline from several suspend functions.

### DIFF
--- a/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
+++ b/coil-base/src/main/java/coil/intercept/EngineInterceptor.kt
@@ -97,7 +97,7 @@ internal class EngineInterceptor(
     }
 
     /** Execute the [Fetcher], decode any data into a [Drawable], and apply any [Transformation]s. */
-    private suspend inline fun execute(
+    private suspend fun execute(
         request: ImageRequest,
         mappedData: Any,
         _options: Options,
@@ -145,7 +145,7 @@ internal class EngineInterceptor(
         return finalResult
     }
 
-    private suspend inline fun fetch(
+    private suspend fun fetch(
         components: ComponentRegistry,
         request: ImageRequest,
         mappedData: Any,
@@ -178,7 +178,7 @@ internal class EngineInterceptor(
         return fetchResult
     }
 
-    private suspend inline fun decode(
+    private suspend fun decode(
         fetchResult: SourceResult,
         components: ComponentRegistry,
         request: ImageRequest,
@@ -215,7 +215,7 @@ internal class EngineInterceptor(
 
     /** Apply any [Transformation]s and return an updated [ExecuteResult]. */
     @VisibleForTesting
-    internal suspend inline fun transform(
+    internal suspend fun transform(
         result: ExecuteResult,
         request: ImageRequest,
         options: Options,

--- a/coil-base/src/main/java/coil/util/Calls.kt
+++ b/coil-base/src/main/java/coil/util/Calls.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-internal suspend inline fun Call.await(): Response {
+internal suspend fun Call.await(): Response {
     return suspendCancellableCoroutine { continuation ->
         val callback = ContinuationCallback(this, continuation)
         enqueue(callback)
@@ -20,7 +20,7 @@ internal suspend inline fun Call.await(): Response {
     }
 }
 
-internal class ContinuationCallback(
+private class ContinuationCallback(
     private val call: Call,
     private val continuation: CancellableContinuation<Response>
 ) : Callback, CompletionHandler {

--- a/coil-base/src/main/java/coil/util/Lifecycles.kt
+++ b/coil-base/src/main/java/coil/util/Lifecycles.kt
@@ -13,17 +13,11 @@ import kotlin.coroutines.resume
 
 /** Suspend until [Lifecycle.getCurrentState] is at least [STARTED] */
 @MainThread
-internal suspend inline fun Lifecycle.awaitStarted() {
+internal suspend fun Lifecycle.awaitStarted() {
     // Fast path: we're already started.
     if (currentState.isAtLeast(STARTED)) return
 
     // Slow path: observe the lifecycle until we're started.
-    observeStarted()
-}
-
-/** Cannot be 'inline' due to a compiler bug. There is a test that guards against this bug. */
-@MainThread
-internal suspend fun Lifecycle.observeStarted() {
     var observer: LifecycleObserver? = null
     try {
         suspendCancellableCoroutine<Unit> { continuation ->


### PR DESCRIPTION
This doesn't improve performance and only increases code sizes since the method is inlined, but also still exists in the class.