### PR TITLE
Support custom ContentScales when computing AsyncImageContent's intrinsic size.

### DIFF
--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -99,7 +99,7 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
                 scale = options.scale
             )
 
-            // Only upscale the image if the request requests an exact size.
+            // Only upscale the image if the options require an exact size.
             if (options.allowInexactSize) {
                 scale = scale.coerceAtMost(1.0)
             }

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -99,7 +99,7 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
                 scale = options.scale
             )
 
-            // Avoid loading the image larger than its original dimensions if allowed.
+            // Only upscale the image if the request requests an exact size.
             if (options.allowInexactSize) {
                 scale = scale.coerceAtMost(1.0)
             }

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -76,7 +76,6 @@ public abstract interface class coil/compose/AsyncImageScope : androidx/compose/
 	public abstract fun getColorFilter ()Landroidx/compose/ui/graphics/ColorFilter;
 	public abstract fun getContentDescription ()Ljava/lang/String;
 	public abstract fun getContentScale ()Landroidx/compose/ui/layout/ContentScale;
-	public abstract fun getContentSize-NH-jbRc ()J
 	public abstract fun getPainter ()Lcoil/compose/AsyncImagePainter;
 }
 

--- a/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
+++ b/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -47,12 +46,10 @@ import coil.request.ImageRequest
 import coil.request.Options
 import coil.request.SuccessResult
 import coil.size.Scale
-import coil.size.Size
 import kotlinx.coroutines.delay
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -503,42 +500,6 @@ class AsyncImageTest {
             .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
             .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
-    }
-
-    @Ignore("Intrinsic measurements are not currently supported.")
-    @Test
-    fun intrinsicMeasurements() {
-        composeTestRule.setContent {
-            Layout(
-                content = {
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data(server.url("/image"))
-                            .size(Size.ORIGINAL)
-                            .build(),
-                        contentDescription = null,
-                        imageLoader = imageLoader,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .testTag(Image)
-                    )
-                },
-                measurePolicy = { measurables, constraints ->
-                    val placeables = measurables.map { measurable ->
-                        // This will throw an exception if using `SubcomposeLayout`.
-                        measurable.minIntrinsicWidth(100)
-                        measurable.measure(constraints)
-                    }
-                    layout(constraints.maxWidth, constraints.maxHeight) {
-                        placeables.forEach { it.placeRelative(0, 0) }
-                    }
-                }
-            )
-        }
-
-        waitForRequestComplete()
-
-        composeTestRule.onNodeWithTag(Image).assertIsDisplayed()
     }
 
     private fun waitForRequestComplete(finishedRequests: Int = 1) {

--- a/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
+++ b/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.delay
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -504,6 +505,7 @@ class AsyncImageTest {
             .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
     }
 
+    @Ignore("Intrinsic measurements are not currently supported.")
     @Test
     fun intrinsicMeasurements() {
         composeTestRule.setContent {

--- a/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
+++ b/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
@@ -506,8 +506,6 @@ class AsyncImageTest {
 
     @Test
     fun intrinsicMeasurements() {
-        assumeSupportsCaptureToImage()
-
         composeTestRule.setContent {
             Layout(
                 content = {
@@ -538,10 +536,7 @@ class AsyncImageTest {
 
         waitForRequestComplete()
 
-        composeTestRule.onNodeWithTag(Image)
-            .assertIsDisplayed()
-            .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample)
+        composeTestRule.onNodeWithTag(Image).assertIsDisplayed()
     }
 
     private fun waitForRequestComplete(finishedRequests: Int = 1) {

--- a/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
+++ b/coil-compose-base/src/androidTest/java/coil/compose/AsyncImageTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -46,6 +47,7 @@ import coil.request.ImageRequest
 import coil.request.Options
 import coil.request.SuccessResult
 import coil.size.Scale
+import coil.size.Size
 import kotlinx.coroutines.delay
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -500,6 +502,46 @@ class AsyncImageTest {
             .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
             .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
+    }
+
+    @Test
+    fun intrinsicMeasurements() {
+        assumeSupportsCaptureToImage()
+
+        composeTestRule.setContent {
+            Layout(
+                content = {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(server.url("/image"))
+                            .size(Size.ORIGINAL)
+                            .build(),
+                        contentDescription = null,
+                        imageLoader = imageLoader,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag(Image)
+                    )
+                },
+                measurePolicy = { measurables, constraints ->
+                    val placeables = measurables.map { measurable ->
+                        // This will throw an exception if using `SubcomposeLayout`.
+                        measurable.minIntrinsicWidth(100)
+                        measurable.measure(constraints)
+                    }
+                    layout(constraints.maxWidth, constraints.maxHeight) {
+                        placeables.forEach { it.placeRelative(0, 0) }
+                    }
+                }
+            )
+        }
+
+        waitForRequestComplete()
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertIsDisplayed()
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
     }
 
     private fun waitForRequestComplete(finishedRequests: Int = 1) {

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
@@ -199,13 +200,11 @@ fun AsyncImageScope.AsyncImageContent(
     Image(
         painter = painter,
         contentDescription = contentDescription,
-        modifier = if (contentSize != Size.Unspecified) {
-            with(LocalDensity.current) {
-                Modifier
-                    // Apply `modifier` second to allow overriding `contentSize`.
-                    .size(contentSize.toDpSize())
-                    .then(modifier)
-            }
+        modifier = if (contentSize.isSpecified) {
+            // Apply `modifier` second to allow overriding `contentSize`.
+            Modifier
+                .size(with(LocalDensity.current) { contentSize.toDpSize() })
+                .then(modifier)
         } else {
             modifier
         },

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -285,9 +285,9 @@ private fun Constraints.toSize(): CoilSize {
 }
 
 private val AsyncImageScope.constraints: Constraints
-    @Stable get() = if (this is RealAsyncImageScope) parentScope.constraints else EmptyConstraints
+    @Stable get() = if (this is RealAsyncImageScope) parentScope.constraints else ZeroConstraints
 
-private val EmptyConstraints = Constraints(0, 0, 0, 0)
+private val ZeroConstraints = Constraints(0, 0, 0, 0)
 
 private class ConstraintsSizeResolver : SizeResolver {
 

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -222,6 +222,7 @@ fun AsyncImageScope.AsyncImageContent(
         modifier = if (contentSize != Size.Unspecified) {
             with(LocalDensity.current) {
                 Modifier
+                    // Apply `modifier` second to allow overriding `contentSize`.
                     .size(contentSize.toDpSize())
                     .then(modifier)
             }

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -283,8 +283,8 @@ private fun computeContentSize(
     val dstHeight: Float
     when {
         constraints.hasFixedWidth && constraints.hasFixedHeight -> {
-            dstWidth = constraints.maxWidth.toFloat()
-            dstHeight = constraints.maxWidth.toFloat()
+            dstWidth = constraints.minWidth.toFloat()
+            dstHeight = constraints.minHeight.toFloat()
         }
         constraints.hasFixedWidth -> {
             dstWidth = constraints.minWidth.toFloat()

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -259,24 +259,15 @@ private fun computeContentSize(
         return Size.Unspecified
     }
 
-    val dstWidth: Float
-    val dstHeight: Float
-    when {
-        constraints.hasFixedWidth && constraints.hasFixedHeight -> {
-            dstWidth = constraints.minWidth.toFloat()
-            dstHeight = constraints.minHeight.toFloat()
-        }
-        constraints.hasFixedWidth -> {
-            dstWidth = constraints.minWidth.toFloat()
-            dstHeight = constraints.maxHeight.toFloat()
-        }
-        constraints.hasFixedHeight -> {
-            dstWidth = constraints.maxWidth.toFloat()
-            dstHeight = constraints.minHeight.toFloat()
-        }
-        else -> return Size.Unspecified
+    // Only set a specific content size if at least one dimension is fixed.
+    val hasFixedAndBoundedWidth = constraints.hasFixedWidth && constraints.hasBoundedWidth
+    val hasFixedAndBoundedHeight = constraints.hasFixedHeight && constraints.hasBoundedHeight
+    if (!hasFixedAndBoundedWidth && !hasFixedAndBoundedHeight) {
+        return Size.Unspecified
     }
-    return srcSize * contentScale.computeScaleFactor(srcSize, Size(dstWidth, dstHeight))
+
+    val dstSize = Size(constraints.maxWidth.toFloat(), constraints.maxHeight.toFloat())
+    return srcSize * contentScale.computeScaleFactor(srcSize, dstSize)
 }
 
 @Stable


### PR DESCRIPTION
Currently we're assuming the image's aspect ratio is always the same - which isn't true for all `ContentScale`s.

This also makes `AsyncImageScope.contentSize` a private API. This is done in case we figure out a way to resolve the size lazily in the future (and not tie it to the scope).