### PR TITLE
Update Coroutines (1.6.0)

### DIFF
--- a/buildSrc/src/main/kotlin/Library.kt
+++ b/buildSrc/src/main/kotlin/Library.kt
@@ -4,7 +4,7 @@ object Library {
 
     // CORE
 
-    private const val COROUTINES_VERSION = "1.6.0-RC3"
+    private const val COROUTINES_VERSION = "1.6.0"
     const val KOTLINX_COROUTINES_ANDROID = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$COROUTINES_VERSION"
 
     const val ANDROIDX_ACTIVITY = "androidx.activity:activity-ktx:1.4.0"

--- a/coil-gif/src/androidTest/java/coil/transform/AnimationCallbacksTest.kt
+++ b/coil-gif/src/androidTest/java/coil/transform/AnimationCallbacksTest.kt
@@ -17,11 +17,10 @@ import coil.request.onAnimationStart
 import coil.request.repeatCount
 import coil.util.TestActivity
 import coil.util.activity
-import coil.util.runTestMain
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -53,7 +52,7 @@ class AnimationCallbacksTest {
     }
 
     @Test
-    fun callbacksTest() = runTestMain {
+    fun callbacksTest() = runTest(dispatchTimeoutMs = 30_000) {
         val imageView = activityRule.scenario.activity.imageView
         val isStartCalled = MutableStateFlow(false)
         val isEndCalled = MutableStateFlow(false)
@@ -77,7 +76,7 @@ class AnimationCallbacksTest {
             .build()
         val result = imageLoader.execute(request)
         if (result is ErrorResult) throw result.throwable
-        withTimeout(30_000) { isStartCalled.first { it } }
-        withTimeout(30_000) { isEndCalled.first { it } }
+        isStartCalled.first { it }
+        isEndCalled.first { it }
     }
 }


### PR DESCRIPTION
- Most of the existing test code is already using Coroutine 1.6 API
- If we can remove usage of `runTestMain()` and `runTestAsync()`, the test code would be more idiomatic.
  - However, I have already spent quite some time refactoring even the production API.
  - I am posting this PR as the easy part for review.

## References
[1.6 guide](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/README.md)
[1.6 migration](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/MIGRATION.md) 