### PR TITLE
Clean up DiskLruCache.

### DIFF
--- a/coil-base/src/main/java/coil/disk/DiskLruCache.kt
+++ b/coil-base/src/main/java/coil/disk/DiskLruCache.kt
@@ -503,7 +503,7 @@ internal class DiskLruCache(
     /**
      * We rewrite [lruEntries] to the on-disk journal after a sufficient number of operations.
      */
-    private fun journalRewriteRequired() = operationsSinceRewrite >= OPERATIONS_THRESHOLD
+    private fun journalRewriteRequired() = operationsSinceRewrite >= 2000
 
     /**
      * Drops the entry for [key] if it exists and can be removed. If the entry for [key] is
@@ -847,7 +847,6 @@ internal class DiskLruCache(
         private const val DIRTY = "DIRTY"
         private const val REMOVE = "REMOVE"
         private const val READ = "READ"
-        private const val OPERATIONS_THRESHOLD = 2000
         private val LEGAL_KEY_PATTERN = "[a-z0-9_-]{1,120}".toRegex()
     }
 }

--- a/coil-base/src/main/java/coil/disk/DiskLruCache.kt
+++ b/coil-base/src/main/java/coil/disk/DiskLruCache.kt
@@ -130,9 +130,10 @@ internal class DiskLruCache(
      */
 
     private val journalFile = directory / JOURNAL_FILE
-    private val journalFileTmp = directory / JOURNAL_FILE_TEMP
+    private val journalFileTmp = directory / JOURNAL_FILE_TMP
     private val journalFileBackup = directory / JOURNAL_FILE_BACKUP
     private val lruEntries = LinkedHashMap<String, Entry>(0, 0.75f, true)
+
     private var size = 0L
     private var operationsSinceRewrite = 0
     private var journalWriter: BufferedSink? = null
@@ -838,7 +839,7 @@ internal class DiskLruCache(
 
     companion object {
         private const val JOURNAL_FILE = "journal"
-        private const val JOURNAL_FILE_TEMP = "journal.tmp"
+        private const val JOURNAL_FILE_TMP = "journal.tmp"
         private const val JOURNAL_FILE_BACKUP = "journal.bkp"
         private const val MAGIC = "libcore.io.DiskLruCache"
         private const val VERSION = "1"

--- a/coil-base/src/main/java/coil/disk/FaultHidingSink.kt
+++ b/coil-base/src/main/java/coil/disk/FaultHidingSink.kt
@@ -6,7 +6,7 @@ import okio.IOException
 import okio.Sink
 
 /** A sink that never throws [IOException]s, even if the underlying sink does. */
-internal open class FaultHidingSink(
+internal class FaultHidingSink(
     delegate: Sink,
     private val onException: (IOException) -> Unit
 ) : ForwardingSink(delegate) {

--- a/coil-base/src/main/java/coil/util/FileSystems.kt
+++ b/coil-base/src/main/java/coil/util/FileSystems.kt
@@ -22,13 +22,6 @@ import okio.FileSystem
 import okio.IOException
 import okio.Path
 
-/** Delete file we expect but don't require to exist. */
-internal fun FileSystem.deleteIfExists(path: Path) {
-    try {
-        delete(path)
-    } catch (_: FileNotFoundException) {}
-}
-
 /** Tolerant delete, try to clear as many files as possible even after a failure. */
 internal fun FileSystem.deleteContents(directory: Path) {
     var exception: IOException? = null
@@ -42,7 +35,6 @@ internal fun FileSystem.deleteContents(directory: Path) {
             if (metadata(file).isDirectory) {
                 deleteContents(file)
             }
-
             delete(file)
         } catch (e: IOException) {
             if (exception == null) {


### PR DESCRIPTION
- Remove `deleteIfExists` as `delete` doesn't throw by default.
- Use `cleanupDispatcher.limitedParallelism(1)` instead of a boolean lock to avoid potential concurrency issues.