### PR TITLE
Fix scaling for Bitmap resources with original size

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -226,7 +226,8 @@ public final class coil/decode/ImageSources {
 }
 
 public final class coil/decode/ResourceMetadata : coil/decode/ImageSource$Metadata {
-	public fun <init> (Ljava/lang/String;I)V
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun getDensity ()I
 	public final fun getPackageName ()Ljava/lang/String;
 	public final fun getResId ()I
 }

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -2,14 +2,11 @@ package coil.decode
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Matrix
-import android.graphics.Paint
-import android.graphics.RectF
 import android.os.Build.VERSION.SDK_INT
-import androidx.core.graphics.applyCanvas
-import androidx.core.graphics.createBitmap
 import androidx.exifinterface.media.ExifInterface
 import coil.ImageLoader
+import coil.decode.Exif.Data.Companion.toExifData
+import coil.decode.Exif.applyExifTransformations
 import coil.fetch.SourceResult
 import coil.request.Options
 import coil.size.isOriginal
@@ -23,7 +20,6 @@ import okio.Buffer
 import okio.ForwardingSource
 import okio.Source
 import okio.buffer
-import java.io.InputStream
 import kotlin.math.roundToInt
 
 /** The base [Decoder] that uses [BitmapFactory] to decode a given [ImageSource]. */
@@ -32,8 +28,6 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
     private val options: Options,
     private val parallelismLock: Semaphore = Semaphore(Int.MAX_VALUE)
 ) : Decoder {
-
-    private val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
     override suspend fun decode() = parallelismLock.withPermit {
         runInterruptible { BitmapFactory.Options().decode() }
@@ -50,26 +44,21 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         inJustDecodeBounds = false
 
         // Read the image's EXIF data.
-        val isFlipped: Boolean
-        val rotationDegrees: Int
-        if (shouldReadExifData(outMimeType)) {
+        val exifData = if (Exif.shouldReadExifData(outMimeType)) {
             val inputStream = safeBufferedSource.peek().inputStream()
             val exifInterface = ExifInterface(ExifInterfaceInputStream(inputStream))
             safeSource.exception?.let { throw it }
-            isFlipped = exifInterface.isFlipped
-            rotationDegrees = exifInterface.rotationDegrees
+            exifInterface.toExifData()
         } else {
-            isFlipped = false
-            rotationDegrees = 0
+            Exif.Data.DEFAULT
         }
 
         // srcWidth and srcHeight are the dimensions of the image after
         // EXIF transformations (but before sampling).
-        val isSwapped = rotationDegrees == 90 || rotationDegrees == 270
-        val srcWidth = if (isSwapped) outHeight else outWidth
-        val srcHeight = if (isSwapped) outWidth else outHeight
+        val srcWidth = if (exifData.isSwapped) outHeight else outWidth
+        val srcHeight = if (exifData.isSwapped) outWidth else outHeight
 
-        inPreferredConfig = computeConfig(options, isFlipped, rotationDegrees)
+        inPreferredConfig = computeConfig(options, exifData)
         inPremultiplied = options.premultipliedAlpha
 
         if (SDK_INT >= 26 && options.colorSpace != null) {
@@ -146,7 +135,7 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         outBitmap.density = options.context.resources.displayMetrics.densityDpi
 
         // Apply any EXIF transformations.
-        val bitmap = applyExifTransformations(outBitmap, inPreferredConfig, isFlipped, rotationDegrees)
+        val bitmap = applyExifTransformations(outBitmap, inPreferredConfig, exifData)
 
         return DecodeResult(
             drawable = bitmap.toDrawable(options.context),
@@ -154,21 +143,15 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         )
     }
 
-    /** Return 'true' if we should read the image's EXIF data. */
-    private fun shouldReadExifData(mimeType: String?): Boolean {
-        return mimeType != null && mimeType in SUPPORTED_EXIF_MIME_TYPES
-    }
-
     /** Compute and return [BitmapFactory.Options.inPreferredConfig]. */
     private fun BitmapFactory.Options.computeConfig(
         options: Options,
-        isFlipped: Boolean,
-        rotationDegrees: Int
+        exifData: Exif.Data
     ): Bitmap.Config {
         var config = options.config
 
         // Disable hardware bitmaps if we need to perform EXIF transformations.
-        if (isFlipped || rotationDegrees > 0) {
+        if (exifData.isFlipped || exifData.rotationDegrees > 0) {
             config = config.toSoftware()
         }
 
@@ -183,48 +166,6 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         }
 
         return config
-    }
-
-    /** This method assumes [config] is not [Bitmap.Config.HARDWARE]. */
-    private fun applyExifTransformations(
-        inBitmap: Bitmap,
-        config: Bitmap.Config,
-        isFlipped: Boolean,
-        rotationDegrees: Int
-    ): Bitmap {
-        // Short circuit if there are no transformations to apply.
-        val isRotated = rotationDegrees > 0
-        if (!isFlipped && !isRotated) {
-            return inBitmap
-        }
-
-        val matrix = Matrix()
-        val centerX = inBitmap.width / 2f
-        val centerY = inBitmap.height / 2f
-        if (isFlipped) {
-            matrix.postScale(-1f, 1f, centerX, centerY)
-        }
-        if (isRotated) {
-            matrix.postRotate(rotationDegrees.toFloat(), centerX, centerY)
-        }
-
-        val rect = RectF(0f, 0f, inBitmap.width.toFloat(), inBitmap.height.toFloat())
-        matrix.mapRect(rect)
-        if (rect.left != 0f || rect.top != 0f) {
-            matrix.postTranslate(-rect.left, -rect.top)
-        }
-
-        val outBitmap = if (rotationDegrees == 90 || rotationDegrees == 270) {
-            createBitmap(inBitmap.height, inBitmap.width, config)
-        } else {
-            createBitmap(inBitmap.width, inBitmap.height, config)
-        }
-
-        outBitmap.applyCanvas {
-            drawBitmap(inBitmap, matrix, paint)
-        }
-        inBitmap.recycle()
-        return outBitmap
     }
 
     class Factory @JvmOverloads constructor(
@@ -258,44 +199,11 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         }
     }
 
-    /** Wrap [delegate] so that it works with [ExifInterface]. */
-    private class ExifInterfaceInputStream(private val delegate: InputStream) : InputStream() {
-
-        // Ensure that this value is always larger than the size of the image
-        // so ExifInterface won't stop reading the stream prematurely.
-        private var availableBytes = GIGABYTE_IN_BYTES
-
-        override fun read() = interceptBytesRead(delegate.read())
-
-        override fun read(b: ByteArray) = interceptBytesRead(delegate.read(b))
-
-        override fun read(b: ByteArray, off: Int, len: Int) =
-            interceptBytesRead(delegate.read(b, off, len))
-
-        override fun skip(n: Long) = delegate.skip(n)
-
-        override fun available() = availableBytes
-
-        override fun close() = delegate.close()
-
-        private fun interceptBytesRead(bytesRead: Int): Int {
-            if (bytesRead == -1) availableBytes = 0
-            return bytesRead
-        }
-    }
-
     internal companion object {
-        private const val MIME_TYPE_JPEG = "image/jpeg"
-        private const val MIME_TYPE_WEBP = "image/webp"
-        private const val MIME_TYPE_HEIC = "image/heic"
-        private const val MIME_TYPE_HEIF = "image/heif"
-        private const val GIGABYTE_IN_BYTES = 1024 * 1024 * 1024
+        internal const val MIME_TYPE_JPEG = "image/jpeg"
+        internal const val MIME_TYPE_WEBP = "image/webp"
+        internal const val MIME_TYPE_HEIC = "image/heic"
+        internal const val MIME_TYPE_HEIF = "image/heif"
         internal const val DEFAULT_MAX_PARALLELISM = 4
-
-        // NOTE: We don't support PNG EXIF data as it's very rarely used and requires buffering
-        // the entire file into memory. All of the supported formats short circuit when the EXIF
-        // chunk is found (often near the top of the file).
-        private val SUPPORTED_EXIF_MIME_TYPES =
-            arrayOf(MIME_TYPE_JPEG, MIME_TYPE_WEBP, MIME_TYPE_HEIC, MIME_TYPE_HEIF)
     }
 }

--- a/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
+++ b/coil-base/src/main/java/coil/decode/BitmapFactoryDecoder.kt
@@ -12,6 +12,7 @@ import androidx.exifinterface.media.ExifInterface
 import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
+import coil.size.isOriginal
 import coil.size.pxOrElse
 import coil.util.toDrawable
 import coil.util.toSoftware
@@ -78,7 +79,15 @@ class BitmapFactoryDecoder @JvmOverloads constructor(
         // Always create immutable bitmaps as they have performance benefits.
         inMutable = false
 
-        if (outWidth > 0 && outHeight > 0) {
+        if (options.size.isOriginal && source.metadata is ResourceMetadata) {
+            inScaled = true
+            // Read the resource density if available
+            inDensity = (source.metadata as ResourceMetadata).density
+            inTargetDensity = options.context.resources.displayMetrics.densityDpi
+            // Clear outWidth and outHeight so that BitmapFactory will handle scaling itself.
+            outWidth = 0
+            outHeight = 0
+        } else if (outWidth > 0 && outHeight > 0) {
             val (width, height) = options.size
             val dstWidth = width.pxOrElse { srcWidth }
             val dstHeight = height.pxOrElse { srcHeight }

--- a/coil-base/src/main/java/coil/decode/Exif.kt
+++ b/coil-base/src/main/java/coil/decode/Exif.kt
@@ -1,0 +1,131 @@
+package coil.decode
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.RectF
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
+import androidx.exifinterface.media.ExifInterface
+import java.io.InputStream
+
+
+internal object Exif {
+
+    /**
+     * NOTE: We don't support PNG EXIF data as it's very rarely used and requires buffering
+     * the entire file into memory. All of the supported formats short circuit when the EXIF
+     * chunk is found (often near the top of the file).
+     */
+    private val SUPPORTED_EXIF_MIME_TYPES = arrayOf(
+        BitmapFactoryDecoder.MIME_TYPE_JPEG,
+        BitmapFactoryDecoder.MIME_TYPE_WEBP,
+        BitmapFactoryDecoder.MIME_TYPE_HEIC,
+        BitmapFactoryDecoder.MIME_TYPE_HEIF
+    )
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+
+    /**
+     * Return 'true' if we should read the image's EXIF data.
+     */
+    internal fun shouldReadExifData(mimeType: String?): Boolean {
+        return mimeType != null && mimeType in SUPPORTED_EXIF_MIME_TYPES
+    }
+
+    /**
+     * This method assumes [config] is not [Bitmap.Config.HARDWARE].
+     */
+    internal fun applyExifTransformations(
+        inBitmap: Bitmap,
+        config: Bitmap.Config,
+        exifData: Data
+    ): Bitmap {
+        // Short circuit if there are no transformations to apply.
+        val isRotated = exifData.rotationDegrees > 0
+        if (!exifData.isFlipped && !isRotated) {
+            return inBitmap
+        }
+
+        val matrix = Matrix()
+        val centerX = inBitmap.width / 2f
+        val centerY = inBitmap.height / 2f
+        if (exifData.isFlipped) {
+            matrix.postScale(-1f, 1f, centerX, centerY)
+        }
+        if (isRotated) {
+            matrix.postRotate(exifData.rotationDegrees.toFloat(), centerX, centerY)
+        }
+
+        val rect = RectF(0f, 0f, inBitmap.width.toFloat(), inBitmap.height.toFloat())
+        matrix.mapRect(rect)
+        if (rect.left != 0f || rect.top != 0f) {
+            matrix.postTranslate(-rect.left, -rect.top)
+        }
+
+        val outBitmap = if (exifData.isSwapped) {
+            createBitmap(inBitmap.height, inBitmap.width, config)
+        } else {
+            createBitmap(inBitmap.width, inBitmap.height, config)
+        }
+
+        outBitmap.applyCanvas {
+            drawBitmap(inBitmap, matrix, paint)
+        }
+        inBitmap.recycle()
+        return outBitmap
+    }
+
+    internal data class Data(
+        val isFlipped: Boolean,
+        val rotationDegrees: Int
+    ) {
+        val isSwapped = rotationDegrees == 90 || rotationDegrees == 270
+
+        internal companion object {
+            val DEFAULT = Data(
+                isFlipped = false,
+                rotationDegrees = 0
+            )
+
+            internal fun ExifInterface.toExifData() = Data(
+                isFlipped = isFlipped,
+                rotationDegrees = rotationDegrees
+            )
+        }
+    }
+}
+
+/**
+ * Wrap [delegate] so that it works with [ExifInterface].
+ */
+internal class ExifInterfaceInputStream(private val delegate: InputStream) : InputStream() {
+
+    /**
+     * Ensure that this value is always larger than the size of the image
+     * so ExifInterface won't stop reading the stream prematurely.
+     */
+    private var availableBytes = GIGABYTE_IN_BYTES
+
+    override fun read() = interceptBytesRead(delegate.read())
+
+    override fun read(b: ByteArray) = interceptBytesRead(delegate.read(b))
+
+    override fun read(b: ByteArray, off: Int, len: Int) =
+        interceptBytesRead(delegate.read(b, off, len))
+
+    override fun skip(n: Long) = delegate.skip(n)
+
+    override fun available() = availableBytes
+
+    override fun close() = delegate.close()
+
+    private fun interceptBytesRead(bytesRead: Int): Int {
+        if (bytesRead == -1) availableBytes = 0
+        return bytesRead
+    }
+
+    private companion object {
+        const val GIGABYTE_IN_BYTES = 1024 * 1024 * 1024
+    }
+}

--- a/coil-base/src/main/java/coil/decode/Exif.kt
+++ b/coil-base/src/main/java/coil/decode/Exif.kt
@@ -9,7 +9,6 @@ import androidx.core.graphics.createBitmap
 import androidx.exifinterface.media.ExifInterface
 import java.io.InputStream
 
-
 internal object Exif {
 
     /**

--- a/coil-base/src/main/java/coil/decode/ImageSource.kt
+++ b/coil-base/src/main/java/coil/decode/ImageSource.kt
@@ -176,12 +176,13 @@ class AssetMetadata(val fileName: String) : ImageSource.Metadata()
 class ContentMetadata(val uri: Uri) : ImageSource.Metadata()
 
 /**
- * Metadata containing the [packageName] and [resId] of an Android resource.
+ * Metadata containing the [packageName], [resId], and [density] of an Android resource.
  */
 @ExperimentalCoilApi
 class ResourceMetadata(
     val packageName: String,
-    @DrawableRes val resId: Int
+    @DrawableRes val resId: Int,
+    val density: Int
 ) : ImageSource.Metadata()
 
 internal class FileImageSource(

--- a/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
+++ b/coil-base/src/main/java/coil/fetch/ResourceUriFetcher.kt
@@ -63,11 +63,13 @@ internal class ResourceUriFetcher(
                 dataSource = DataSource.DISK
             )
         } else {
+            val typedValue = TypedValue()
+            val inputStream = resources.openRawResource(resId, typedValue)
             SourceResult(
                 source = ImageSource(
-                    source = resources.openRawResource(resId).source().buffer(),
+                    source = inputStream.source().buffer(),
                     context = context,
-                    metadata = ResourceMetadata(packageName, resId)
+                    metadata = ResourceMetadata(packageName, resId, typedValue.density)
                 ),
                 mimeType = mimeType,
                 dataSource = DataSource.DISK


### PR DESCRIPTION
Resolves #1053

When the requested size is `Original`, previously it would fall into `(outWidth > 0 && outHeight > 0)`, where `val dstWidth = width.pxOrElse { srcWidth }` would always be evaluated to `srcWidth`, and `srcWidth` ignores the screen density. 

This PR addresses the case of android resources specifically by applying the same logic handled inside `BitmapFactory.decodeResourceStream()`.

## Testing
https://github.com/chao2zhang/coil/tree/chao/fixresourcescale-test
Tested on 440dpi and 560dpi devices using the code snippet in the original issue. Coil loaded image and android native BitmapFactory displays the image of the same size.