### PR TITLE
Convert AsyncImage.contentDescription to be an optional argument.

### DIFF
--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -1,6 +1,6 @@
 public final class coil/compose/AsyncImageKt {
-	public static final fun AsyncImage-HtA5bXE (Ljava/lang/Object;Ljava/lang/String;Lcoil/ImageLoader;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
-	public static final fun AsyncImage-h7wOGxc (Ljava/lang/Object;Ljava/lang/String;Lcoil/ImageLoader;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
+	public static final fun AsyncImage-HtA5bXE (Ljava/lang/Object;Lcoil/ImageLoader;Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AsyncImage-h7wOGxc (Ljava/lang/Object;Lcoil/ImageLoader;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Ljava/lang/String;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
 	public static final fun AsyncImageContent (Lcoil/compose/AsyncImageScope;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -40,14 +40,14 @@ import coil.size.Size as CoilSize
  * A composable that executes an [ImageRequest] asynchronously and renders the result.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
- * @param contentDescription Text used by accessibility services to describe what this image
- *  represents. This should always be provided unless this image is used for decorative purposes,
- *  and does not represent a meaningful action that a user can take.
  * @param imageLoader The [ImageLoader] that will be used to execute the request.
  * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param loading An optional callback to overwrite what's drawn while the image request is loading.
  * @param success An optional callback to overwrite what's drawn when the image request succeeds.
  * @param error An optional callback to overwrite what's drawn when the image request fails.
+ * @param contentDescription Text used by accessibility services to describe what this image
+ *  represents. This should always be provided unless this image is used for decorative purposes,
+ *  and does not represent a meaningful action that a user can take.
  * @param alignment Optional alignment parameter used to place the [AsyncImagePainter] in the given
  *  bounds defined by the width and height.
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be
@@ -62,12 +62,12 @@ import coil.size.Size as CoilSize
 @Composable
 fun AsyncImage(
     model: Any?,
-    contentDescription: String?,
     imageLoader: ImageLoader,
     modifier: Modifier = Modifier,
     loading: @Composable (AsyncImageScope.(State.Loading) -> Unit)? = null,
     success: @Composable (AsyncImageScope.(State.Success) -> Unit)? = null,
     error: @Composable (AsyncImageScope.(State.Error) -> Unit)? = null,
+    contentDescription: String? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
@@ -75,9 +75,9 @@ fun AsyncImage(
     filterQuality: FilterQuality = DefaultFilterQuality,
 ) = AsyncImage(
     model = model,
-    contentDescription = contentDescription,
     imageLoader = imageLoader,
     modifier = modifier,
+    contentDescription = contentDescription,
     alignment = alignment,
     contentScale = contentScale,
     alpha = alpha,
@@ -90,11 +90,11 @@ fun AsyncImage(
  * A composable that executes an [ImageRequest] asynchronously and renders the result.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
+ * @param imageLoader The [ImageLoader] that will be used to execute the request.
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param contentDescription Text used by accessibility services to describe what this image
  *  represents. This should always be provided unless this image is used for decorative purposes,
  *  and does not represent a meaningful action that a user can take.
- * @param imageLoader The [ImageLoader] that will be used to execute the request.
- * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param alignment Optional alignment parameter used to place the [AsyncImagePainter] in the given
  *  bounds defined by the width and height.
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be
@@ -110,9 +110,9 @@ fun AsyncImage(
 @Composable
 fun AsyncImage(
     model: Any?,
-    contentDescription: String?,
     imageLoader: ImageLoader,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,

--- a/coil-compose-singleton/api/coil-compose-singleton.api
+++ b/coil-compose-singleton/api/coil-compose-singleton.api
@@ -19,8 +19,8 @@ public final class coil/compose/LocalImageLoaderKt {
 }
 
 public final class coil/compose/SingletonAsyncImageKt {
-	public static final fun AsyncImage-MvsnxeU (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
-	public static final fun AsyncImage-_kETKwk (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AsyncImage-MvsnxeU (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Ljava/lang/String;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILandroidx/compose/runtime/Composer;III)V
+	public static final fun AsyncImage-_kETKwk (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class coil/compose/SingletonAsyncImagePainterKt {

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
@@ -18,13 +18,13 @@ import coil.request.ImageRequest
  * A composable that executes an [ImageRequest] asynchronously and renders the result.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
- * @param contentDescription Text used by accessibility services to describe what this image
- *  represents. This should always be provided unless this image is used for decorative purposes,
- *  and does not represent a meaningful action that a user can take.
  * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param loading An optional callback to overwrite what's drawn while the image request is loading.
  * @param success An optional callback to overwrite what's drawn when the image request succeeds.
  * @param error An optional callback to overwrite what's drawn when the image request fails.
+ * @param contentDescription Text used by accessibility services to describe what this image
+ *  represents. This should always be provided unless this image is used for decorative purposes,
+ *  and does not represent a meaningful action that a user can take.
  * @param alignment Optional alignment parameter used to place the [AsyncImagePainter] in the given
  *  bounds defined by the width and height.
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be
@@ -39,11 +39,11 @@ import coil.request.ImageRequest
 @Composable
 fun AsyncImage(
     model: Any?,
-    contentDescription: String?,
     modifier: Modifier = Modifier,
     loading: @Composable (AsyncImageScope.(State.Loading) -> Unit)? = null,
     success: @Composable (AsyncImageScope.(State.Success) -> Unit)? = null,
     error: @Composable (AsyncImageScope.(State.Error) -> Unit)? = null,
+    contentDescription: String? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
@@ -51,12 +51,12 @@ fun AsyncImage(
     filterQuality: FilterQuality = DefaultFilterQuality,
 ) = AsyncImage(
     model = model,
-    contentDescription = contentDescription,
     imageLoader = LocalImageLoader.current,
     modifier = modifier,
     loading = loading,
     success = success,
     error = error,
+    contentDescription = contentDescription,
     alignment = alignment,
     contentScale = contentScale,
     alpha = alpha,
@@ -68,10 +68,10 @@ fun AsyncImage(
  * A composable that executes an [ImageRequest] asynchronously and renders the result.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
+ * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param contentDescription Text used by accessibility services to describe what this image
  *  represents. This should always be provided unless this image is used for decorative purposes,
  *  and does not represent a meaningful action that a user can take.
- * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
  * @param alignment Optional alignment parameter used to place the [AsyncImagePainter] in the given
  *  bounds defined by the width and height.
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be
@@ -87,8 +87,8 @@ fun AsyncImage(
 @Composable
 fun AsyncImage(
     model: Any?,
-    contentDescription: String?,
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     alignment: Alignment = Alignment.Center,
     contentScale: ContentScale = ContentScale.Fit,
     alpha: Float = DefaultAlpha,
@@ -97,9 +97,9 @@ fun AsyncImage(
     content: @Composable (AsyncImageScope.(State) -> Unit) = DefaultContent,
 ) = AsyncImage(
     model = model,
-    contentDescription = contentDescription,
     imageLoader = LocalImageLoader.current,
     modifier = modifier,
+    contentDescription = contentDescription,
     alignment = alignment,
     contentScale = contentScale,
     alpha = alpha,


### PR DESCRIPTION
Creating this PR for consideration before the 2.x API is finalized. Compose's built in `Image` composable has `contentDescription` as a required parameter to encourage users to set it to a not-null value, which is important for users who use screen readers. To be clear, accessibility is important and users should set a content description (we do at Instacart)! That said, I think there are some differences between `Image` and `AsyncImage` that might make us want to choose a different default:

- `Image` typically displays static content from a local source. `AsyncImage` typically displays dynamic content from a remote source where it's tough to know what the content description should be without a separate endpoint.
- `AsyncImage` is a more complicated composable than `Image`. Having an extra required argument can crowd the callsite especially if it's often set to `null`.
- Coil's `AsyncImage` takes notes from [SwiftUI's `AsyncImage`](https://developer.apple.com/documentation/swiftui/asyncimage) which does not have `contentDescription` as a required parameter.