### PR TITLE
[WIP] Memory leak for Gifs in ImageDecoderDecoder

### DIFF
--- a/coil-base/src/main/java/coil/decode/ImageSource.kt
+++ b/coil-base/src/main/java/coil/decode/ImageSource.kt
@@ -272,7 +272,7 @@ internal class SourceImageSource(
     override fun close() {
         isClosed = true
         source?.closeQuietly()
-        file?.delete()
+//        file?.delete()
     }
 
     private fun assertNotClosed() {

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -47,32 +47,28 @@ class ImageDecoderDecoder @JvmOverloads constructor(
     override suspend fun decode(): DecodeResult = decode2()
 
     private fun ImageSource.toImageDecoderSource(): ImageDecoder.Source {
-        use { imageSource ->
-            val file = fileOrNull()
-            if (file != null) {
-                return ImageDecoder.createSource(file)
-            }
+        val file = fileOrNull()
+        if (file != null) {
+            return ImageDecoder.createSource(file)
+        }
 
-            val metadata = metadata
-            if (metadata is AssetMetadata) {
-                return ImageDecoder.createSource(options.context.assets, metadata.fileName)
-            }
-            if (metadata is ContentMetadata) {
-                return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
-            }
-            if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
-                return ImageDecoder.createSource(options.context.resources, metadata.resId)
-            }
-            return when {
-                SDK_INT >= 31 -> ImageDecoder.createSource(
-                    imageSource.source().use { it.readByteArray() })
-                SDK_INT == 30 -> ImageDecoder.createSource(
-                    ByteBuffer.wrap(
-                        imageSource.source().use { it.readByteArray() })
-                )
-                // https://issuetracker.google.com/issues/139371066
-                else -> ImageDecoder.createSource(file())
-            }
+        val metadata = metadata
+        if (metadata is AssetMetadata) {
+            return ImageDecoder.createSource(options.context.assets, metadata.fileName)
+        }
+        if (metadata is ContentMetadata) {
+            return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
+        }
+        if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
+            return ImageDecoder.createSource(options.context.resources, metadata.resId)
+        }
+        return when {
+            SDK_INT >= 31 -> ImageDecoder.createSource(source().use { it.readByteArray() })
+            SDK_INT == 30 -> ImageDecoder.createSource(
+                ByteBuffer.wrap(source().use { it.readByteArray() })
+            )
+            // https://issuetracker.google.com/issues/139371066
+            else -> ImageDecoder.createSource(file())
         }
     }
 

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -44,45 +44,7 @@ class ImageDecoderDecoder @JvmOverloads constructor(
     private val enforceMinimumFrameDelay: Boolean = true
 ) : Decoder {
 
-    override suspend fun decode(): DecodeResult = decode2()
-
-    private fun ImageSource.toImageDecoderSource(): ImageDecoder.Source {
-        val file = fileOrNull()
-        if (file != null) {
-            return ImageDecoder.createSource(file)
-        }
-
-        val metadata = metadata
-        if (metadata is AssetMetadata) {
-            return ImageDecoder.createSource(options.context.assets, metadata.fileName)
-        }
-        if (metadata is ContentMetadata) {
-            return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
-        }
-        if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
-            return ImageDecoder.createSource(options.context.resources, metadata.resId)
-        }
-        return when {
-            SDK_INT >= 31 -> ImageDecoder.createSource(source().use { it.readByteArray() })
-            SDK_INT == 30 -> ImageDecoder.createSource(
-                ByteBuffer.wrap(source().use { it.readByteArray() })
-            )
-            // https://issuetracker.google.com/issues/139371066
-            else -> ImageDecoder.createSource(file())
-        }
-    }
-
-    private fun getImageDecoderSource(imageSource: ImageSource): ImageSource {
-        return if (enforceMinimumFrameDelay && DecodeUtils.isGif(imageSource.source())) {
-            // Wrap the source to rewrite its frame delay as it's read.
-            val rewritingSource = FrameDelayRewritingSource(imageSource.source())
-            ImageSource(rewritingSource.buffer(), options.context)
-        } else {
-            imageSource
-        }
-    }
-
-    private suspend fun decode2(): DecodeResult {
+    override suspend fun decode(): DecodeResult {
         var isSampled = false
 
         val baseDrawable = getImageDecoderSource(source)
@@ -125,6 +87,42 @@ class ImageDecoderDecoder @JvmOverloads constructor(
 
         val parsedDrawable = parseDrawable(baseDrawable)
         return DecodeResult(drawable = parsedDrawable, isSampled = isSampled)
+    }
+
+    private fun ImageSource.toImageDecoderSource(): ImageDecoder.Source {
+        val file = fileOrNull()
+        if (file != null) {
+            return ImageDecoder.createSource(file)
+        }
+
+        val metadata = metadata
+        if (metadata is AssetMetadata) {
+            return ImageDecoder.createSource(options.context.assets, metadata.fileName)
+        }
+        if (metadata is ContentMetadata) {
+            return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
+        }
+        if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
+            return ImageDecoder.createSource(options.context.resources, metadata.resId)
+        }
+        return when {
+            SDK_INT >= 31 -> ImageDecoder.createSource(source().use { it.readByteArray() })
+            SDK_INT == 30 -> ImageDecoder.createSource(
+                ByteBuffer.wrap(source().use { it.readByteArray() })
+            )
+            // https://issuetracker.google.com/issues/139371066
+            else -> ImageDecoder.createSource(file())
+        }
+    }
+
+    private fun getImageDecoderSource(imageSource: ImageSource): ImageSource {
+        return if (enforceMinimumFrameDelay && DecodeUtils.isGif(imageSource.source())) {
+            // Wrap the source to rewrite its frame delay as it's read.
+            val rewritingSource = FrameDelayRewritingSource(imageSource.source())
+            ImageSource(rewritingSource.buffer(), options.context)
+        } else {
+            imageSource
+        }
     }
 
     private fun parseAllocator(options: Options): Int {


### PR DESCRIPTION
fixes #1107 

This PR removes a memory leak in the `ImageDecoderDecoder` when loading Gifs in a `RecyclerView`. 

At the moment, there's a problem with MP4 load. The library goes in a loop in the performance is greatly affected. @colinrtwhite some input would be appreciated about what can be causing this. 

