### PR TITLE
Manually close ImageDecoder.

### DIFF
--- a/coil-gif/src/main/java/coil/decode/FrameDelayRewritingSource.kt
+++ b/coil-gif/src/main/java/coil/decode/FrameDelayRewritingSource.kt
@@ -1,5 +1,4 @@
-// https://youtrack.jetbrains.com/issue/KTIJ-196
-@file:Suppress("SameParameterValue", "UnusedEquals", "UnusedUnaryOperator")
+@file:Suppress("SameParameterValue")
 
 package coil.decode
 

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -47,32 +47,28 @@ class ImageDecoderDecoder @JvmOverloads constructor(
     override suspend fun decode(): DecodeResult = decode2()
 
     private fun ImageSource.toImageDecoderSource(): ImageDecoder.Source {
-        use { imageSource ->
-            val file = fileOrNull()
-            if (file != null) {
-                return ImageDecoder.createSource(file)
-            }
+        val file = fileOrNull()
+        if (file != null) {
+            return ImageDecoder.createSource(file)
+        }
 
-            val metadata = metadata
-            if (metadata is AssetMetadata) {
-                return ImageDecoder.createSource(options.context.assets, metadata.fileName)
-            }
-            if (metadata is ContentMetadata) {
-                return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
-            }
-            if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
-                return ImageDecoder.createSource(options.context.resources, metadata.resId)
-            }
-            return when {
-                SDK_INT >= 31 -> ImageDecoder.createSource(
-                    imageSource.source().use { it.readByteArray() })
-                SDK_INT == 30 -> ImageDecoder.createSource(
-                    ByteBuffer.wrap(
-                        imageSource.source().use { it.readByteArray() })
-                )
-                // https://issuetracker.google.com/issues/139371066
-                else -> ImageDecoder.createSource(file())
-            }
+        val metadata = metadata
+        if (metadata is AssetMetadata) {
+            return ImageDecoder.createSource(options.context.assets, metadata.fileName)
+        }
+        if (metadata is ContentMetadata) {
+            return ImageDecoder.createSource(options.context.contentResolver, metadata.uri)
+        }
+        if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
+            return ImageDecoder.createSource(options.context.resources, metadata.resId)
+        }
+        return when {
+            SDK_INT >= 31 -> ImageDecoder.createSource(source().use { it.readByteArray() })
+            SDK_INT == 30 -> ImageDecoder.createSource(
+                ByteBuffer.wrap(source().use { it.readByteArray() })
+            )
+            // https://issuetracker.google.com/issues/139371066
+            else -> ImageDecoder.createSource(file())
         }
     }
 

--- a/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil/decode/ImageDecoderDecoder.kt
@@ -122,8 +122,8 @@ class ImageDecoderDecoder @JvmOverloads constructor(
         }
 
         return when {
-            SDK_INT >= 31 -> ImageDecoder.createSource(source().use { it.readByteArray() })
-            SDK_INT == 30 -> ImageDecoder.createSource(ByteBuffer.wrap(source().use { it.readByteArray() }))
+            SDK_INT >= 31 -> ImageDecoder.createSource(source().readByteArray())
+            SDK_INT == 30 -> ImageDecoder.createSource(ByteBuffer.wrap(source().readByteArray()))
             // https://issuetracker.google.com/issues/139371066
             else -> ImageDecoder.createSource(file())
         }


### PR DESCRIPTION
Fixes #1107.

[`ImageDecoder`'s source says we shouldn't call this method manually](https://android.googlesource.com/platform/frameworks/base/+/master/graphics/java/android/graphics/ImageDecoder.java#1643), but it looks like it isn't cleaned up unless it's called manually.