### PR TITLE
Convert FetchResult and DecodeResult to be non-data classes.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -168,15 +168,12 @@ public final class coil/decode/DataSource : java/lang/Enum {
 
 public final class coil/decode/DecodeResult {
 	public fun <init> (Landroid/graphics/drawable/Drawable;Z)V
-	public final fun component1 ()Landroid/graphics/drawable/Drawable;
-	public final fun component2 ()Z
 	public final fun copy (Landroid/graphics/drawable/Drawable;Z)Lcoil/decode/DecodeResult;
 	public static synthetic fun copy$default (Lcoil/decode/DecodeResult;Landroid/graphics/drawable/Drawable;ZILjava/lang/Object;)Lcoil/decode/DecodeResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDrawable ()Landroid/graphics/drawable/Drawable;
 	public fun hashCode ()I
 	public final fun isSampled ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class coil/decode/DecodeUtils {
@@ -310,9 +307,6 @@ public final class coil/drawable/CrossfadeDrawable$Companion {
 
 public final class coil/fetch/DrawableResult : coil/fetch/FetchResult {
 	public fun <init> (Landroid/graphics/drawable/Drawable;ZLcoil/decode/DataSource;)V
-	public final fun component1 ()Landroid/graphics/drawable/Drawable;
-	public final fun component2 ()Z
-	public final fun component3 ()Lcoil/decode/DataSource;
 	public final fun copy (Landroid/graphics/drawable/Drawable;ZLcoil/decode/DataSource;)Lcoil/fetch/DrawableResult;
 	public static synthetic fun copy$default (Lcoil/fetch/DrawableResult;Landroid/graphics/drawable/Drawable;ZLcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/fetch/DrawableResult;
 	public fun equals (Ljava/lang/Object;)Z
@@ -320,7 +314,6 @@ public final class coil/fetch/DrawableResult : coil/fetch/FetchResult {
 	public final fun getDrawable ()Landroid/graphics/drawable/Drawable;
 	public fun hashCode ()I
 	public final fun isSampled ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class coil/fetch/FetchResult {
@@ -336,9 +329,6 @@ public abstract interface class coil/fetch/Fetcher$Factory {
 
 public final class coil/fetch/SourceResult : coil/fetch/FetchResult {
 	public fun <init> (Lcoil/decode/ImageSource;Ljava/lang/String;Lcoil/decode/DataSource;)V
-	public final fun component1 ()Lcoil/decode/ImageSource;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Lcoil/decode/DataSource;
 	public final fun copy (Lcoil/decode/ImageSource;Ljava/lang/String;Lcoil/decode/DataSource;)Lcoil/fetch/SourceResult;
 	public static synthetic fun copy$default (Lcoil/fetch/SourceResult;Lcoil/decode/ImageSource;Ljava/lang/String;Lcoil/decode/DataSource;ILjava/lang/Object;)Lcoil/fetch/SourceResult;
 	public fun equals (Ljava/lang/Object;)Z
@@ -346,7 +336,6 @@ public final class coil/fetch/SourceResult : coil/fetch/FetchResult {
 	public final fun getMimeType ()Ljava/lang/String;
 	public final fun getSource ()Lcoil/decode/ImageSource;
 	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class coil/intercept/Interceptor {

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -22,11 +22,7 @@ import okio.buffer
 import okio.source
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BitmapFactoryDecoderTest {
@@ -42,41 +38,41 @@ class BitmapFactoryDecoderTest {
 
     @Test
     fun basic() = runTest {
-        val (drawable, isSampled) = decode(
+        val result = decode(
             assetName = "normal.jpg",
             size = Size(100, 100)
         )
 
-        assertTrue(isSampled)
-        assertIs<BitmapDrawable>(drawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
         assertEquals(Size(100, 125), drawable.bitmap.size)
         assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
     }
 
     @Test
     fun unboundedWidth() = runTest {
-        val (drawable, isSampled) = decode(
+        val result = decode(
             assetName = "normal.jpg",
             size = Size(Dimension.Original, Dimension(100)),
             scale = Scale.FIT
         )
 
-        assertTrue(isSampled)
-        assertIs<BitmapDrawable>(drawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
         assertEquals(Size(80, 100), drawable.bitmap.size)
         assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
     }
 
     @Test
     fun unboundedHeight() = runTest {
-        val (drawable, isSampled) = decode(
+        val result = decode(
             assetName = "normal.jpg",
             size = Size(Dimension(100), Dimension.Original),
             scale = Scale.FIT
         )
 
-        assertTrue(isSampled)
-        assertIs<BitmapDrawable>(drawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
         assertEquals(Size(100, 125), drawable.bitmap.size)
         assertEquals(Bitmap.Config.ARGB_8888, drawable.bitmap.config)
     }
@@ -93,13 +89,13 @@ class BitmapFactoryDecoderTest {
 
     @Test
     fun resultIsSampledIfGreaterThanHalfSize() = runTest {
-        val (drawable, isSampled) = decode(
+        val result = decode(
             assetName = "normal.jpg",
             size = Size(600, 600)
         )
 
-        assertTrue(isSampled)
-        assertIs<BitmapDrawable>(drawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
         assertEquals(Size(600, 750), drawable.bitmap.size)
     }
 
@@ -240,10 +236,10 @@ class BitmapFactoryDecoderTest {
         // The emulator runs out of memory on pre-23.
         assumeTrue(SDK_INT >= 23)
 
-        val (drawable, isSampled) = decode("16_bit.png", Size(250, 250))
+        val result = decode("16_bit.png", Size(250, 250))
 
-        assertTrue(isSampled)
-        assertIs<BitmapDrawable>(drawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
         assertEquals(Size(250, 250), drawable.bitmap.size)
 
         val expectedConfig = if (SDK_INT >= 26) Bitmap.Config.RGBA_F16 else Bitmap.Config.ARGB_8888

--- a/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
+++ b/coil-base/src/androidTest/java/coil/decode/BitmapFactoryDecoderTest.kt
@@ -22,7 +22,11 @@ import okio.buffer
 import okio.source
 import org.junit.Before
 import org.junit.Test
-import kotlin.test.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class BitmapFactoryDecoderTest {

--- a/coil-base/src/main/java/coil/decode/DecodeResult.kt
+++ b/coil-base/src/main/java/coil/decode/DecodeResult.kt
@@ -11,7 +11,29 @@ import android.graphics.drawable.Drawable
  *
  * @see Decoder
  */
-data class DecodeResult(
+class DecodeResult(
     val drawable: Drawable,
     val isSampled: Boolean,
-)
+) {
+
+    fun copy(
+        drawable: Drawable = this.drawable,
+        isSampled: Boolean = this.isSampled,
+    ) = DecodeResult(
+        drawable = drawable,
+        isSampled = isSampled
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is DecodeResult &&
+            drawable == other.drawable &&
+            isSampled == other.isSampled
+    }
+
+    override fun hashCode(): Int {
+        var result = drawable.hashCode()
+        result = 31 * result + isSampled.hashCode()
+        return result
+    }
+}

--- a/coil-base/src/main/java/coil/fetch/FetchResult.kt
+++ b/coil-base/src/main/java/coil/fetch/FetchResult.kt
@@ -16,11 +16,37 @@ sealed class FetchResult
  * @param mimeType An optional MIME type for the [source].
  * @param dataSource The source that [source] was fetched from.
  */
-data class SourceResult(
+class SourceResult(
     val source: ImageSource,
     val mimeType: String?,
     val dataSource: DataSource,
-) : FetchResult()
+) : FetchResult() {
+
+    fun copy(
+        source: ImageSource = this.source,
+        mimeType: String? = this.mimeType,
+        dataSource: DataSource = this.dataSource,
+    ) = SourceResult(
+        source = source,
+        mimeType = mimeType,
+        dataSource = dataSource
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is SourceResult &&
+            source == other.source &&
+            mimeType == other.mimeType &&
+            dataSource == other.dataSource
+    }
+
+    override fun hashCode(): Int {
+        var result = source.hashCode()
+        result = 31 * result + mimeType.hashCode()
+        result = 31 * result + dataSource.hashCode()
+        return result
+    }
+}
 
 /**
  * A direct [Drawable] result. Return this from a [Fetcher] if its data cannot
@@ -31,8 +57,34 @@ data class SourceResult(
  *  at less than its original size).
  * @param dataSource The source that [drawable] was fetched from.
  */
-data class DrawableResult(
+class DrawableResult(
     val drawable: Drawable,
     val isSampled: Boolean,
     val dataSource: DataSource,
-) : FetchResult()
+) : FetchResult() {
+
+    fun copy(
+        drawable: Drawable = this.drawable,
+        isSampled: Boolean = this.isSampled,
+        dataSource: DataSource = this.dataSource,
+    ) = DrawableResult(
+        drawable = drawable,
+        isSampled = isSampled,
+        dataSource = dataSource
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return other is DrawableResult &&
+            drawable == other.drawable &&
+            isSampled == other.isSampled &&
+            dataSource == other.dataSource
+    }
+
+    override fun hashCode(): Int {
+        var result = drawable.hashCode()
+        result = 31 * result + isSampled.hashCode()
+        result = 31 * result + dataSource.hashCode()
+        return result
+    }
+}

--- a/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
+++ b/coil-svg/src/androidTest/java/coil/decode/SvgDecoderTest.kt
@@ -19,6 +19,7 @@ import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -83,7 +84,7 @@ class SvgDecoderTest {
             size = Size(400, 250), // coil_logo.svg's intrinsic dimensions are 200x200.
             scale = Scale.FIT
         )
-        val (drawable, isSampled) = assertNotNull(
+        val result = assertNotNull(
             decoderFactory.create(
                 result = source.asSourceResult(),
                 options = options,
@@ -91,8 +92,8 @@ class SvgDecoderTest {
             )?.decode()
         )
 
-        assertTrue(isSampled)
-        assertTrue(drawable is BitmapDrawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
 
         val expected = context.decodeBitmapAsset("coil_logo_250.png")
         drawable.bitmap.assertIsSimilarTo(expected)
@@ -106,7 +107,7 @@ class SvgDecoderTest {
             size = Size(326, 50),
             scale = Scale.FILL
         )
-        val (drawable, isSampled) = assertNotNull(
+        val result = assertNotNull(
             decoderFactory.create(
                 result = source.asSourceResult(),
                 options = options,
@@ -114,8 +115,8 @@ class SvgDecoderTest {
             )?.decode()
         )
 
-        assertTrue(isSampled)
-        assertTrue(drawable is BitmapDrawable)
+        assertTrue(result.isSampled)
+        val drawable = assertIs<BitmapDrawable>(result.drawable)
 
         val expected = context.decodeBitmapAsset("instacart_logo_326.png")
         drawable.bitmap.assertIsSimilarTo(expected)


### PR DESCRIPTION
This will be easier to maintain since it's possible we add new properties to these classes in the future.