### PR TITLE
Split relevant DecodeUtils functions into coil-gif and coil-svg.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -185,11 +185,6 @@ public final class coil/decode/DecodeUtils {
 	public static final fun computeSizeMultiplier (DDDDLcoil/size/Scale;)D
 	public static final fun computeSizeMultiplier (FFFFLcoil/size/Scale;)F
 	public static final fun computeSizeMultiplier (IIIILcoil/size/Scale;)D
-	public static final fun isAnimatedHeif (Lokio/BufferedSource;)Z
-	public static final fun isAnimatedWebP (Lokio/BufferedSource;)Z
-	public static final fun isGif (Lokio/BufferedSource;)Z
-	public static final fun isHeif (Lokio/BufferedSource;)Z
-	public static final fun isWebP (Lokio/BufferedSource;)Z
 }
 
 public abstract interface class coil/decode/Decoder {

--- a/coil-base/src/main/java/coil/decode/DecodeUtils.kt
+++ b/coil-base/src/main/java/coil/decode/DecodeUtils.kt
@@ -3,65 +3,11 @@ package coil.decode
 import android.graphics.BitmapFactory
 import androidx.annotation.Px
 import coil.size.Scale
-import okio.BufferedSource
-import okio.ByteString.Companion.encodeUtf8
-import kotlin.experimental.and
 import kotlin.math.max
 import kotlin.math.min
 
 /** A collection of useful utility methods for decoding images. */
 object DecodeUtils {
-
-    // https://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
-    private val GIF_HEADER_87A = "GIF87a".encodeUtf8()
-    private val GIF_HEADER_89A = "GIF89a".encodeUtf8()
-
-    // https://developers.google.com/speed/webp/docs/riff_container
-    private val WEBP_HEADER_RIFF = "RIFF".encodeUtf8()
-    private val WEBP_HEADER_WEBP = "WEBP".encodeUtf8()
-    private val WEBP_HEADER_VPX8 = "VP8X".encodeUtf8()
-
-    // https://nokiatech.github.io/heif/technical.html
-    private val HEIF_HEADER_FTYP = "ftyp".encodeUtf8()
-    private val HEIF_HEADER_MSF1 = "msf1".encodeUtf8()
-    private val HEIF_HEADER_HEVC = "hevc".encodeUtf8()
-    private val HEIF_HEADER_HEVX = "hevx".encodeUtf8()
-
-    /** Return 'true' if the [source] contains a GIF image. The [source] is not consumed. */
-    @JvmStatic
-    fun isGif(source: BufferedSource): Boolean {
-        return source.rangeEquals(0, GIF_HEADER_89A) || source.rangeEquals(0, GIF_HEADER_87A)
-    }
-
-    /** Return 'true' if the [source] contains a WebP image. The [source] is not consumed. */
-    @JvmStatic
-    fun isWebP(source: BufferedSource): Boolean {
-        return source.rangeEquals(0, WEBP_HEADER_RIFF) && source.rangeEquals(8, WEBP_HEADER_WEBP)
-    }
-
-    /** Return 'true' if the [source] contains an animated WebP image. The [source] is not consumed. */
-    @JvmStatic
-    fun isAnimatedWebP(source: BufferedSource): Boolean {
-        return isWebP(source) &&
-            source.rangeEquals(12, WEBP_HEADER_VPX8) &&
-            source.request(17) &&
-            (source.buffer[16] and 0b00000010) > 0
-    }
-
-    /** Return 'true' if the [source] contains an HEIF image. The [source] is not consumed. */
-    @JvmStatic
-    fun isHeif(source: BufferedSource): Boolean {
-        return source.rangeEquals(4, HEIF_HEADER_FTYP)
-    }
-
-    /** Return 'true' if the [source] contains an animated HEIF image sequence. The [source] is not consumed. */
-    @JvmStatic
-    fun isAnimatedHeif(source: BufferedSource): Boolean {
-        return isHeif(source) &&
-            (source.rangeEquals(8, HEIF_HEADER_MSF1) ||
-                source.rangeEquals(8, HEIF_HEADER_HEVC) ||
-                source.rangeEquals(8, HEIF_HEADER_HEVX))
-    }
 
     /**
      * Calculate the [BitmapFactory.Options.inSampleSize] given the source dimensions of the image
@@ -84,8 +30,8 @@ object DecodeUtils {
     }
 
     /**
-     * Calculate the percentage to multiply the source dimensions by to fit/fill the
-     * destination dimensions while preserving aspect ratio.
+     * Calculate the percentage to multiply the source dimensions by to fit/fill the destination
+     * dimensions while preserving aspect ratio.
      */
     @JvmStatic
     fun computeSizeMultiplier(

--- a/coil-base/src/test/java/coil/decode/DecodeUtilsTest.kt
+++ b/coil-base/src/test/java/coil/decode/DecodeUtilsTest.kt
@@ -3,15 +3,11 @@ package coil.decode
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import coil.size.Scale
-import okio.buffer
-import okio.source
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class DecodeUtilsTest {
@@ -55,65 +51,5 @@ class DecodeUtilsTest {
         assertEquals(DecodeUtils.calculateInSampleSize(160, 1024, 80, 80, Scale.FIT), 8)
 
         assertEquals(DecodeUtils.calculateInSampleSize(50, 50, 100, 100, Scale.FIT), 1)
-    }
-
-    @Test
-    fun `isGif true positive`() {
-        val source = context.assets.open("animated.gif").source().buffer()
-        assertTrue(DecodeUtils.isGif(source))
-    }
-
-    @Test
-    fun `isGif true negative`() {
-        val source = context.assets.open("normal.jpg").source().buffer()
-        assertFalse(DecodeUtils.isGif(source))
-    }
-
-    @Test
-    fun `isWebP true positive`() {
-        val source = context.assets.open("static.webp").source().buffer()
-        assertTrue(DecodeUtils.isWebP(source))
-    }
-
-    @Test
-    fun `isWebP true negative`() {
-        val source = context.assets.open("animated.gif").source().buffer()
-        assertFalse(DecodeUtils.isWebP(source))
-    }
-
-    @Test
-    fun `isAnimatedWebP true positive`() {
-        val source = context.assets.open("animated.webp").source().buffer()
-        assertTrue(DecodeUtils.isAnimatedWebP(source))
-    }
-
-    @Test
-    fun `isAnimatedWebP true negative`() {
-        val source = context.assets.open("static.webp").source().buffer()
-        assertFalse(DecodeUtils.isAnimatedWebP(source))
-    }
-
-    @Test
-    fun `isHeif true positive`() {
-        val source = context.assets.open("static.heif").source().buffer()
-        assertTrue(DecodeUtils.isHeif(source))
-    }
-
-    @Test
-    fun `isHeif true negative`() {
-        val source = context.assets.open("normal.jpg").source().buffer()
-        assertFalse(DecodeUtils.isHeif(source))
-    }
-
-    @Test
-    fun `isAnimatedHeif true positive`() {
-        val source = context.assets.open("animated.heif").source().buffer()
-        assertTrue(DecodeUtils.isAnimatedHeif(source))
-    }
-
-    @Test
-    fun `isAnimatedHeif true negative`() {
-        val source = context.assets.open("animated.webp").source().buffer()
-        assertFalse(DecodeUtils.isAnimatedHeif(source))
     }
 }

--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -1,3 +1,11 @@
+public final class coil/decode/GifDecodeUtils {
+	public static final fun isAnimatedHeif (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+	public static final fun isAnimatedWebP (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+	public static final fun isGif (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+	public static final fun isHeif (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+	public static final fun isWebP (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+}
+
 public final class coil/decode/GifDecoder : coil/decode/Decoder {
 	public static final field ANIMATED_TRANSFORMATION_KEY Ljava/lang/String;
 	public static final field ANIMATION_END_CALLBACK_KEY Ljava/lang/String;

--- a/coil-gif/src/main/java/coil/decode/DecodeUtils.kt
+++ b/coil-gif/src/main/java/coil/decode/DecodeUtils.kt
@@ -1,0 +1,67 @@
+@file:JvmName("GifDecodeUtils")
+@file:Suppress("unused")
+
+package coil.decode
+
+import okio.BufferedSource
+import okio.ByteString.Companion.encodeUtf8
+import kotlin.experimental.and
+
+// https://www.matthewflickinger.com/lab/whatsinagif/bits_and_bytes.asp
+private val GIF_HEADER_87A = "GIF87a".encodeUtf8()
+private val GIF_HEADER_89A = "GIF89a".encodeUtf8()
+
+// https://developers.google.com/speed/webp/docs/riff_container
+private val WEBP_HEADER_RIFF = "RIFF".encodeUtf8()
+private val WEBP_HEADER_WEBP = "WEBP".encodeUtf8()
+private val WEBP_HEADER_VPX8 = "VP8X".encodeUtf8()
+
+// https://nokiatech.github.io/heif/technical.html
+private val HEIF_HEADER_FTYP = "ftyp".encodeUtf8()
+private val HEIF_HEADER_MSF1 = "msf1".encodeUtf8()
+private val HEIF_HEADER_HEVC = "hevc".encodeUtf8()
+private val HEIF_HEADER_HEVX = "hevx".encodeUtf8()
+
+/**
+ * Return 'true' if the [source] contains a GIF image. The [source] is not consumed.
+ */
+fun DecodeUtils.isGif(source: BufferedSource): Boolean {
+    return source.rangeEquals(0, GIF_HEADER_89A) ||
+        source.rangeEquals(0, GIF_HEADER_87A)
+}
+
+/**
+ * Return 'true' if the [source] contains a WebP image. The [source] is not consumed.
+ */
+fun DecodeUtils.isWebP(source: BufferedSource): Boolean {
+    return source.rangeEquals(0, WEBP_HEADER_RIFF) &&
+        source.rangeEquals(8, WEBP_HEADER_WEBP)
+}
+
+/**
+ * Return 'true' if the [source] contains an animated WebP image. The [source] is not consumed.
+ */
+fun DecodeUtils.isAnimatedWebP(source: BufferedSource): Boolean {
+    return isWebP(source) &&
+        source.rangeEquals(12, WEBP_HEADER_VPX8) &&
+        source.request(17) &&
+        (source.buffer[16] and 0b00000010) > 0
+}
+
+/**
+ * Return 'true' if the [source] contains an HEIF image. The [source] is not consumed.
+ */
+fun DecodeUtils.isHeif(source: BufferedSource): Boolean {
+    return source.rangeEquals(4, HEIF_HEADER_FTYP)
+}
+
+/**
+ * Return 'true' if the [source] contains an animated HEIF image sequence. The [source] is not
+ * consumed.
+ */
+fun DecodeUtils.isAnimatedHeif(source: BufferedSource): Boolean {
+    return isHeif(source) &&
+        (source.rangeEquals(8, HEIF_HEADER_MSF1) ||
+            source.rangeEquals(8, HEIF_HEADER_HEVC) ||
+            source.rangeEquals(8, HEIF_HEADER_HEVX))
+}

--- a/coil-gif/src/test/java/coil/decode/DecodeUtilsTest.kt
+++ b/coil-gif/src/test/java/coil/decode/DecodeUtilsTest.kt
@@ -1,0 +1,83 @@
+package coil.decode
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import okio.buffer
+import okio.source
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class DecodeUtilsTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun before() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `isGif true positive`() {
+        val source = context.assets.open("animated.gif").source().buffer()
+        assertTrue(DecodeUtils.isGif(source))
+    }
+
+    @Test
+    fun `isGif true negative`() {
+        val source = context.assets.open("normal.jpg").source().buffer()
+        assertFalse(DecodeUtils.isGif(source))
+    }
+
+    @Test
+    fun `isWebP true positive`() {
+        val source = context.assets.open("static.webp").source().buffer()
+        assertTrue(DecodeUtils.isWebP(source))
+    }
+
+    @Test
+    fun `isWebP true negative`() {
+        val source = context.assets.open("animated.gif").source().buffer()
+        assertFalse(DecodeUtils.isWebP(source))
+    }
+
+    @Test
+    fun `isAnimatedWebP true positive`() {
+        val source = context.assets.open("animated.webp").source().buffer()
+        assertTrue(DecodeUtils.isAnimatedWebP(source))
+    }
+
+    @Test
+    fun `isAnimatedWebP true negative`() {
+        val source = context.assets.open("static.webp").source().buffer()
+        assertFalse(DecodeUtils.isAnimatedWebP(source))
+    }
+
+    @Test
+    fun `isHeif true positive`() {
+        val source = context.assets.open("static.heif").source().buffer()
+        assertTrue(DecodeUtils.isHeif(source))
+    }
+
+    @Test
+    fun `isHeif true negative`() {
+        val source = context.assets.open("normal.jpg").source().buffer()
+        assertFalse(DecodeUtils.isHeif(source))
+    }
+
+    @Test
+    fun `isAnimatedHeif true positive`() {
+        val source = context.assets.open("animated.heif").source().buffer()
+        assertTrue(DecodeUtils.isAnimatedHeif(source))
+    }
+
+    @Test
+    fun `isAnimatedHeif true negative`() {
+        val source = context.assets.open("animated.webp").source().buffer()
+        assertFalse(DecodeUtils.isAnimatedHeif(source))
+    }
+}

--- a/coil-svg/api/coil-svg.api
+++ b/coil-svg/api/coil-svg.api
@@ -1,3 +1,7 @@
+public final class coil/decode/SvgDecodeUtils {
+	public static final fun isSvg (Lcoil/decode/DecodeUtils;Lokio/BufferedSource;)Z
+}
+
 public final class coil/decode/SvgDecoder : coil/decode/Decoder {
 	public fun <init> (Lcoil/decode/ImageSource;Lcoil/request/Options;)V
 	public fun <init> (Lcoil/decode/ImageSource;Lcoil/request/Options;Z)V

--- a/coil-svg/src/main/java/coil/decode/DecodeUtils.kt
+++ b/coil-svg/src/main/java/coil/decode/DecodeUtils.kt
@@ -1,0 +1,22 @@
+@file:JvmName("SvgDecodeUtils")
+@file:Suppress("unused")
+
+package coil.decode
+
+import coil.util.indexOf
+import okio.BufferedSource
+import okio.ByteString.Companion.encodeUtf8
+
+private val SVG_TAG = "<svg ".encodeUtf8()
+private val LEFT_ANGLE_BRACKET = "<".encodeUtf8()
+
+/**
+ * Return 'true' if the [source] contains an SVG image. The [source] is not consumed.
+ *
+ * NOTE: There's no guaranteed method to determine if a byte stream is an SVG without attempting
+ * to decode it. This method uses heuristics.
+ */
+fun DecodeUtils.isSvg(source: BufferedSource): Boolean {
+    return source.rangeEquals(0, LEFT_ANGLE_BRACKET) &&
+        source.indexOf(SVG_TAG, 0, 1024) != -1L
+}

--- a/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
+++ b/coil-svg/src/main/java/coil/decode/SvgDecoder.kt
@@ -8,19 +8,17 @@ import coil.ImageLoader
 import coil.fetch.SourceResult
 import coil.request.Options
 import coil.size.Dimension
-import coil.util.indexOf
 import coil.util.toSoftware
 import com.caverock.androidsvg.SVG
 import kotlinx.coroutines.runInterruptible
-import okio.BufferedSource
-import okio.ByteString.Companion.encodeUtf8
 import kotlin.math.roundToInt
 
 /**
- * A [Decoder] that uses [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) to decode SVG files.
+ * A [Decoder] that uses [AndroidSVG](https://bigbadaboom.github.io/androidsvg/) to decode SVG
+ * files.
  *
- * @param useViewBoundsAsIntrinsicSize If true, uses the SVG's view bounds as the intrinsic size for the SVG.
- *  If false, uses the SVG's width/height as the intrinsic size for the SVG.
+ * @param useViewBoundsAsIntrinsicSize If true, uses the SVG's view bounds as the intrinsic size for
+ *  the SVG. If false, uses the SVG's width/height as the intrinsic size for the SVG.
  */
 class SvgDecoder @JvmOverloads constructor(
     private val source: ImageSource,
@@ -97,17 +95,13 @@ class SvgDecoder @JvmOverloads constructor(
         }
 
         private fun isApplicable(result: SourceResult): Boolean {
-            return result.mimeType == MIME_TYPE_SVG || containsSvgTag(result.source.source())
-        }
-
-        private fun containsSvgTag(source: BufferedSource): Boolean {
-            return source.rangeEquals(0, LEFT_ANGLE_BRACKET) &&
-                source.indexOf(SVG_TAG, 0, SVG_TAG_SEARCH_THRESHOLD_BYTES) != -1L
+            return result.mimeType == MIME_TYPE_SVG || DecodeUtils.isSvg(result.source.source())
         }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
-            return other is Factory && useViewBoundsAsIntrinsicSize == other.useViewBoundsAsIntrinsicSize
+            return other is Factory &&
+                useViewBoundsAsIntrinsicSize == other.useViewBoundsAsIntrinsicSize
         }
 
         override fun hashCode() = useViewBoundsAsIntrinsicSize.hashCode()
@@ -116,8 +110,5 @@ class SvgDecoder @JvmOverloads constructor(
     private companion object {
         private const val MIME_TYPE_SVG = "image/svg+xml"
         private const val DEFAULT_SIZE = 512f
-        private const val SVG_TAG_SEARCH_THRESHOLD_BYTES = 1024L
-        private val SVG_TAG = "<svg ".encodeUtf8()
-        private val LEFT_ANGLE_BRACKET = "<".encodeUtf8()
     }
 }


### PR DESCRIPTION
This reduces the size of `coil-base` and makes `DecodeUtils.isSvg` public.