### PR TITLE
Enable Gradle's type-safe project accessors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,10 @@ apply(plugin = "org.jetbrains.dokka")
 tasks.withType<DokkaMultiModuleTask>().configureEach {
     outputDirectory by file("$rootDir/docs/api")
     removeChildTasks(listOf(
-        project(":coil-sample-common"),
-        project(":coil-sample-compose"),
-        project(":coil-sample-view"),
-        project(":coil-test")
+        projects.coilSampleCommon.dependencyProject,
+        projects.coilSampleCompose.dependencyProject,
+        projects.coilSampleView.dependencyProject,
+        projects.coilTest.dependencyProject
     ))
 }
 

--- a/coil-base/build.gradle.kts
+++ b/coil-base/build.gradle.kts
@@ -21,9 +21,9 @@ dependencies {
     api(libs.okhttp)
     api(libs.okio)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
 }

--- a/coil-bom/build.gradle.kts
+++ b/coil-bom/build.gradle.kts
@@ -10,12 +10,12 @@ setupLibraryModule()
 
 dependencies {
     constraints {
-        api(project(":coil-base"))
-        api(project(":coil-singleton"))
-        api(project(":coil-compose-base"))
-        api(project(":coil-compose-singleton"))
-        api(project(":coil-gif"))
-        api(project(":coil-svg"))
-        api(project(":coil-video"))
+        api(projects.coilBase)
+        api(projects.coilSingleton)
+        api(projects.coilComposeBase)
+        api(projects.coilComposeSingleton)
+        api(projects.coilGif)
+        api(projects.coilSvg)
+        api(projects.coilVideo)
     }
 }

--- a/coil-compose-base/build.gradle.kts
+++ b/coil-compose-base/build.gradle.kts
@@ -17,16 +17,16 @@ setupLibraryModule {
 }
 
 dependencies {
-    api(project(":coil-base"))
+    api(projects.coilBase)
 
     implementation(libs.androidx.core)
     implementation(libs.accompanist.drawablepainter)
     api(libs.compose.foundation)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
     androidTestImplementation(libs.compose.ui.test)
 }

--- a/coil-compose-singleton/build.gradle.kts
+++ b/coil-compose-singleton/build.gradle.kts
@@ -17,6 +17,6 @@ setupLibraryModule {
 }
 
 dependencies {
-    api(project(":coil-compose-base"))
-    api(project(":coil-singleton"))
+    api(projects.coilComposeBase)
+    api(projects.coilSingleton)
 }

--- a/coil-gif/build.gradle.kts
+++ b/coil-gif/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 setupLibraryModule()
 
 dependencies {
-    api(project(":coil-base"))
+    api(projects.coilBase)
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.vectordrawable.animated)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
 }

--- a/coil-sample-common/build.gradle.kts
+++ b/coil-sample-common/build.gradle.kts
@@ -8,10 +8,10 @@ plugins {
 setupLibraryModule(enableBuildConfig = true)
 
 dependencies {
-    api(project(":coil-singleton"))
-    api(project(":coil-gif"))
-    api(project(":coil-svg"))
-    api(project(":coil-video"))
+    api(projects.coilSingleton)
+    api(projects.coilGif)
+    api(projects.coilSvg)
+    api(projects.coilVideo)
 
     api(libs.androidx.core)
     api(libs.androidx.lifecycle.viewmodel)

--- a/coil-sample-compose/build.gradle.kts
+++ b/coil-sample-compose/build.gradle.kts
@@ -26,11 +26,11 @@ setupAppModule {
 }
 
 dependencies {
-    implementation(project(":coil-sample-common"))
-    implementation(project(":coil-compose-singleton"))
-    implementation(project(":coil-gif"))
-    implementation(project(":coil-svg"))
-    implementation(project(":coil-video"))
+    implementation(projects.coilSampleCommon)
+    implementation(projects.coilComposeSingleton)
+    implementation(projects.coilGif)
+    implementation(projects.coilSvg)
+    implementation(projects.coilVideo)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.accompanist.insets)

--- a/coil-sample-view/build.gradle.kts
+++ b/coil-sample-view/build.gradle.kts
@@ -23,11 +23,11 @@ setupAppModule {
 }
 
 dependencies {
-    implementation(project(":coil-sample-common"))
-    implementation(project(":coil-singleton"))
-    implementation(project(":coil-gif"))
-    implementation(project(":coil-svg"))
-    implementation(project(":coil-video"))
+    implementation(projects.coilSampleCommon)
+    implementation(projects.coilSingleton)
+    implementation(projects.coilGif)
+    implementation(projects.coilSvg)
+    implementation(projects.coilVideo)
 
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)

--- a/coil-singleton/build.gradle.kts
+++ b/coil-singleton/build.gradle.kts
@@ -10,11 +10,11 @@ plugins {
 setupLibraryModule()
 
 dependencies {
-    api(project(":coil-base"))
+    api(projects.coilBase)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
 }

--- a/coil-svg/build.gradle.kts
+++ b/coil-svg/build.gradle.kts
@@ -10,14 +10,14 @@ plugins {
 setupLibraryModule()
 
 dependencies {
-    api(project(":coil-base"))
+    api(projects.coilBase)
 
     implementation(libs.androidx.core)
     implementation(libs.svg)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
 }

--- a/coil-test/build.gradle.kts
+++ b/coil-test/build.gradle.kts
@@ -9,7 +9,7 @@ setupLibraryModule()
 
 dependencies {
     // Prevent a dependency cycle.
-    compileOnly(project(":coil-base"))
+    compileOnly(projects.coilBase)
 
     api(libs.androidx.activity)
     api(libs.androidx.core)

--- a/coil-video/build.gradle.kts
+++ b/coil-video/build.gradle.kts
@@ -10,13 +10,13 @@ plugins {
 setupLibraryModule()
 
 dependencies {
-    api(project(":coil-base"))
+    api(projects.coilBase)
 
     implementation(libs.androidx.core)
 
-    testImplementation(project(":coil-test"))
+    testImplementation(projects.coilTest)
     testImplementation(libs.bundles.test.jvm)
 
-    androidTestImplementation(project(":coil-test"))
+    androidTestImplementation(projects.coilTest)
     androidTestImplementation(libs.bundles.test.android)
 }


### PR DESCRIPTION
Follow up #1129.

https://docs.gradle.org/7.0/userguide/declaring_dependencies.html#sec:type-safe-project-accessors