### PR TITLE
Add ContentScale argument to AsyncImagePainter.

### DIFF
--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -70,8 +70,8 @@ public final class coil/compose/AsyncImagePainter$State$Success : coil/compose/A
 }
 
 public final class coil/compose/AsyncImagePainterKt {
-	public static final fun rememberAsyncImagePainter-19ie5dc (Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberAsyncImagePainter-MqR-F_0 (Ljava/lang/Object;Lcoil/ImageLoader;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberAsyncImagePainter-3HmZ8SU (Ljava/lang/Object;Lcoil/ImageLoader;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/layout/ContentScale;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberAsyncImagePainter-5jETZwI (Ljava/lang/Object;Lcoil/ImageLoader;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/layout/ContentScale;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
 }
 
 public final class coil/compose/ComposableSingletons$SubcomposeAsyncImageKt {

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -58,8 +58,8 @@ import coil.size.Size as CoilSize
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun AsyncImage(
@@ -112,8 +112,8 @@ fun AsyncImage(
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun AsyncImage(

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -131,7 +131,9 @@ fun AsyncImage(
 ) {
     // Create and execute the image request.
     val request = updateRequest(requestOf(model), contentScale)
-    val painter = rememberAsyncImagePainter(request, imageLoader, transform, onState, filterQuality)
+    val painter = rememberAsyncImagePainter(
+        request, imageLoader, transform, onState, contentScale, filterQuality
+    )
 
     // Draw the content without a parent composable or subcomposition.
     val constraintsResolver = request.constraintsResolver
@@ -184,10 +186,14 @@ internal fun updateRequest(
     contentScale: ContentScale,
 ) = request.newBuilder()
     .apply {
-        val resolver = remember { ConstraintsResolver() }
-        resolver.scale = contentScale.toScale()
-        if (request.defined.sizeResolver == null) size(resolver)
-        if (request.defined.scaleResolver == null) scale(resolver)
+        if (request.defined.sizeResolver == null) {
+            val resolver = remember { ConstraintsResolver() }
+            size(resolver)
+            if (request.defined.scaleResolver == null) {
+                resolver.scale = contentScale.toScale()
+                scale(resolver)
+            }
+        }
     }
     .build()
 
@@ -254,10 +260,4 @@ private fun computeScale(constraints: Constraints, original: Scale): Scale {
         // Always scale to fit the minimum dimension when at least one dimension is unbounded.
         return Scale.FIT
     }
-}
-
-@Stable
-private fun ContentScale.toScale() = when (this) {
-    ContentScale.Fit, ContentScale.Inside -> Scale.FIT
-    else -> Scale.FILL
 }

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -3,7 +3,9 @@ package coil.compose
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.Stable
@@ -26,7 +28,9 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Constraints
 import coil.ImageLoader
 import coil.compose.AsyncImagePainter.Companion.DefaultTransform
 import coil.compose.AsyncImagePainter.State
@@ -58,10 +62,12 @@ import coil.size.Size as CoilSize
  * **This is a lower-level API than [AsyncImage] and may not work as expected in all situations.**
  * **It's highly recommended to use [AsyncImage] unless you need a reference to a [Painter].**
  *
- * Notably, [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called,
- * which can occur for composables that don't have a fixed size (e.g. [LazyColumn]). Also
- * [AsyncImagePainter.state] will not transition to [State.Success] synchronously during the
- * composition phase.
+ * - [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called.
+ *   This can occur if a composable has an unbounded (i.e. [Constraints.Infinity]) width/height
+ *   constraint. For example, to use [AsyncImagePainter] with [LazyRow] or [LazyColumn], you must
+ *   set a bounded width or height respectively.
+ * - [AsyncImagePainter.state] does not transition to [State.Success] synchronously during the
+ *   composition phase. Use [SubcomposeAsyncImage] if you need this.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
  * @param imageLoader The [ImageLoader] that will be used to execute the request.
@@ -71,8 +77,11 @@ import coil.size.Size as CoilSize
  * @param onLoading Called when the image request begins loading.
  * @param onSuccess Called when the image request completes successfully.
  * @param onError Called when the image request completes unsuccessfully.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param contentScale Used to determine the aspect ratio scaling to be used if the canvas bounds
+ *  are a different size from the intrinsic size of the image loaded by [model]. This should be set
+ *  to the same value that's passed to [Image].
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun rememberAsyncImagePainter(
@@ -84,12 +93,14 @@ fun rememberAsyncImagePainter(
     onLoading: ((State.Loading) -> Unit)? = null,
     onSuccess: ((State.Success) -> Unit)? = null,
     onError: ((State.Error) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
     filterQuality: FilterQuality = DefaultFilterQuality,
 ) = rememberAsyncImagePainter(
     model = model,
     imageLoader = imageLoader,
     transform = transformOf(placeholder, error, fallback),
     onState = onStateOf(onLoading, onSuccess, onError),
+    contentScale = contentScale,
     filterQuality = filterQuality,
 )
 
@@ -99,18 +110,23 @@ fun rememberAsyncImagePainter(
  * **This is a lower-level API than [AsyncImage] and may not work as expected in all situations.**
  * **It's highly recommended to use [AsyncImage] unless you need a reference to a [Painter].**
  *
- * Notably, [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called,
- * which can occur for composables that don't have a fixed size (e.g. [LazyColumn]). Also
- * [AsyncImagePainter.state] will not transition to [State.Success] synchronously during the
- * composition phase.
+ * - [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called.
+ *   This can occur if a composable has an unbounded (i.e. [Constraints.Infinity]) width/height
+ *   constraint. For example, to use [AsyncImagePainter] with [LazyRow] or [LazyColumn], you must
+ *   set a bounded width or height respectively.
+ * - [AsyncImagePainter.state] does not transition to [State.Success] synchronously during the
+ *   composition phase. Use [SubcomposeAsyncImage] if you need this.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
  * @param imageLoader The [ImageLoader] that will be used to execute the request.
  * @param transform A callback to transform a new [State] before it's applied to the
  *  [AsyncImagePainter]. Typically this is used to overwrite the state's [Painter].
  * @param onState Called when the state of this painter changes.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param contentScale Used to determine the aspect ratio scaling to be used if the canvas bounds
+ *  are a different size from the intrinsic size of the image loaded by [model]. This should be set
+ *  to the same value that's passed to [Image].
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun rememberAsyncImagePainter(
@@ -118,6 +134,7 @@ fun rememberAsyncImagePainter(
     imageLoader: ImageLoader,
     transform: (State) -> State = DefaultTransform,
     onState: ((State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
     filterQuality: FilterQuality = DefaultFilterQuality,
 ): AsyncImagePainter {
     val request = requestOf(model)
@@ -126,6 +143,7 @@ fun rememberAsyncImagePainter(
     val painter = remember { AsyncImagePainter(request, imageLoader) }
     painter.transform = transform
     painter.onState = onState
+    painter.contentScale = contentScale
     painter.filterQuality = filterQuality
     painter.isPreview = LocalInspectionMode.current
     painter.imageLoader = imageLoader
@@ -165,6 +183,7 @@ class AsyncImagePainter internal constructor(
 
     internal var transform = DefaultTransform
     internal var onState: ((State) -> Unit)? = null
+    internal var contentScale = ContentScale.Fit
     internal var filterQuality = DefaultFilterQuality
     internal var isPreview = false
 
@@ -254,6 +273,10 @@ class AsyncImagePainter internal constructor(
                     // If no other size resolver is set, suspend until the canvas size is positive.
                     size { drawSize.mapNotNull { it.toSizeOrNull() }.first() }
                 }
+                if (request.defined.scaleResolver == null) {
+                    // If no other scale resolver is set, use the content scale.
+                    scale(contentScale.toScale())
+                }
                 if (request.defined.precision != Precision.EXACT) {
                     // AsyncImagePainter scales the image to fit the canvas size at draw time.
                     precision(Precision.INEXACT)
@@ -291,19 +314,10 @@ class AsyncImagePainter internal constructor(
         // a `CrossfadeTransformation`.
         val transition = result.request.transitionFactory.create(FakeTransitionTarget, result)
         if (transition is CrossfadeTransition) {
-            // Use the original scale inside of the scale that's used for determining the
-            // decode dimensions.
-            val scaleResolver = result.request.scaleResolver
-            val scale = if (scaleResolver is ConstraintsResolver) {
-                scaleResolver.scale
-            } else {
-                scaleResolver.scale()
-            }
-
             return CrossfadePainter(
                 start = previous.painter.takeIf { previous is State.Loading },
                 end = current.painter,
-                scale = scale,
+                contentScale = contentScale,
                 durationMillis = transition.durationMillis,
                 fadeStart = result !is SuccessResult || !result.isPlaceholderCached,
                 preferExactIntrinsicSize = transition.preferExactIntrinsicSize

--- a/coil-compose-base/src/main/java/coil/compose/CrossfadePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/CrossfadePainter.kt
@@ -13,21 +13,21 @@ import androidx.compose.ui.graphics.DefaultAlpha
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.inset
 import androidx.compose.ui.graphics.painter.Painter
-import coil.decode.DecodeUtils
-import coil.size.Scale
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.times
 import kotlin.math.max
 
 /**
  * A [Painter] that crossfades from [start] to [end].
  *
- * NOTE: The animation can only be executed once as the [start] drawable is
- * dereferenced at the end of the transition.
+ * NOTE: The animation can only be executed once as the [start] drawable is dereferenced at
+ * the end of the transition.
  */
 @Stable
 internal class CrossfadePainter(
     private var start: Painter?,
     private val end: Painter?,
-    private val scale: Scale,
+    private val contentScale: ContentScale,
     private val durationMillis: Int,
     private val fadeStart: Boolean,
     private val preferExactIntrinsicSize: Boolean,
@@ -119,23 +119,9 @@ internal class CrossfadePainter(
         }
     }
 
-    /** Scale the src size into the dst size preserving aspect ratio. */
     private fun computeDrawSize(srcSize: Size, dstSize: Size): Size {
         if (srcSize.isUnspecified || srcSize.isEmpty()) return dstSize
         if (dstSize.isUnspecified || dstSize.isEmpty()) return dstSize
-
-        val srcWidth = srcSize.width
-        val srcHeight = srcSize.height
-        val multiplier = DecodeUtils.computeSizeMultiplier(
-            srcWidth = srcWidth,
-            srcHeight = srcHeight,
-            dstWidth = dstSize.width,
-            dstHeight = dstSize.height,
-            scale = scale
-        )
-        return Size(
-            width = multiplier * srcWidth,
-            height = multiplier * srcHeight
-        )
+        return srcSize * contentScale.computeScaleFactor(srcSize, dstSize)
     }
 }

--- a/coil-compose-base/src/main/java/coil/compose/SubcomposeAsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/SubcomposeAsyncImage.kt
@@ -118,7 +118,9 @@ fun SubcomposeAsyncImage(
 ) {
     // Create and execute the image request.
     val request = updateRequest(requestOf(model), contentScale)
-    val painter = rememberAsyncImagePainter(request, imageLoader, transform, onState, filterQuality)
+    val painter = rememberAsyncImagePainter(
+        request, imageLoader, transform, onState, contentScale, filterQuality
+    )
 
     val constraintsResolver = request.constraintsResolver
     if (constraintsResolver == null) {

--- a/coil-compose-base/src/main/java/coil/compose/SubcomposeAsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/SubcomposeAsyncImage.kt
@@ -43,8 +43,8 @@ import coil.request.ImageRequest
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun SubcomposeAsyncImage(
@@ -97,8 +97,8 @@ fun SubcomposeAsyncImage(
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  * @param content A callback to draw the content inside an [SubcomposeAsyncImageScope].
  */
 @Composable

--- a/coil-compose-base/src/main/java/coil/compose/Utils.kt
+++ b/coil-compose-base/src/main/java/coil/compose/Utils.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
@@ -13,6 +14,7 @@ import coil.compose.AsyncImagePainter.Companion.DefaultTransform
 import coil.compose.AsyncImagePainter.State
 import coil.request.ImageRequest
 import coil.request.NullRequestDataException
+import coil.size.Scale
 import kotlin.math.roundToInt
 
 /** Create an [ImageRequest] from the [model]. */
@@ -69,6 +71,12 @@ internal fun onStateOf(
     } else {
         null
     }
+}
+
+@Stable
+internal fun ContentScale.toScale() = when (this) {
+    ContentScale.Fit, ContentScale.Inside -> Scale.FIT
+    else -> Scale.FILL
 }
 
 internal val ImageRequest.constraintsResolver: ConstraintsResolver?

--- a/coil-compose-singleton/api/coil-compose-singleton.api
+++ b/coil-compose-singleton/api/coil-compose-singleton.api
@@ -23,8 +23,8 @@ public final class coil/compose/SingletonAsyncImageKt {
 }
 
 public final class coil/compose/SingletonAsyncImagePainterKt {
-	public static final fun rememberAsyncImagePainter-5h-nEew (Ljava/lang/Object;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
-	public static final fun rememberAsyncImagePainter-DJqXB-Q (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberAsyncImagePainter-19ie5dc (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/layout/ContentScale;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
+	public static final fun rememberAsyncImagePainter-MqR-F_0 (Ljava/lang/Object;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/layout/ContentScale;ILandroidx/compose/runtime/Composer;II)Lcoil/compose/AsyncImagePainter;
 }
 
 public final class coil/compose/SingletonImagePainterKt {

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
@@ -37,8 +37,8 @@ import coil.request.ImageRequest
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun AsyncImage(
@@ -93,8 +93,8 @@ fun AsyncImage(
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun AsyncImage(

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImagePainter.kt
@@ -2,23 +2,31 @@
 
 package coil.compose
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.drawscope.DrawScope.Companion.DefaultFilterQuality
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Constraints
 import coil.compose.AsyncImagePainter.Companion.DefaultTransform
 import coil.compose.AsyncImagePainter.State
 import coil.request.ImageRequest
 
 /**
- * Return an [AsyncImagePainter] that executes an [ImageRequest] asynchronously and
- * renders the result.
+ * Return an [AsyncImagePainter] that executes an [ImageRequest] asynchronously and renders the result.
  *
- * This is a lower-level API than [AsyncImage] and may not work as expected in all situations.
- * Notably, it will not finish loading if [AsyncImagePainter.onDraw] is not called, which can occur
- * for composables that don't have a fixed size (e.g. [LazyColumn]). It's recommended to use
- * [AsyncImage] unless you need a reference to a [Painter].
+ * **This is a lower-level API than [AsyncImage] and may not work as expected in all situations.**
+ * **It's highly recommended to use [AsyncImage] unless you need a reference to a [Painter].**
+ *
+ * - [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called.
+ *   This can occur if a composable has an unbounded (i.e. [Constraints.Infinity]) width/height
+ *   constraint. For example, to use [AsyncImagePainter] with [LazyRow] or [LazyColumn], you must
+ *   set a bounded width or height respectively.
+ * - [AsyncImagePainter.state] does not transition to [State.Success] synchronously during the
+ *   composition phase. Use [SubcomposeAsyncImage] if you need this.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
  * @param placeholder A [Painter] that is displayed while the image is loading.
@@ -27,8 +35,11 @@ import coil.request.ImageRequest
  * @param onLoading Called when the image request begins loading.
  * @param onSuccess Called when the image request completes successfully.
  * @param onError Called when the image request completes unsuccessfully.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param contentScale Used to determine the aspect ratio scaling to be used if the canvas bounds
+ *  are a different size from the intrinsic size of the image loaded by [model]. This should be set
+ *  to the same value that's passed to [Image].
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun rememberAsyncImagePainter(
@@ -39,6 +50,7 @@ fun rememberAsyncImagePainter(
     onLoading: ((State.Loading) -> Unit)? = null,
     onSuccess: ((State.Success) -> Unit)? = null,
     onError: ((State.Error) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
     filterQuality: FilterQuality = DefaultFilterQuality,
 ) = rememberAsyncImagePainter(
     model = model,
@@ -49,6 +61,7 @@ fun rememberAsyncImagePainter(
     onLoading = onLoading,
     onSuccess = onSuccess,
     onError = onError,
+    contentScale = contentScale,
     filterQuality = filterQuality
 )
 
@@ -58,28 +71,35 @@ fun rememberAsyncImagePainter(
  * **This is a lower-level API than [AsyncImage] and may not work as expected in all situations.**
  * **It's highly recommended to use [AsyncImage] unless you need a reference to a [Painter].**
  *
- * Notably, [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called,
- * which can occur for composables that don't have a fixed size (e.g. [LazyColumn]). Also
- * [AsyncImagePainter.state] will not transition to [State.Success] synchronously during the
- * composition phase.
+ * - [AsyncImagePainter] will not finish loading if [AsyncImagePainter.onDraw] is not called.
+ *   This can occur if a composable has an unbounded (i.e. [Constraints.Infinity]) width/height
+ *   constraint. For example, to use [AsyncImagePainter] with [LazyRow] or [LazyColumn], you must
+ *   set a bounded width or height respectively.
+ * - [AsyncImagePainter.state] does not transition to [State.Success] synchronously during the
+ *   composition phase. Use [SubcomposeAsyncImage] if you need this.
  *
  * @param model Either an [ImageRequest] or the [ImageRequest.data] value.
  * @param transform A callback to transform a new [State] before it's applied to the
  *  [AsyncImagePainter]. Typically this is used to overwrite the state's [Painter].
  * @param onState Called when the state of this painter changes.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param contentScale Used to determine the aspect ratio scaling to be used if the canvas bounds
+ *  are a different size from the intrinsic size of the image loaded by [model]. This should be set
+ *  to the same value that's passed to [Image].
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun rememberAsyncImagePainter(
     model: Any?,
     transform: (State) -> State = DefaultTransform,
     onState: ((State) -> Unit)? = null,
+    contentScale: ContentScale = ContentScale.Fit,
     filterQuality: FilterQuality = DefaultFilterQuality,
 ) = rememberAsyncImagePainter(
     model = model,
     imageLoader = LocalImageLoader.current,
     transform = transform,
     onState = onState,
+    contentScale = contentScale,
     filterQuality = filterQuality
 )

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonSubcomposeAsyncImage.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonSubcomposeAsyncImage.kt
@@ -37,8 +37,8 @@ import coil.request.ImageRequest
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  */
 @Composable
 fun SubcomposeAsyncImage(
@@ -93,8 +93,8 @@ fun SubcomposeAsyncImage(
  *  onscreen.
  * @param colorFilter Optional [ColorFilter] to apply for the [AsyncImagePainter] when it is
  *  rendered onscreen.
- * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn
- *  into the destination.
+ * @param filterQuality Sampling algorithm applied to a bitmap when it is scaled and drawn into the
+ *  destination.
  * @param content A callback to draw the content inside an [SubcomposeAsyncImageScope].
  */
 @Composable


### PR DESCRIPTION
This also updates `CrossfadePainter` to scale the image more accurately using `ContentScale` instead of `Scale`.