### PR TITLE
Move plugins into libs.versions.toml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,19 +8,18 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import java.net.URL
 
 buildscript {
-    apply(from = "buildSrc/plugins.gradle.kts")
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
     }
     dependencies {
-        classpath(rootProject.extra["androidPlugin"].toString())
-        classpath(rootProject.extra["kotlinPlugin"].toString())
-        classpath(rootProject.extra["dokkaPlugin"].toString())
-        classpath(rootProject.extra["mavenPublishPlugin"].toString())
-        classpath(rootProject.extra["binaryCompatibilityPlugin"].toString())
-        classpath(rootProject.extra["ktlintPlugin"].toString())
+        classpath(libs.androidPlugin)
+        classpath(libs.kotlinPlugin)
+        classpath(libs.dokkaPlugin)
+        classpath(libs.mavenPublishPlugin)
+        classpath(libs.binaryCompatibilityPlugin)
+        classpath(libs.ktlintPlugin)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,12 +14,12 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath(libs.androidPlugin)
-        classpath(libs.kotlinPlugin)
-        classpath(libs.dokkaPlugin)
-        classpath(libs.mavenPublishPlugin)
-        classpath(libs.binaryCompatibilityPlugin)
-        classpath(libs.ktlintPlugin)
+        classpath(libs.gradlePlugin.android)
+        classpath(libs.gradlePlugin.kotlin)
+        classpath(libs.gradlePlugin.dokka)
+        classpath(libs.gradlePlugin.mavenPublish)
+        classpath(libs.gradlePlugin.binaryCompatibility)
+        classpath(libs.gradlePlugin.ktlint)
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,6 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.androidPlugin)
-    implementation(libs.kotlinPlugin)
+    implementation(libs.gradlePlugin.android)
+    implementation(libs.gradlePlugin.kotlin)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,7 @@ repositories {
     mavenCentral()
 }
 
-apply(from = "plugins.gradle.kts")
-
 dependencies {
-    implementation(rootProject.extra["androidPlugin"].toString())
-    implementation(rootProject.extra["kotlinPlugin"].toString())
+    implementation(libs.androidPlugin)
+    implementation(libs.kotlinPlugin)
 }

--- a/buildSrc/plugins.gradle.kts
+++ b/buildSrc/plugins.gradle.kts
@@ -1,8 +1,0 @@
-rootProject.extra.apply {
-    set("androidPlugin", "com.android.tools.build:gradle:7.1.1")
-    set("kotlinPlugin", "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
-    set("dokkaPlugin", "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10")
-    set("mavenPublishPlugin", "com.vanniktech:gradle-maven-publish-plugin:0.18.0")
-    set("binaryCompatibilityPlugin", "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0")
-    set("ktlintPlugin", "org.jlleitschuh.gradle:ktlint-gradle:10.2.1")
-}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,13 @@ okhttp = "4.9.3"
 okio = "3.0.0"
 
 [libraries]
+androidPlugin = "com.android.tools.build:gradle:7.1.1"
+kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
+mavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+binaryCompatibilityPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
+ktlintPlugin = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
+
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanist" }
 accompanist-insets = { module = "com.google.accompanist:accompanist-insets", version.ref = "accompanist" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,12 +9,12 @@ okhttp = "4.9.3"
 okio = "3.0.0"
 
 [libraries]
-androidPlugin = "com.android.tools.build:gradle:7.1.1"
-kotlinPlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
-dokkaPlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
-mavenPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
-binaryCompatibilityPlugin = "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
-ktlintPlugin = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
+gradlePlugin-android = "com.android.tools.build:gradle:7.1.1"
+gradlePlugin-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+gradlePlugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
+gradlePlugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+gradlePlugin-binaryCompatibility = "org.jetbrains.kotlinx:binary-compatibility-validator:0.8.0"
+gradlePlugin-ktlint = "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
 
 accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "accompanist" }
 accompanist-insets = { module = "com.google.accompanist:accompanist-insets", version.ref = "accompanist" }


### PR DESCRIPTION
Seems we can use version catalogs by adding `buildSrc/settings.gradle.kts`, now all deps are declared in `gradle/libs.versions.toml`.