### PR TITLE
Remove jvm-default=all compiler flag.

### DIFF
--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -76,8 +76,6 @@ private inline fun <reified T : BaseExtension> Project.setupBaseModule(
         val arguments = mutableListOf(
             // https://kotlinlang.org/docs/compiler-reference.html#progressive
             "-progressive",
-            // Generate native Java 8 default interface methods.
-            "-Xjvm-default=all",
             // Generate smaller bytecode by not generating runtime not-null assertions.
             "-Xno-call-assertions",
             "-Xno-param-assertions",

--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -31,29 +31,52 @@ public final class coil/ComponentRegistry$Builder {
 public abstract interface class coil/EventListener : coil/request/ImageRequest$Listener {
 	public static final field Companion Lcoil/EventListener$Companion;
 	public static final field NONE Lcoil/EventListener;
-	public fun decodeEnd (Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;Lcoil/decode/DecodeResult;)V
-	public fun decodeStart (Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;)V
-	public fun fetchEnd (Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;Lcoil/fetch/FetchResult;)V
-	public fun fetchStart (Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;)V
-	public fun keyEnd (Lcoil/request/ImageRequest;Ljava/lang/String;)V
-	public fun keyStart (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
-	public fun mapEnd (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
-	public fun mapStart (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
-	public fun onCancel (Lcoil/request/ImageRequest;)V
-	public fun onError (Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
-	public fun onStart (Lcoil/request/ImageRequest;)V
-	public fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
-	public fun resolveScaleEnd (Lcoil/request/ImageRequest;Lcoil/size/Scale;)V
-	public fun resolveScaleStart (Lcoil/request/ImageRequest;)V
-	public fun resolveSizeEnd (Lcoil/request/ImageRequest;Lcoil/size/Size;)V
-	public fun resolveSizeStart (Lcoil/request/ImageRequest;)V
-	public fun transformEnd (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
-	public fun transformStart (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
-	public fun transitionEnd (Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
-	public fun transitionStart (Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
+	public abstract fun decodeEnd (Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;Lcoil/decode/DecodeResult;)V
+	public abstract fun decodeStart (Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;)V
+	public abstract fun fetchEnd (Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;Lcoil/fetch/FetchResult;)V
+	public abstract fun fetchStart (Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;)V
+	public abstract fun keyEnd (Lcoil/request/ImageRequest;Ljava/lang/String;)V
+	public abstract fun keyStart (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public abstract fun mapEnd (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public abstract fun mapStart (Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public abstract fun onCancel (Lcoil/request/ImageRequest;)V
+	public abstract fun onError (Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
+	public abstract fun onStart (Lcoil/request/ImageRequest;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
+	public abstract fun resolveScaleEnd (Lcoil/request/ImageRequest;Lcoil/size/Scale;)V
+	public abstract fun resolveScaleStart (Lcoil/request/ImageRequest;)V
+	public abstract fun resolveSizeEnd (Lcoil/request/ImageRequest;Lcoil/size/Size;)V
+	public abstract fun resolveSizeStart (Lcoil/request/ImageRequest;)V
+	public abstract fun transformEnd (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
+	public abstract fun transformStart (Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
+	public abstract fun transitionEnd (Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
+	public abstract fun transitionStart (Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
 }
 
 public final class coil/EventListener$Companion {
+}
+
+public final class coil/EventListener$DefaultImpls {
+	public static fun decodeEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;Lcoil/decode/DecodeResult;)V
+	public static fun decodeStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/decode/Decoder;Lcoil/request/Options;)V
+	public static fun fetchEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;Lcoil/fetch/FetchResult;)V
+	public static fun fetchStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/fetch/Fetcher;Lcoil/request/Options;)V
+	public static fun keyEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/String;)V
+	public static fun keyStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public static fun mapEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public static fun mapStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Ljava/lang/Object;)V
+	public static fun onCancel (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
+	public static fun onError (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
+	public static fun onStart (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
+	public static fun onSuccess (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
+	public static fun resolveScaleEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/Scale;)V
+	public static fun resolveScaleStart (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
+	public static fun resolveSizeEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/size/Size;)V
+	public static fun resolveSizeStart (Lcoil/EventListener;Lcoil/request/ImageRequest;)V
+	public static fun transformEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
+	public static fun transformStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Landroid/graphics/Bitmap;)V
+	public static fun transitionEnd (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
+	public static fun transitionStart (Lcoil/EventListener;Lcoil/request/ImageRequest;Lcoil/transition/Transition;)V
 }
 
 public abstract interface class coil/EventListener$Factory {
@@ -612,10 +635,17 @@ public final class coil/request/ImageRequest$Builder {
 }
 
 public abstract interface class coil/request/ImageRequest$Listener {
-	public fun onCancel (Lcoil/request/ImageRequest;)V
-	public fun onError (Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
-	public fun onStart (Lcoil/request/ImageRequest;)V
-	public fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
+	public abstract fun onCancel (Lcoil/request/ImageRequest;)V
+	public abstract fun onError (Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
+	public abstract fun onStart (Lcoil/request/ImageRequest;)V
+	public abstract fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
+}
+
+public final class coil/request/ImageRequest$Listener$DefaultImpls {
+	public static fun onCancel (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
+	public static fun onError (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/ErrorResult;)V
+	public static fun onStart (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;)V
+	public static fun onSuccess (Lcoil/request/ImageRequest$Listener;Lcoil/request/ImageRequest;Lcoil/request/SuccessResult;)V
 }
 
 public abstract class coil/request/ImageResult {
@@ -812,9 +842,14 @@ public final class coil/size/SizeResolvers {
 }
 
 public abstract interface class coil/size/ViewSizeResolver : coil/size/SizeResolver {
-	public fun getSubtractPadding ()Z
+	public abstract fun getSubtractPadding ()Z
 	public abstract fun getView ()Landroid/view/View;
-	public fun size (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun size (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class coil/size/ViewSizeResolver$DefaultImpls {
+	public static fun getSubtractPadding (Lcoil/size/ViewSizeResolver;)Z
+	public static fun size (Lcoil/size/ViewSizeResolver;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil/size/ViewSizeResolvers {
@@ -845,13 +880,25 @@ public class coil/target/ImageViewTarget : coil/target/GenericViewTarget {
 }
 
 public abstract interface class coil/target/Target {
-	public fun onError (Landroid/graphics/drawable/Drawable;)V
-	public fun onStart (Landroid/graphics/drawable/Drawable;)V
-	public fun onSuccess (Landroid/graphics/drawable/Drawable;)V
+	public abstract fun onError (Landroid/graphics/drawable/Drawable;)V
+	public abstract fun onStart (Landroid/graphics/drawable/Drawable;)V
+	public abstract fun onSuccess (Landroid/graphics/drawable/Drawable;)V
+}
+
+public final class coil/target/Target$DefaultImpls {
+	public static fun onError (Lcoil/target/Target;Landroid/graphics/drawable/Drawable;)V
+	public static fun onStart (Lcoil/target/Target;Landroid/graphics/drawable/Drawable;)V
+	public static fun onSuccess (Lcoil/target/Target;Landroid/graphics/drawable/Drawable;)V
 }
 
 public abstract interface class coil/target/ViewTarget : coil/target/Target {
 	public abstract fun getView ()Landroid/view/View;
+}
+
+public final class coil/target/ViewTarget$DefaultImpls {
+	public static fun onError (Lcoil/target/ViewTarget;Landroid/graphics/drawable/Drawable;)V
+	public static fun onStart (Lcoil/target/ViewTarget;Landroid/graphics/drawable/Drawable;)V
+	public static fun onSuccess (Lcoil/target/ViewTarget;Landroid/graphics/drawable/Drawable;)V
 }
 
 public final class coil/transform/CircleCropTransformation : coil/transform/Transformation {
@@ -916,6 +963,12 @@ public final class coil/transition/Transition$Factory$Companion {
 public abstract interface class coil/transition/TransitionTarget : coil/target/Target {
 	public abstract fun getDrawable ()Landroid/graphics/drawable/Drawable;
 	public abstract fun getView ()Landroid/view/View;
+}
+
+public final class coil/transition/TransitionTarget$DefaultImpls {
+	public static fun onError (Lcoil/transition/TransitionTarget;Landroid/graphics/drawable/Drawable;)V
+	public static fun onStart (Lcoil/transition/TransitionTarget;Landroid/graphics/drawable/Drawable;)V
+	public static fun onSuccess (Lcoil/transition/TransitionTarget;Landroid/graphics/drawable/Drawable;)V
 }
 
 public final class coil/util/CoilUtils {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -27,7 +27,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += "-Xjvm-default=all" // Only required for 2.x.
     }
 }
 ```
@@ -42,7 +41,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += "-Xjvm-default=all" // Only required for 2.x.
     }
 }
 ```


### PR DESCRIPTION
I was hoping to land this in 2.x (and 1.x too!), but unfortunately I don't think we can ship this in the stable release. If we declare this flag we're requiring all consumers to also opt-into this experimental flag and possible a binary incompatible change. I've gotten some feedback that this might be a blocker for libraries that use Coil.

The initial reason for adding this flag was Okio 3.0 uses it and we would need to also declare it to implement one of Okio's interfaces, though I found out we can declare `-Xjvm-default=compatibility` instead. `-Xjvm-default=compatibility` doesn't require consumers to also declare the flag and isn't a binary compatible change.

Additionally, while it's nice to generate Java 8 default methods as they don't need to be desugared if your min SDK is 24+, the difference in the size of the library is minimal. Furthermore, R8 strips any extra code generated by Kotlin's default method implementation making the two methods almost identical in a release build.

The Kotlin team are still working on stabilizing this feature ([ticket](https://youtrack.jetbrains.com/issue/KT-46770)). Hopefully one day Coil can use it!