### PR TITLE
Remove component functions from MemoryCache.Key, MemoryCache.Value, and Parameters.

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -408,8 +408,6 @@ public final class coil/memory/MemoryCache$Key : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Map;
 	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcoil/memory/MemoryCache$Key;
 	public static synthetic fun copy$default (Lcoil/memory/MemoryCache$Key;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcoil/memory/MemoryCache$Key;
 	public fun describeContents ()I
@@ -424,8 +422,6 @@ public final class coil/memory/MemoryCache$Key : android/os/Parcelable {
 public final class coil/memory/MemoryCache$Value {
 	public fun <init> (Landroid/graphics/Bitmap;Ljava/util/Map;)V
 	public synthetic fun <init> (Landroid/graphics/Bitmap;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Landroid/graphics/Bitmap;
-	public final fun component2 ()Ljava/util/Map;
 	public final fun copy (Landroid/graphics/Bitmap;Ljava/util/Map;)Lcoil/memory/MemoryCache$Value;
 	public static synthetic fun copy$default (Lcoil/memory/MemoryCache$Value;Landroid/graphics/Bitmap;Ljava/util/Map;ILjava/lang/Object;)Lcoil/memory/MemoryCache$Value;
 	public fun equals (Ljava/lang/Object;)Z
@@ -720,10 +716,6 @@ public final class coil/request/Parameters$Companion {
 
 public final class coil/request/Parameters$Entry {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/String;)Lcoil/request/Parameters$Entry;
-	public static synthetic fun copy$default (Lcoil/request/Parameters$Entry;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lcoil/request/Parameters$Entry;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMemoryCacheKey ()Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/Object;

--- a/coil-base/src/main/java/coil/decode/ImageSource.kt
+++ b/coil-base/src/main/java/coil/decode/ImageSource.kt
@@ -115,6 +115,11 @@ fun ImageSource(
 sealed class ImageSource : Closeable {
 
     /**
+     * The [FileSystem] which contains the [file].
+     */
+    abstract val fileSystem: FileSystem
+
+    /**
      * Return the [Metadata] for this [ImageSource].
      */
     @ExperimentalCoilApi
@@ -144,11 +149,6 @@ sealed class ImageSource : Closeable {
      * already been created. Else, return 'null'.
      */
     abstract fun fileOrNull(): Path?
-
-    /**
-     * The [FileSystem] which contains the [file].
-     */
-    abstract val fileSystem: FileSystem
 
     /**
      * A marker class for metadata for an [ImageSource].

--- a/coil-base/src/main/java/coil/memory/MemoryCache.kt
+++ b/coil-base/src/main/java/coil/memory/MemoryCache.kt
@@ -54,10 +54,33 @@ interface MemoryCache {
      *  **must be** treated as immutable and should not be modified.
      */
     @Parcelize
-    data class Key(
+    class Key(
         val key: String,
         val extras: Map<String, String> = emptyMap(),
-    ) : Parcelable
+    ) : Parcelable {
+
+        fun copy(
+            key: String = this.key,
+            extras: Map<String, String> = this.extras
+        ) = Key(key, extras)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return other is Key &&
+                key == other.key &&
+                extras == other.extras
+        }
+
+        override fun hashCode(): Int {
+            var result = key.hashCode()
+            result = 31 * result + extras.hashCode()
+            return result
+        }
+
+        override fun toString(): String {
+            return "Key(key=$key, extras=$extras)"
+        }
+    }
 
     /**
      * The value for a [Bitmap] in the memory cache.
@@ -66,10 +89,33 @@ interface MemoryCache {
      * @param extras Metadata for [bitmap]. This map **must be**
      *  treated as immutable and should not be modified.
      */
-    data class Value(
+    class Value(
         val bitmap: Bitmap,
         val extras: Map<String, Any> = emptyMap(),
-    )
+    ) {
+
+        fun copy(
+            bitmap: Bitmap = this.bitmap,
+            extras: Map<String, Any> = this.extras
+        ) = Value(bitmap, extras)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return other is Value &&
+                bitmap == other.bitmap &&
+                extras == other.extras
+        }
+
+        override fun hashCode(): Int {
+            var result = bitmap.hashCode()
+            result = 31 * result + extras.hashCode()
+            return result
+        }
+
+        override fun toString(): String {
+            return "Value(bitmap=$bitmap, extras=$extras)"
+        }
+    }
 
     class Builder(private val context: Context) {
 

--- a/coil-base/src/main/java/coil/request/Parameters.kt
+++ b/coil-base/src/main/java/coil/request/Parameters.kt
@@ -71,10 +71,28 @@ class Parameters private constructor(
 
     fun newBuilder() = Builder(this)
 
-    data class Entry(
+    class Entry(
         val value: Any?,
         val memoryCacheKey: String?,
-    )
+    ) {
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            return other is Entry &&
+                value == other.value &&
+                memoryCacheKey == other.memoryCacheKey
+        }
+
+        override fun hashCode(): Int {
+            var result = value.hashCode()
+            result = 31 * result + memoryCacheKey.hashCode()
+            return result
+        }
+
+        override fun toString(): String {
+            return "Entry(value=$value, memoryCacheKey=$memoryCacheKey)"
+        }
+    }
 
     class Builder {
 


### PR DESCRIPTION
Removing these before `2.0.0` stable as it makes it tougher to make changes to these classes in the future without breaking binary compatibility.