### PR TITLE
Don't use kotlin-parcelize plugin

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -413,6 +413,7 @@ public final class coil/memory/MemoryCache$Builder {
 
 public final class coil/memory/MemoryCache$Key : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcoil/memory/MemoryCache$Key$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcoil/memory/MemoryCache$Key;
@@ -424,6 +425,9 @@ public final class coil/memory/MemoryCache$Key : android/os/Parcelable {
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class coil/memory/MemoryCache$Key$Companion {
 }
 
 public final class coil/memory/MemoryCache$Key$Creator : android/os/Parcelable$Creator {

--- a/coil-base/build.gradle.kts
+++ b/coil-base/build.gradle.kts
@@ -3,7 +3,6 @@ import coil.setupLibraryModule
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("kotlin-parcelize")
 }
 
 setupLibraryModule(name = "coil.base", publish = true)


### PR DESCRIPTION
The kotlin-parcelize plugin isn't supported in AOSP
( read, Parcelable methods aren't generated )

Since there's only one usage in the library
it's rather easy to re-implement it manually
instead of using code-generation

Signed-off-by: Luca Stefani <luca.stefani.ge1@gmail.com>
