### PR TITLE
Enable necessary JDK modules for tests

### DIFF
--- a/buildSrc/src/main/kotlin/Projects.kt
+++ b/buildSrc/src/main/kotlin/Projects.kt
@@ -103,7 +103,15 @@ private inline fun <reified T : BaseExtension> Project.setupBaseModule(
         )
     }
     testOptions {
-        unitTests.isIncludeAndroidResources = true
+        unitTests {
+            isIncludeAndroidResources = true
+            all {
+                it.jvmArgs(listOf(
+                    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                    "--add-opens=java.base/java.util=ALL-UNNAMED"
+                ))
+            }
+        }
     }
     lint {
         warningsAsErrors = true


### PR DESCRIPTION
These modules are removed from Gradle 7.5.x and above version, and they are needed if we run Robolectric tests with JDK 19.