### PR TITLE
Tweak JVM arguments.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8
 
 # https://issuetracker.google.com/issues/189367188
 android.disableAutomaticComponentCreation=true


### PR DESCRIPTION
Remove `-XX:+UseParallelGC` and use the default garbage collector as the improvements are minimal on JDK 19.