### PR TITLE
Minimize compose state of AsyncImagePainter

### DIFF
--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -164,7 +164,18 @@ class AsyncImagePainter internal constructor(
     private var rememberScope: CoroutineScope? = null
     private val drawSize = MutableStateFlow(Size.Zero)
 
-    private var painter: Painter? by mutableStateOf(null)
+    private var painterNotifier: Int by mutableStateOf(0)
+    private var painter: Painter? = null
+        get() {
+            painterNotifier
+            return _painter
+        }
+        set(value) {
+            if (field != value) {
+                field = value
+                painterNotifier = value.hashCode()
+            }
+        }
     private var alpha: Float by mutableStateOf(DefaultAlpha)
     private var colorFilter: ColorFilter? by mutableStateOf(null)
 
@@ -187,9 +198,20 @@ class AsyncImagePainter internal constructor(
     internal var filterQuality = DefaultFilterQuality
     internal var isPreview = false
 
+    private var stateNotifier: Int by mutableStateOf(0)
+
     /** The current [AsyncImagePainter.State]. */
-    var state: State by mutableStateOf(State.Empty)
-        private set
+    var state: State = State.Empty
+        get() {
+            stateNotifier
+            return field
+        }
+        private set(value) {
+            if (field != value) {
+                field = value
+                stateNotifier = value.hashCode()
+            }
+        }
 
     /** The current [ImageRequest]. */
     var request: ImageRequest by mutableStateOf(request)
@@ -260,6 +282,7 @@ class AsyncImagePainter internal constructor(
     private fun clear() {
         rememberScope?.cancel()
         rememberScope = null
+        updateState(State.Empty)
     }
 
     /** Update the [request] to work with [AsyncImagePainter]. */

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -168,7 +168,7 @@ class AsyncImagePainter internal constructor(
     private var painter: Painter? = null
         get() {
             painterNotifier
-            return _painter
+            return field
         }
         set(value) {
             if (field != value) {


### PR DESCRIPTION
# Context

Hi. I have a LazyList what state changes frequently, and I'm experiencing a leak where the forgotten state persists for a long time because the snapshots don't go away in time.
I know this isn't a coil problem, but it's hard to fix the compose leak right away, so I've reduced the state to a minimum so that it's okay if the AsyncImagePainter survives longer than expected.

# Change
- Changed the field holding the drawable in AsyncImagePainter to be non-state and indirectly notify to an int field.
- In clear , explicitly change the state to Empty to clear the painter and the drawable held by the state.