### PR TITLE
Annotate AsyncImage overloads as NonRestartableComposable.

### DIFF
--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -28,6 +28,7 @@ import coil.compose.AsyncImagePainter.State
 import coil.request.ImageRequest
 import coil.size.Dimension
 import coil.size.Size as CoilSize
+import androidx.compose.runtime.NonRestartableComposable
 import coil.size.SizeResolver
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -60,6 +61,7 @@ import kotlinx.coroutines.flow.mapNotNull
  *  destination.
  */
 @Composable
+@NonRestartableComposable
 fun AsyncImage(
     model: Any?,
     contentDescription: String?,

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImage.kt
@@ -1,6 +1,7 @@
 package coil.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -28,7 +29,6 @@ import coil.compose.AsyncImagePainter.State
 import coil.request.ImageRequest
 import coil.size.Dimension
 import coil.size.Size as CoilSize
-import androidx.compose.runtime.NonRestartableComposable
 import coil.size.SizeResolver
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first

--- a/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
+++ b/coil-compose-singleton/src/main/java/coil/compose/SingletonAsyncImage.kt
@@ -3,6 +3,7 @@
 package coil.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
@@ -41,6 +42,7 @@ import coil.request.ImageRequest
  *  destination.
  */
 @Composable
+@NonRestartableComposable
 fun AsyncImage(
     model: Any?,
     contentDescription: String?,
@@ -97,6 +99,7 @@ fun AsyncImage(
  *  destination.
  */
 @Composable
+@NonRestartableComposable
 fun AsyncImage(
     model: Any?,
     contentDescription: String?,


### PR DESCRIPTION
These overloads don't have much logic and mostly delegate to the main `AsyncImage` function.