### PR TITLE
[nits] Update CHANGELOG.md with correct info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Update `androidx.compose.foundation` to 1.4.0.
 - Update `androidx.core` to 1.9.0.
 - Update `androidx.exifinterface:exifinterface` to 1.3.6.
-- Update `androidx.lifecycle` to 1.6.1.
+- Update `androidx.lifecycle` to 2.6.1.
 - Update `okio` to 3.3.0.
 
 ## [2.2.2] - October 1, 2022


### PR DESCRIPTION
It's a minor issue, but the version number of androidx.lifecycle is incorrect.
https://github.com/coil-kt/coil/blob/8694abaf0574f909caef533b73f1d818cdd96021/gradle/libs.versions.toml#L3