### PR TITLE
Call cacheDir lazily in ImageSource.

### DIFF
--- a/coil-base/src/main/java/coil/decode/ImageSource.kt
+++ b/coil-base/src/main/java/coil/decode/ImageSource.kt
@@ -297,7 +297,7 @@ internal class SourceImageSource(
 
     private fun createTempFile(): Path {
         val cacheDirectory = cacheDirectoryFactory!!.invoke()
-        require(cacheDirectory.isDirectory) { "cacheDirectory must be a directory." }
+        check(cacheDirectory.isDirectory) { "cacheDirectory must be a directory." }
 
         // Replace JVM call with https://github.com/square/okio/issues/1090 once it's available.
         return File.createTempFile("tmp", null, cacheDirectory).toOkioPath()

--- a/coil-base/src/main/java/coil/decode/ImageSource.kt
+++ b/coil-base/src/main/java/coil/decode/ImageSource.kt
@@ -65,7 +65,7 @@ fun ImageSource(
 fun ImageSource(
     source: BufferedSource,
     context: Context,
-): ImageSource = SourceImageSource(source, context.safeCacheDir, null)
+): ImageSource = SourceImageSource(source, { context.safeCacheDir }, null)
 
 /**
  * Create a new [ImageSource] backed by a [BufferedSource].
@@ -80,7 +80,7 @@ fun ImageSource(
     source: BufferedSource,
     context: Context,
     metadata: ImageSource.Metadata? = null,
-): ImageSource = SourceImageSource(source, context.safeCacheDir, metadata)
+): ImageSource = SourceImageSource(source, { context.safeCacheDir }, metadata)
 
 /**
  * Create a new [ImageSource] backed by a [BufferedSource].
@@ -92,7 +92,7 @@ fun ImageSource(
 fun ImageSource(
     source: BufferedSource,
     cacheDirectory: File,
-): ImageSource = SourceImageSource(source, cacheDirectory, null)
+): ImageSource = SourceImageSource(source, { cacheDirectory }, null)
 
 /**
  * Create a new [ImageSource] backed by a [BufferedSource].
@@ -107,7 +107,7 @@ fun ImageSource(
     source: BufferedSource,
     cacheDirectory: File,
     metadata: ImageSource.Metadata? = null,
-): ImageSource = SourceImageSource(source, cacheDirectory, metadata)
+): ImageSource = SourceImageSource(source, { cacheDirectory }, metadata)
 
 /**
  * Provides access to the image data to be decoded.
@@ -246,17 +246,14 @@ internal class FileImageSource(
 
 internal class SourceImageSource(
     source: BufferedSource,
-    private val cacheDirectory: File,
+    cacheDirectoryFactory: () -> File,
     override val metadata: Metadata?
 ) : ImageSource() {
 
     private var isClosed = false
     private var source: BufferedSource? = source
+    private var cacheDirectoryFactory: (() -> File)? = cacheDirectoryFactory
     private var file: Path? = null
-
-    init {
-        require(cacheDirectory.isDirectory) { "cacheDirectory must be a directory." }
-    }
 
     override val fileSystem get() = FileSystem.SYSTEM
 
@@ -275,13 +272,14 @@ internal class SourceImageSource(
         file?.let { return it }
 
         // Copy the source to a temp file.
-        // Replace JVM call with https://github.com/square/okio/issues/1090 once it's available.
-        val tempFile = File.createTempFile("tmp", null, cacheDirectory).toOkioPath()
+        val tempFile = createTempFile()
         fileSystem.write(tempFile) {
             writeAll(source!!)
         }
         source = null
-        return tempFile.also { file = it }
+        file = tempFile
+        cacheDirectoryFactory = null
+        return tempFile
     }
 
     @Synchronized
@@ -295,6 +293,14 @@ internal class SourceImageSource(
         isClosed = true
         source?.closeQuietly()
         file?.let(fileSystem::delete)
+    }
+
+    private fun createTempFile(): Path {
+        val cacheDirectory = cacheDirectoryFactory!!.invoke()
+        require(cacheDirectory.isDirectory) { "cacheDirectory must be a directory." }
+
+        // Replace JVM call with https://github.com/square/okio/issues/1090 once it's available.
+        return File.createTempFile("tmp", null, cacheDirectory).toOkioPath()
     }
 
     private fun assertNotClosed() {

--- a/coil-test-paparazzi/src/test/java/coil/test/PaparazziTest.kt
+++ b/coil-test-paparazzi/src/test/java/coil/test/PaparazziTest.kt
@@ -9,7 +9,10 @@ import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_6
 import app.cash.paparazzi.Paparazzi
 import coil.ImageLoader
 import coil.compose.AsyncImage
+import coil.decode.ImageSource
 import coil.request.ImageRequest
+import kotlin.test.assertTrue
+import okio.Buffer
 import org.junit.Rule
 import org.junit.Test
 
@@ -71,5 +74,12 @@ class PaparazziTest {
                 contentScale = ContentScale.None,
             )
         }
+    }
+
+    /** Regression test: https://github.com/coil-kt/coil/issues/1754 */
+    @Test
+    fun createSourceImageSource() {
+        val source = ImageSource(Buffer(), paparazzi.context)
+        assertTrue(source.source().exhausted())
     }
 }


### PR DESCRIPTION
Resolves: https://github.com/coil-kt/coil/issues/1754