### PR TITLE
Fix incorrect link to OkHttpClient.newBuilder

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -41,7 +41,7 @@ val imageLoader = ImageLoader.Builder(context)
 ```
 
 !!! Note
-    If you already have a built `OkHttpClient`, use [`newBuilder()`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-http-url/new-builder/) to build a new client that shares resources with the original.
+    If you already have a built `OkHttpClient`, use [`newBuilder()`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#customize-your-client-with-newbuilder) to build a new client that shares resources with the original.
 
 #### Headers
 


### PR DESCRIPTION
It might also be worth linking to [some more detailed docs](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#customize-your-client-with-newbuilder) instead.