### PR TITLE
Add SHIFT6m to hardware bitmap blocklist

### DIFF
--- a/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
+++ b/coil-base/src/main/java/coil/util/HardwareBitmaps.kt
@@ -206,7 +206,8 @@ private val IS_DEVICE_BLOCKED = when (SDK_INT) {
             "S80Lite", // Doogee S80Lite
             "SGINO6", // SGiNO 6
             "st18c10bnn", // Barnes and Noble BNTV650
-            "TECNO-CA8" // Tecno CAMON X Pro
+            "TECNO-CA8", // Tecno CAMON X Pro,
+            "SHIFT6m" // SHIFT 6m
         )
     }
     else -> false


### PR DESCRIPTION
I received the following stacktrace from a user with a `SHIFT6m` device running Android 8.1 (API 27). This is not in a shared element transition.
```
java.lang.IllegalStateException: Software rendering doesn't support hardware bitmaps
	at android.graphics.BaseCanvas.throwIfHwBitmapInSwMode(BaseCanvas.java:532)
	at android.graphics.BaseCanvas.throwIfCannotDraw(BaseCanvas.java:62)
	at android.graphics.BaseCanvas.drawBitmap(BaseCanvas.java:120)
	at android.graphics.Canvas.drawBitmap(Canvas.java:1434)
	at android.graphics.drawable.BitmapDrawable.draw(BitmapDrawable.java:529)
	at android.widget.ImageView.onDraw(ImageView.java:1349)
	at android.view.View.draw(View.java:19315)
	at android.view.View.draw(View.java:19179)
	at android.view.ViewGroup.drawChild(ViewGroup.java:4297)
	at androidx.recyclerview.widget.RecyclerView.drawChild(RecyclerView.java:5499)
	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4083)
	at android.view.View.draw(View.java:19323)
	at androidx.recyclerview.widget.RecyclerView.draw(RecyclerView.java:4898)
	at android.view.View.draw(View.java:19179)
	at android.view.ViewGroup.drawChild(ViewGroup.java:4297)
	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4083)
	at android.view.View.draw(View.java:19323)
	at androidx.transition.TransitionUtils.createViewBitmap(TransitionUtils.java:133)
	at androidx.transition.TransitionUtils.copyViewImage(TransitionUtils.java:64)
	at androidx.transition.Visibility.onDisappear(Visibility.java:404)
	at androidx.transition.Visibility.createAnimator(Visibility.java:257)
	at androidx.transition.Transition.createAnimators(Transition.java:744)
	at androidx.transition.TransitionSet.createAnimators(TransitionSet.java:480)
	at androidx.transition.TransitionSet.createAnimators(TransitionSet.java:480)
	at androidx.transition.Transition.playTransition(Transition.java:1808)
	at androidx.transition.TransitionManager$MultiListener.onPreDraw(TransitionManager.java:300)
	at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:977)
	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2451)
	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1443)
	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7011)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:916)
	at android.view.Choreographer.doCallbacks(Choreographer.java:728)
	at android.view.Choreographer.doFrame(Choreographer.java:660)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:902)
	at android.os.Handler.handleCallback(Handler.java:790)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6548)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:857)
```