### PR TITLE
Remove the Okio Proguard rule.

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -105,7 +105,7 @@ val drawable = imageLoader.execute(request).drawable
 
 Coil は R8 と完全に互換性があり、追加のルールを追加する必要はありません。
 
-Proguardを使用している場合は、[Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)、[OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro)、[Okio](https://github.com/square/okio/blob/master/okio/src/jvmMain/resources/META-INF/proguard/okio.pro)にルールを追加する必要があるかもしれません。
+Proguardを使用している場合は、[Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)、[OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro)にルールを追加する必要があるかもしれません。
 
 ## ライセンス
 

--- a/README-ko.md
+++ b/README-ko.md
@@ -105,7 +105,7 @@ val drawable = imageLoader.execute(request).drawable
 
 Coil은 별도의 설정 없이 R8과 완벽하게 호환 가능하며 추가 규칙이 필요하지 않습니다.
 
-Proguard를 사용할 경우, [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro), [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro), [Okio](https://github.com/square/okio/blob/master/okio/src/jvmMain/resources/META-INF/proguard/okio.pro)에 규칙을 추가할 필요가 있을 수 있습니다.
+Proguard를 사용할 경우, [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro)와 [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro)의 규칙을 추가할 필요가 있을 수 있습니다.
 
 ## 라이선스
 

--- a/README-tr.md
+++ b/README-tr.md
@@ -90,7 +90,7 @@ Coil'in [dokümantasyonunun tamamına buradan](https://coil-kt.github.io/coil/ge
 
 Coil R8 ile tamamen uyumludur ve ek kurallar eklemeyi gerektirmez.
 
-Eğer Proguard kullanıyorsanız, [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro), [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro) ve [Okio](https://github.com/square/okio/blob/master/okio/src/jvmMain/resources/META-INF/proguard/okio.pro) için kurallar eklemeniz gerekebilir.
+Eğer Proguard kullanıyorsanız, [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro) ve [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro) için kurallar eklemeniz gerekebilir.
 
 ## Lisans
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -106,7 +106,7 @@ val drawable = imageLoader.execute(request).drawable
 
 Coil 兼容 R8 混淆，您无需再添加其他的规则
 
-如果您需要混淆代码，可能需要添加对应的混淆规则：[Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro), [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro), [Okio](https://github.com/square/okio/blob/master/okio/src/jvmMain/resources/META-INF/proguard/okio.pro)。
+如果您需要混淆代码，可能需要添加对应的混淆规则：[Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro), [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro)。
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Check out Coil's [full documentation here](https://coil-kt.github.io/coil/gettin
 
 Coil is fully compatible with R8 out of the box and doesn't require adding any extra rules.
 
-If you use Proguard, you may need to add rules for [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro), [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro) and [Okio](https://github.com/square/okio/blob/master/okio/src/jvmMain/resources/META-INF/proguard/okio.pro).
+If you use Proguard, you may need to add rules for [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro) and [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro).
 
 ## License
 


### PR DESCRIPTION
Okio removed the Proguard rule link from their document because they do not need it anymore.
https://github.com/square/okio/pull/1290
https://github.com/square/okio/pull/1304

The Okio Proguard rule link does not work anymore.
So we should remove it.