### PR TITLE
Disk cache load fails after 304 Not Modified when cached headers include non-ASCII characters

### DIFF
--- a/coil-base/src/main/java/coil/network/CacheStrategy.kt
+++ b/coil-base/src/main/java/coil/network/CacheStrategy.kt
@@ -242,14 +242,14 @@ internal class CacheStrategy private constructor(
                     continue
                 }
                 if (isContentSpecificHeader(name) || !isEndToEnd(name) || networkHeaders[name] == null) {
-                    result.add(name, value)
+                    result.addUnsafeNonAscii(name, value)
                 }
             }
 
             for (index in 0 until networkHeaders.size) {
                 val fieldName = networkHeaders.name(index)
                 if (!isContentSpecificHeader(fieldName) && isEndToEnd(fieldName)) {
-                    result.add(fieldName, networkHeaders.value(index))
+                    result.addUnsafeNonAscii(fieldName, networkHeaders.value(index))
                 }
             }
 

--- a/coil-base/src/test/java/coil/fetch/HttpUriFetcherTest.kt
+++ b/coil-base/src/test/java/coil/fetch/HttpUriFetcherTest.kt
@@ -377,7 +377,7 @@ class HttpUriFetcherTest {
         assertIs<SourceResult>(result)
         assertEquals(DataSource.NETWORK, result.dataSource)
         assertEquals(expectedSize, result.source.use { it.source().readAll(blackholeSink()) })
-        diskCache[url].use(::assertNotNull)
+        diskCache.openSnapshot(url).use(::assertNotNull)
 
         // Don't set a response body as it should be read from the cache.
         val response = MockResponse()

--- a/coil-base/src/test/java/coil/fetch/HttpUriFetcherTest.kt
+++ b/coil-base/src/test/java/coil/fetch/HttpUriFetcherTest.kt
@@ -357,6 +357,53 @@ class HttpUriFetcherTest {
         assertEquals(expectedHeaders.toSet(), cacheResponse.responseHeaders.toSet())
     }
 
+    /** Regression test: https://github.com/coil-kt/coil/issues/1838 */
+    @Test
+    fun `cache control - HTTP_NOT_MODIFIED response combines headers with cached response with non-ASCII cached headers`() = runTestAsync {
+        val url = server.url(IMAGE).toString()
+        val headers = Headers.Builder()
+            .set("Cache-Control", "no-cache")
+            .set("Cache-Header", "none")
+            .set("ETag", "fake_etag")
+            .addUnsafeNonAscii(
+                "Content-Disposition",
+                "inline; filename=\"alimentación.webp\""
+            )
+            .build()
+        val expectedSize = server.enqueueImage(IMAGE, headers)
+        var result = newFetcher(url).fetch()
+
+        assertEquals(1, server.requestCount)
+        assertIs<SourceResult>(result)
+        assertEquals(DataSource.NETWORK, result.dataSource)
+        assertEquals(expectedSize, result.source.use { it.source().readAll(blackholeSink()) })
+        diskCache[url].use(::assertNotNull)
+
+        // Don't set a response body as it should be read from the cache.
+        val response = MockResponse()
+            .setResponseCode(HTTP_NOT_MODIFIED)
+            .addHeader("Response-Header", "none")
+        server.enqueue(response)
+        result = newFetcher(url).fetch()
+
+        assertIs<SourceResult>(result)
+        assertEquals(DataSource.NETWORK, result.dataSource)
+        assertEquals(expectedSize, result.source.use { it.source().readAll(blackholeSink()) })
+
+        server.takeRequest() // Discard the first request.
+
+        assertEquals(2, server.requestCount)
+        val cacheResponse = diskCache.openSnapshot(url)!!.use { snapshot ->
+            CacheResponse(diskCache.fileSystem.source(snapshot.metadata).buffer())
+        }
+        val expectedHeaders = headers.newBuilder()
+            .addAll(response.headers)
+            // Content-Length is set later by OkHttp.
+            .set("Content-Length", expectedSize.toString())
+            .build()
+        assertEquals(expectedHeaders.toSet(), cacheResponse.responseHeaders.toSet())
+    }
+
     @Test
     fun `cache control - unexpired max-age is returned from cache`() = runTestAsync {
         val url = server.url(IMAGE).toString()


### PR DESCRIPTION
Fixes #1838 