### PR TITLE
Optimize ByteBufferFetcher, Prototype

### DIFF
--- a/coil-core/api/android/coil-core.api
+++ b/coil-core/api/android/coil-core.api
@@ -255,6 +255,11 @@ public final class coil3/decode/BitmapFactoryDecoder$Factory : coil3/decode/Deco
 	public fun create (Lcoil3/fetch/SourceFetchResult;Lcoil3/request/Options;Lcoil3/ImageLoader;)Lcoil3/decode/Decoder;
 }
 
+public final class coil3/decode/ByteBufferMetadata : coil3/decode/ImageSource$Metadata {
+	public fun <init> (Ljava/nio/ByteBuffer;)V
+	public final fun getByteBuffer ()Ljava/nio/ByteBuffer;
+}
+
 public final class coil3/decode/ContentMetadata : coil3/decode/ImageSource$Metadata {
 	public fun <init> (Lcoil3/Uri;)V
 	public final fun getUri ()Lcoil3/Uri;

--- a/coil-core/api/jvm/coil-core.api
+++ b/coil-core/api/jvm/coil-core.api
@@ -212,6 +212,11 @@ public abstract interface annotation class coil3/annotation/ExperimentalCoilApi 
 public abstract interface annotation class coil3/annotation/InternalCoilApi : java/lang/annotation/Annotation {
 }
 
+public final class coil3/decode/ByteBufferMetadata : coil3/decode/ImageSource$Metadata {
+	public fun <init> (Ljava/nio/ByteBuffer;)V
+	public final fun getByteBuffer ()Ljava/nio/ByteBuffer;
+}
+
 public final class coil3/decode/DataSource : java/lang/Enum {
 	public static final field DISK Lcoil3/decode/DataSource;
 	public static final field MEMORY Lcoil3/decode/DataSource;

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoderDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoderDecoder.kt
@@ -7,6 +7,7 @@ import androidx.core.util.component1
 import androidx.core.util.component2
 import coil3.ImageLoader
 import coil3.asCoilImage
+import coil3.fetch.ByteBufferFetcher.ByteBufferMetadata
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.request.allowRgb565
@@ -125,6 +126,9 @@ private fun ImageSource.fastImageDecoderSourceOrNull(options: Options): ImageDec
     }
     if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
         return ImageDecoder.createSource(options.context.resources, metadata.resId)
+    }
+    if (metadata is ByteBufferMetadata) {
+        return ImageDecoder.createSource(metadata.byteBuffer)
     }
 
     return null

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoderDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoderDecoder.kt
@@ -7,7 +7,6 @@ import androidx.core.util.component1
 import androidx.core.util.component2
 import coil3.ImageLoader
 import coil3.asCoilImage
-import coil3.fetch.ByteBufferFetcher.ByteBufferMetadata
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.request.allowRgb565

--- a/coil-core/src/jvmCommonMain/kotlin/coil3/decode/ImageSource.kt
+++ b/coil-core/src/jvmCommonMain/kotlin/coil3/decode/ImageSource.kt
@@ -1,0 +1,12 @@
+package coil3.decode
+
+import coil3.annotation.ExperimentalCoilApi
+import java.nio.ByteBuffer
+
+/**
+ * Metadata containing the [bytebuffer] of a ByteBuffer, maybe direct
+ */
+@ExperimentalCoilApi
+class ByteBufferMetadata(
+    val byteBuffer: ByteBuffer
+) : ImageSource.Metadata()

--- a/coil-core/src/jvmCommonMain/kotlin/coil3/fetch/ByteBufferFetcher.kt
+++ b/coil-core/src/jvmCommonMain/kotlin/coil3/fetch/ByteBufferFetcher.kt
@@ -1,6 +1,7 @@
 package coil3.fetch
 
 import coil3.ImageLoader
+import coil3.decode.ByteBufferMetadata
 import coil3.decode.DataSource
 import coil3.decode.ImageSource
 import coil3.request.Options
@@ -37,8 +38,6 @@ internal class ByteBufferFetcher(
             return ByteBufferFetcher(data, options)
         }
     }
-
-    class ByteBufferMetadata(val byteBuffer: ByteBuffer) : ImageSource.Metadata()
 }
 
 internal fun ByteBuffer.asSource() = object : Source {

--- a/coil-core/src/jvmCommonMain/kotlin/coil3/fetch/ByteBufferFetcher.kt
+++ b/coil-core/src/jvmCommonMain/kotlin/coil3/fetch/ByteBufferFetcher.kt
@@ -17,7 +17,11 @@ internal class ByteBufferFetcher(
 
     override suspend fun fetch(): FetchResult {
         return SourceFetchResult(
-            source = ImageSource(data.asSource().buffer(), options.fileSystem),
+            source = ImageSource(
+                source = data.asSource().buffer(),
+                fileSystem = options.fileSystem,
+                metadata = ByteBufferMetadata(data),
+            ),
             mimeType = null,
             dataSource = DataSource.MEMORY,
         )
@@ -33,6 +37,8 @@ internal class ByteBufferFetcher(
             return ByteBufferFetcher(data, options)
         }
     }
+
+    class ByteBufferMetadata(val byteBuffer: ByteBuffer) : ImageSource.Metadata()
 }
 
 internal fun ByteBuffer.asSource() = object : Source {

--- a/coil-core/src/jvmCommonTest/kotlin/coil3/fetch/ByteBufferFetcherTest.kt
+++ b/coil-core/src/jvmCommonTest/kotlin/coil3/fetch/ByteBufferFetcherTest.kt
@@ -1,0 +1,32 @@
+package coil3.fetch
+
+import java.nio.ByteBuffer
+import kotlin.random.Random
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import okio.buffer
+import org.junit.Test
+
+class ByteBufferFetcherTest {
+    private val factory = ByteBufferFetcher.Factory()
+
+    @Test
+    fun testDataIntegrity() = runTest {
+        val buffer = ByteBuffer.wrap(DATA.encodeToByteArray())
+        val fetched = buffer.asSource().buffer().readUtf8()
+        assertEquals(fetched, DATA)
+    }
+
+    @Test
+    fun testDiscreteRead() = runTest {
+        // 64 okio Segments
+        val buffer = ByteBuffer.allocate(64 * 8192).slice()
+        Random.nextBytes(buffer.array())
+        val source = buffer.asSource().buffer()
+        val data = source.readByteArray()
+        assertContentEquals(buffer.array(), data)
+    }
+}
+
+private const val DATA = "Hello world!"

--- a/coil-gif/src/main/java/coil3/decode/AnimatedImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil3/decode/AnimatedImageDecoderDecoder.kt
@@ -126,6 +126,10 @@ class AnimatedImageDecoderDecoder @JvmOverloads constructor(
         if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
             return ImageDecoder.createSource(options.context.resources, metadata.resId)
         }
+        if (metadata is ByteBufferMetadata) {
+            val isDirect = metadata.byteBuffer.isDirect
+            if (isDirect || SDK_INT >= 30) return ImageDecoder.createSource(metadata.byteBuffer)
+        }
 
         return when {
             SDK_INT >= 31 -> ImageDecoder.createSource(source().readByteArray())


### PR DESCRIPTION
Close #1971 

We will do following things in this CL

* Make ByteBuffer lazily extracted to okio Buffer, to avoid heap thrashing (Actually we should let okio Buffer take these byte[]'s ownership if it is a HeapByteBuffer, but seems it is not possible)
* Introduce ByteBufferMetadata , to allow ImageDecoder take it directly