### PR TITLE
Fix link to OkHttp Proguard file

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Check out Coil's [full documentation here](https://coil-kt.github.io/coil/gettin
 
 Coil is fully compatible with R8 out of the box and doesn't require adding any extra rules.
 
-If you use Proguard, you may need to add rules for [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro) and [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/jvmMain/resources/META-INF/proguard/okhttp3.pro).
+If you use Proguard, you may need to add rules for [Coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-core/jvm/resources/META-INF/proguard/coroutines.pro) and [OkHttp](https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro).
 
 ## License
 


### PR DESCRIPTION
OkHttp recently updated the location of their Proguard file so this should now point to the correct location.