### PR TITLE
Don't share afd in AnimatedImageDecoderDecoder

### DIFF
--- a/coil-gif/src/main/java/coil3/decode/AnimatedImageDecoderDecoder.kt
+++ b/coil-gif/src/main/java/coil3/decode/AnimatedImageDecoderDecoder.kt
@@ -111,12 +111,7 @@ class AnimatedImageDecoderDecoder @JvmOverloads constructor(
             return ImageDecoder.createSource(options.context.assets, metadata.filePath)
         }
         if (metadata is ContentMetadata) {
-            return if (SDK_INT >= 29) {
-                // ImageDecoder will seek inner fd to startOffset
-                ImageDecoder.createSource { metadata.assetFileDescriptor }
-            } else {
-                ImageDecoder.createSource(options.context.contentResolver, metadata.uri.toAndroidUri())
-            }
+            ImageDecoder.createSource(options.context.contentResolver, metadata.uri.toAndroidUri())
         }
         if (metadata is ResourceMetadata && metadata.packageName == options.context.packageName) {
             return ImageDecoder.createSource(options.context.resources, metadata.resId)


### PR DESCRIPTION
ImageDecoder require its source still available if returned drawable is Animatable
But we will close ImageSource after decode, associated afd will be closed as well
https://developer.android.com/reference/android/graphics/ImageDecoder#createSource(java.nio.ByteBuffer)
My bad