### PR TITLE
Switch to hardware accelerated linux runner for running instrumented tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
     instrumentation-tests:
         name: Instrumentation tests
-        runs-on: macos-13
+        runs-on: ubuntu-latest
         timeout-minutes: 60
         strategy:
             fail-fast: true
@@ -82,6 +82,12 @@ jobs:
               id: avd-info
               with:
                   api-level: ${{ matrix.api-level }}
+
+            - name: Enable KVM
+              run: |
+                  echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+                  sudo udevadm control --reload-rules
+                  sudo udevadm trigger --name-match=kvm
 
             - name: Instrumentation tests
               uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
[The larger linux runners](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/) that supports hardware acceleration is now [available for public repos](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/).

This PR switches `instrumentation-tests` to `ubuntu-latest` and enable KVM.