### PR TITLE
Convert NetworkResponseBody to wrap a ByteString.

### DIFF
--- a/coil-network-core/api/android/coil-network-core.api
+++ b/coil-network-core/api/android/coil-network-core.api
@@ -38,15 +38,15 @@ public final class coil3/network/HttpException : java/lang/RuntimeException {
 
 public final class coil3/network/ImageRequestsKt {
 	public static final fun getHttpBody (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
-	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lokio/ByteString;
-	public static final fun getHttpBody (Lcoil3/request/Options;)Lokio/ByteString;
+	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkRequestBody;
+	public static final fun getHttpBody (Lcoil3/request/Options;)Lcoil3/network/NetworkRequestBody;
 	public static final fun getHttpHeaders (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpHeaders (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpHeaders (Lcoil3/request/Options;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpMethod (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpMethod (Lcoil3/request/ImageRequest;)Ljava/lang/String;
 	public static final fun getHttpMethod (Lcoil3/request/Options;)Ljava/lang/String;
-	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lokio/ByteString;)Lcoil3/request/ImageRequest$Builder;
+	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkRequestBody;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpHeaders (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkHeaders;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpMethod (Lcoil3/request/ImageRequest$Builder;Ljava/lang/String;)Lcoil3/request/ImageRequest$Builder;
 }
@@ -56,6 +56,7 @@ public abstract interface class coil3/network/NetworkClient {
 }
 
 public final class coil3/network/NetworkClientKt {
+	public static final fun NetworkRequestBody (Lokio/ByteString;)Lcoil3/network/NetworkRequestBody;
 	public static final fun NetworkResponseBody (Lokio/BufferedSource;)Lcoil3/network/NetworkResponseBody;
 }
 
@@ -96,17 +97,21 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)Lcoil3/network/NetworkRequest;
-	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Lokio/ByteString;
+	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class coil3/network/NetworkRequestBody {
+	public abstract fun writeTo (Lokio/BufferedSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil3/network/NetworkResponse {

--- a/coil-network-core/api/android/coil-network-core.api
+++ b/coil-network-core/api/android/coil-network-core.api
@@ -37,12 +37,16 @@ public final class coil3/network/HttpException : java/lang/RuntimeException {
 }
 
 public final class coil3/network/ImageRequestsKt {
+	public static final fun getHttpBody (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
+	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lokio/ByteString;
+	public static final fun getHttpBody (Lcoil3/request/Options;)Lokio/ByteString;
 	public static final fun getHttpHeaders (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpHeaders (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpHeaders (Lcoil3/request/Options;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpMethod (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpMethod (Lcoil3/request/ImageRequest;)Ljava/lang/String;
 	public static final fun getHttpMethod (Lcoil3/request/Options;)Ljava/lang/String;
+	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lokio/ByteString;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpHeaders (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkHeaders;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpMethod (Lcoil3/request/ImageRequest$Builder;Ljava/lang/String;)Lcoil3/request/ImageRequest$Builder;
 }
@@ -52,7 +56,6 @@ public abstract interface class coil3/network/NetworkClient {
 }
 
 public final class coil3/network/NetworkClientKt {
-	public static final fun NetworkRequestBody (Lokio/BufferedSource;)Lcoil3/network/NetworkRequestBody;
 	public static final fun NetworkResponseBody (Lokio/BufferedSource;)Lcoil3/network/NetworkResponseBody;
 }
 
@@ -93,21 +96,17 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
-	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
+	public final fun getBody ()Lokio/ByteString;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class coil3/network/NetworkRequestBody : java/io/Closeable {
-	public abstract fun writeTo (Lokio/BufferedSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil3/network/NetworkResponse {

--- a/coil-network-core/api/jvm/coil-network-core.api
+++ b/coil-network-core/api/jvm/coil-network-core.api
@@ -38,15 +38,15 @@ public final class coil3/network/HttpException : java/lang/RuntimeException {
 
 public final class coil3/network/ImageRequestsKt {
 	public static final fun getHttpBody (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
-	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lokio/ByteString;
-	public static final fun getHttpBody (Lcoil3/request/Options;)Lokio/ByteString;
+	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkRequestBody;
+	public static final fun getHttpBody (Lcoil3/request/Options;)Lcoil3/network/NetworkRequestBody;
 	public static final fun getHttpHeaders (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpHeaders (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpHeaders (Lcoil3/request/Options;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpMethod (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpMethod (Lcoil3/request/ImageRequest;)Ljava/lang/String;
 	public static final fun getHttpMethod (Lcoil3/request/Options;)Ljava/lang/String;
-	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lokio/ByteString;)Lcoil3/request/ImageRequest$Builder;
+	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkRequestBody;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpHeaders (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkHeaders;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpMethod (Lcoil3/request/ImageRequest$Builder;Ljava/lang/String;)Lcoil3/request/ImageRequest$Builder;
 }
@@ -56,6 +56,7 @@ public abstract interface class coil3/network/NetworkClient {
 }
 
 public final class coil3/network/NetworkClientKt {
+	public static final fun NetworkRequestBody (Lokio/ByteString;)Lcoil3/network/NetworkRequestBody;
 	public static final fun NetworkResponseBody (Lokio/BufferedSource;)Lcoil3/network/NetworkResponseBody;
 }
 
@@ -96,17 +97,21 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)Lcoil3/network/NetworkRequest;
-	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Lokio/ByteString;
+	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class coil3/network/NetworkRequestBody {
+	public abstract fun writeTo (Lokio/BufferedSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil3/network/NetworkResponse {

--- a/coil-network-core/api/jvm/coil-network-core.api
+++ b/coil-network-core/api/jvm/coil-network-core.api
@@ -37,12 +37,16 @@ public final class coil3/network/HttpException : java/lang/RuntimeException {
 }
 
 public final class coil3/network/ImageRequestsKt {
+	public static final fun getHttpBody (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
+	public static final fun getHttpBody (Lcoil3/request/ImageRequest;)Lokio/ByteString;
+	public static final fun getHttpBody (Lcoil3/request/Options;)Lokio/ByteString;
 	public static final fun getHttpHeaders (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpHeaders (Lcoil3/request/ImageRequest;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpHeaders (Lcoil3/request/Options;)Lcoil3/network/NetworkHeaders;
 	public static final fun getHttpMethod (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getHttpMethod (Lcoil3/request/ImageRequest;)Ljava/lang/String;
 	public static final fun getHttpMethod (Lcoil3/request/Options;)Ljava/lang/String;
+	public static final fun httpBody (Lcoil3/request/ImageRequest$Builder;Lokio/ByteString;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpHeaders (Lcoil3/request/ImageRequest$Builder;Lcoil3/network/NetworkHeaders;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun httpMethod (Lcoil3/request/ImageRequest$Builder;Ljava/lang/String;)Lcoil3/request/ImageRequest$Builder;
 }
@@ -52,7 +56,6 @@ public abstract interface class coil3/network/NetworkClient {
 }
 
 public final class coil3/network/NetworkClientKt {
-	public static final fun NetworkRequestBody (Lokio/BufferedSource;)Lcoil3/network/NetworkRequestBody;
 	public static final fun NetworkResponseBody (Lokio/BufferedSource;)Lcoil3/network/NetworkResponseBody;
 }
 
@@ -93,21 +96,17 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
-	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lokio/ByteString;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
+	public final fun getBody ()Lokio/ByteString;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class coil3/network/NetworkRequestBody : java/io/Closeable {
-	public abstract fun writeTo (Lokio/BufferedSink;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class coil3/network/NetworkResponse {

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
@@ -38,19 +38,39 @@ class NetworkRequest(
     val url: String,
     val method: String = HTTP_METHOD_GET,
     val headers: NetworkHeaders = NetworkHeaders.EMPTY,
-    val body: ByteString? = null,
+    val body: NetworkRequestBody? = null,
 ) {
     fun copy(
         url: String = this.url,
         method: String = this.method,
         headers: NetworkHeaders = this.headers,
-        body: ByteString? = this.body,
+        body: NetworkRequestBody? = this.body,
     ) = NetworkRequest(
         url = url,
         method = method,
         headers = headers,
         body = body,
     )
+}
+
+@ExperimentalCoilApi
+interface NetworkRequestBody {
+    suspend fun writeTo(sink: BufferedSink)
+}
+
+@ExperimentalCoilApi
+fun NetworkRequestBody(
+    bytes: ByteString,
+): NetworkRequestBody = ByteStringNetworkRequestBody(bytes)
+
+@JvmInline
+private value class ByteStringNetworkRequestBody(
+    private val bytes: ByteString,
+) : NetworkRequestBody {
+
+    override suspend fun writeTo(sink: BufferedSink) {
+        sink.write(bytes)
+    }
 }
 
 /**

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
@@ -8,6 +8,7 @@ import coil3.network.internal.HTTP_METHOD_GET
 import kotlin.jvm.JvmInline
 import okio.BufferedSink
 import okio.BufferedSource
+import okio.ByteString
 import okio.Closeable
 import okio.FileSystem
 import okio.Path
@@ -37,44 +38,19 @@ class NetworkRequest(
     val url: String,
     val method: String = HTTP_METHOD_GET,
     val headers: NetworkHeaders = NetworkHeaders.EMPTY,
-    val body: NetworkRequestBody? = null,
+    val body: ByteString? = null,
 ) {
     fun copy(
         url: String = this.url,
         method: String = this.method,
         headers: NetworkHeaders = this.headers,
-        body: NetworkRequestBody? = this.body,
+        body: ByteString? = this.body,
     ) = NetworkRequest(
         url = url,
         method = method,
         headers = headers,
         body = body,
     )
-}
-
-@ExperimentalCoilApi
-interface NetworkRequestBody : Closeable {
-    suspend fun writeTo(sink: BufferedSink)
-}
-
-@ExperimentalCoilApi
-fun NetworkRequestBody(
-    source: BufferedSource,
-): NetworkRequestBody = SourceRequestBody(source)
-
-@ExperimentalCoilApi
-@JvmInline
-private value class SourceRequestBody(
-    private val source: BufferedSource,
-) : NetworkRequestBody {
-
-    override suspend fun writeTo(sink: BufferedSink) {
-        source.readAll(sink)
-    }
-
-    override fun close() {
-        source.close()
-    }
 }
 
 /**

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
@@ -15,13 +15,13 @@ import coil3.network.internal.CONTENT_TYPE
 import coil3.network.internal.MIME_TYPE_TEXT_PLAIN
 import coil3.network.internal.abortQuietly
 import coil3.network.internal.assertNotOnMainThread
+import coil3.network.internal.readBuffer
 import coil3.request.Options
 import coil3.util.MimeTypeMap
 import coil3.util.closeQuietly
 import okio.Buffer
 import okio.FileSystem
 import okio.IOException
-import okio.use
 
 class NetworkFetcher(
     private val url: String,
@@ -68,8 +68,7 @@ class NetworkFetcher(
                 }
 
                 // If we failed to read a new snapshot then read the response body if it's not empty.
-                val responseBodyBuffer = Buffer()
-                responseBody.use { it.writeTo(responseBodyBuffer) }
+                val responseBodyBuffer = responseBody.readBuffer()
                 if (responseBodyBuffer.size > 0) {
                     return@executeNetworkRequest SourceFetchResult(
                         source = responseBodyBuffer.toImageSource(),
@@ -183,6 +182,7 @@ class NetworkFetcher(
             url = url,
             method = options.httpMethod,
             headers = headers.build(),
+            body = options.httpBody,
         )
     }
 

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
@@ -54,19 +54,19 @@ private val httpHeadersKey = Extras.Key(default = NetworkHeaders.EMPTY)
 /**
  * Set the HTTP request body for any network operations performed by this image request.
  */
-fun ImageRequest.Builder.httpBody(body: ByteString) = apply {
+fun ImageRequest.Builder.httpBody(body: NetworkRequestBody) = apply {
     extras[httpBodyKey] = body
 }
 
-val ImageRequest.httpBody: ByteString?
+val ImageRequest.httpBody: NetworkRequestBody?
     get() = getExtra(httpBodyKey)
 
-val Options.httpBody: ByteString?
+val Options.httpBody: NetworkRequestBody?
     get() = getExtra(httpBodyKey)
 
-val Extras.Key.Companion.httpBody: Extras.Key<ByteString?>
+val Extras.Key.Companion.httpBody: Extras.Key<NetworkRequestBody?>
     get() = httpBodyKey
 
-private val httpBodyKey = Extras.Key<ByteString?>(default = null)
+private val httpBodyKey = Extras.Key<NetworkRequestBody?>(default = null)
 
 // endregion

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
@@ -5,7 +5,6 @@ import coil3.getExtra
 import coil3.network.internal.HTTP_METHOD_GET
 import coil3.request.ImageRequest
 import coil3.request.Options
-import okio.ByteString
 
 // region httpMethod
 

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
@@ -13,7 +13,7 @@ import okio.ByteString
  * Set the HTTP request method for any network operations performed by this image request.
  */
 fun ImageRequest.Builder.httpMethod(method: String) = apply {
-    extras[httpMethodKey] = method
+    extras[httpMethodKey] = method.uppercase()
 }
 
 val ImageRequest.httpMethod: String

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/imageRequests.kt
@@ -5,11 +5,12 @@ import coil3.getExtra
 import coil3.network.internal.HTTP_METHOD_GET
 import coil3.request.ImageRequest
 import coil3.request.Options
+import okio.ByteString
 
 // region httpMethod
 
 /**
- * Set the HTTP method for any network operations performed by this image request.
+ * Set the HTTP request method for any network operations performed by this image request.
  */
 fun ImageRequest.Builder.httpMethod(method: String) = apply {
     extras[httpMethodKey] = method
@@ -30,7 +31,7 @@ private val httpMethodKey = Extras.Key(default = HTTP_METHOD_GET)
 // region httpHeaders
 
 /**
- * Set the HTTP headers for any network operations performed by this image request.
+ * Set the HTTP request headers for any network operations performed by this image request.
  */
 fun ImageRequest.Builder.httpHeaders(headers: NetworkHeaders) = apply {
     extras[httpHeadersKey] = headers
@@ -46,5 +47,26 @@ val Extras.Key.Companion.httpHeaders: Extras.Key<NetworkHeaders>
     get() = httpHeadersKey
 
 private val httpHeadersKey = Extras.Key(default = NetworkHeaders.EMPTY)
+
+// endregion
+// region httpBody
+
+/**
+ * Set the HTTP request body for any network operations performed by this image request.
+ */
+fun ImageRequest.Builder.httpBody(body: ByteString) = apply {
+    extras[httpBodyKey] = body
+}
+
+val ImageRequest.httpBody: ByteString?
+    get() = getExtra(httpBodyKey)
+
+val Options.httpBody: ByteString?
+    get() = getExtra(httpBodyKey)
+
+val Extras.Key.Companion.httpBody: Extras.Key<ByteString?>
+    get() = httpBodyKey
+
+private val httpBodyKey = Extras.Key<ByteString?>(default = null)
 
 // endregion

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/internal/utils.common.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/internal/utils.common.kt
@@ -2,6 +2,9 @@ package coil3.network.internal
 
 import coil3.disk.DiskCache
 import coil3.network.NetworkHeaders
+import coil3.network.NetworkResponseBody
+import okio.Buffer
+import okio.use
 
 internal fun NetworkHeaders.Builder.append(line: String) = apply {
     val index = line.indexOf(':')
@@ -13,6 +16,12 @@ internal fun DiskCache.Editor.abortQuietly() {
     try {
         abort()
     } catch (_: Exception) {}
+}
+
+internal suspend fun NetworkResponseBody.readBuffer(): Buffer = use { body ->
+    val buffer = Buffer()
+    body.writeTo(buffer)
+    return buffer
 }
 
 internal expect fun assertNotOnMainThread()

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -22,7 +22,7 @@ class NetworkFetcherTest : RobolectricTest() {
         val headers = NetworkHeaders.Builder()
             .set("key", "value")
             .build()
-        val body = ByteArray(500).toByteString()
+        val body = NetworkRequestBody(ByteArray(500).toByteString())
         val options = Options(
             context = context,
             extras = Extras.Builder()

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -1,0 +1,73 @@
+package coil3.network
+
+import coil3.Extras
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import coil3.test.utils.context
+import coil3.test.utils.runTestAsync
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import okio.Buffer
+import okio.ByteString.Companion.toByteString
+
+class NetworkFetcherTest {
+
+    @Test
+    fun networkRequestParamsArePassedThrough() = runTestAsync {
+        val expectedSize = 1_000
+        val url = "https://example.com/image.jpg"
+        val method = "POST"
+        val headers = NetworkHeaders.Builder()
+            .set("key", "value")
+            .build()
+        val body = ByteArray(500).toByteString()
+        val options = Options(
+            context = context,
+            extras = Extras.Builder()
+                .set(Extras.Key.httpMethod, method)
+                .set(Extras.Key.httpHeaders, headers)
+                .set(Extras.Key.httpBody, body)
+                .build(),
+        )
+        val networkClient = FakeNetworkClient(
+            respond = { request ->
+                NetworkResponse(
+                    request = request,
+                    body = NetworkResponseBody(Buffer().apply { write(ByteArray(expectedSize)) }),
+                )
+            },
+        )
+        val result = NetworkFetcher(
+            url = url,
+            options = options,
+            networkClient = lazyOf(networkClient),
+            diskCache = lazyOf(null),
+            cacheStrategy = lazyOf(CacheStrategy()),
+        ).fetch()
+
+        assertIs<SourceFetchResult>(result)
+
+        val expected = NetworkRequest(url, method, headers, body)
+
+        assertEquals(expected, networkClient.requests.single())
+        assertEquals(expected, networkClient.responses.single().request)
+    }
+
+    class FakeNetworkClient(
+        private val respond: suspend (NetworkRequest) -> NetworkResponse,
+    ) : NetworkClient {
+        val requests = mutableListOf<NetworkRequest>()
+        val responses = mutableListOf<NetworkResponse>()
+
+        override suspend fun <T> executeRequest(
+            request: NetworkRequest,
+            block: suspend (response: NetworkResponse) -> T,
+        ): T {
+            requests += request
+            val response = respond(request)
+            responses += response
+            return block(response)
+        }
+    }
+}

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -3,6 +3,7 @@ package coil3.network
 import coil3.Extras
 import coil3.fetch.SourceFetchResult
 import coil3.request.Options
+import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
 import coil3.test.utils.runTestAsync
 import kotlin.test.Test
@@ -11,7 +12,7 @@ import kotlin.test.assertIs
 import okio.Buffer
 import okio.ByteString.Companion.toByteString
 
-class NetworkFetcherTest {
+class NetworkFetcherTest : RobolectricTest() {
 
     @Test
     fun networkRequestParamsArePassedThrough() = runTestAsync {

--- a/coil-network-ktor/src/commonMain/kotlin/coil3/network/ktor/internal/utils.common.kt
+++ b/coil-network-ktor/src/commonMain/kotlin/coil3/network/ktor/internal/utils.common.kt
@@ -3,6 +3,7 @@ package coil3.network.ktor.internal
 import coil3.network.NetworkClient
 import coil3.network.NetworkHeaders
 import coil3.network.NetworkRequest
+import coil3.network.NetworkRequestBody
 import coil3.network.NetworkResponse
 import coil3.network.NetworkResponseBody
 import io.ktor.client.HttpClient
@@ -18,6 +19,7 @@ import io.ktor.http.takeFrom
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.cancel
 import kotlin.jvm.JvmInline
+import okio.Buffer
 import okio.BufferedSink
 import okio.FileSystem
 import okio.Path
@@ -34,13 +36,19 @@ internal value class KtorNetworkClient(
     }
 }
 
-private fun NetworkRequest.toHttpRequestBuilder(): HttpRequestBuilder {
+private suspend fun NetworkRequest.toHttpRequestBuilder(): HttpRequestBuilder {
     val request = HttpRequestBuilder()
     request.url.takeFrom(url)
     request.method = HttpMethod.parse(method)
     request.headers.takeFrom(headers)
-    body?.toByteArray()?.let(request::setBody)
+    body?.readByteArray()?.let(request::setBody)
     return request
+}
+
+private suspend fun NetworkRequestBody.readByteArray(): ByteArray {
+    val buffer = Buffer()
+    writeTo(buffer)
+    return buffer.readByteArray()
 }
 
 private suspend fun HttpResponse.toNetworkResponse(request: NetworkRequest): NetworkResponse {

--- a/coil-network-ktor/src/commonMain/kotlin/coil3/network/ktor/internal/utils.common.kt
+++ b/coil-network-ktor/src/commonMain/kotlin/coil3/network/ktor/internal/utils.common.kt
@@ -3,7 +3,6 @@ package coil3.network.ktor.internal
 import coil3.network.NetworkClient
 import coil3.network.NetworkHeaders
 import coil3.network.NetworkRequest
-import coil3.network.NetworkRequestBody
 import coil3.network.NetworkResponse
 import coil3.network.NetworkResponseBody
 import io.ktor.client.HttpClient
@@ -19,11 +18,9 @@ import io.ktor.http.takeFrom
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.cancel
 import kotlin.jvm.JvmInline
-import okio.Buffer
 import okio.BufferedSink
 import okio.FileSystem
 import okio.Path
-import okio.use
 
 @JvmInline
 internal value class KtorNetworkClient(
@@ -37,19 +34,13 @@ internal value class KtorNetworkClient(
     }
 }
 
-private suspend fun NetworkRequest.toHttpRequestBuilder(): HttpRequestBuilder = body.use { body ->
+private fun NetworkRequest.toHttpRequestBuilder(): HttpRequestBuilder {
     val request = HttpRequestBuilder()
     request.url.takeFrom(url)
     request.method = HttpMethod.parse(method)
     request.headers.takeFrom(headers)
-    body?.readByteArray()?.let(request::setBody)
+    body?.toByteArray()?.let(request::setBody)
     return request
-}
-
-private suspend fun NetworkRequestBody.readByteArray(): ByteArray {
-    val buffer = Buffer()
-    writeTo(buffer)
-    return buffer.readByteArray()
 }
 
 private suspend fun HttpResponse.toNetworkResponse(request: NetworkRequest): NetworkResponse {

--- a/coil-network-ktor/src/commonTest/kotlin/coil3/network/ktor/KtorNetworkFetcherTest.kt
+++ b/coil-network-ktor/src/commonTest/kotlin/coil3/network/ktor/KtorNetworkFetcherTest.kt
@@ -8,6 +8,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import kotlin.test.assertIs
+import okio.ByteString
 
 class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
 
@@ -17,13 +18,13 @@ class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
 
     override fun newFetcher(
         path: String,
-        responseBody: ByteArray,
+        responseBody: ByteString,
         options: Options,
     ): NetworkFetcher {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler {
-                    respond(responseBody)
+                    respond(responseBody.toByteArray())
                 }
             }
         }

--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
@@ -3,7 +3,6 @@ package coil3.network.okhttp.internal
 import coil3.network.NetworkClient
 import coil3.network.NetworkHeaders
 import coil3.network.NetworkRequest
-import coil3.network.NetworkRequestBody
 import coil3.network.NetworkResponse
 import coil3.network.NetworkResponseBody
 import okhttp3.Call
@@ -11,7 +10,6 @@ import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okio.Buffer
 
 @JvmInline
 internal value class CallFactoryNetworkClient(
@@ -25,18 +23,12 @@ internal value class CallFactoryNetworkClient(
     }
 }
 
-private suspend fun NetworkRequest.toRequest(): Request = body.use { body ->
+private fun NetworkRequest.toRequest(): Request {
     val request = Request.Builder()
     request.url(url)
-    request.method(method, body?.readByteArray()?.toRequestBody())
+    request.method(method, body?.toRequestBody())
     request.headers(headers.toHeaders())
     return request.build()
-}
-
-private suspend fun NetworkRequestBody.readByteArray(): ByteArray {
-    val buffer = Buffer()
-    writeTo(buffer)
-    return buffer.readByteArray()
 }
 
 private fun Response.toNetworkResponse(request: NetworkRequest): NetworkResponse {

--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
@@ -3,6 +3,7 @@ package coil3.network.okhttp.internal
 import coil3.network.NetworkClient
 import coil3.network.NetworkHeaders
 import coil3.network.NetworkRequest
+import coil3.network.NetworkRequestBody
 import coil3.network.NetworkResponse
 import coil3.network.NetworkResponseBody
 import okhttp3.Call
@@ -10,6 +11,8 @@ import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okio.Buffer
+import okio.ByteString
 
 @JvmInline
 internal value class CallFactoryNetworkClient(
@@ -23,12 +26,18 @@ internal value class CallFactoryNetworkClient(
     }
 }
 
-private fun NetworkRequest.toRequest(): Request {
+private suspend fun NetworkRequest.toRequest(): Request {
     val request = Request.Builder()
     request.url(url)
-    request.method(method, body?.toRequestBody())
+    request.method(method, body?.readByteString()?.toRequestBody())
     request.headers(headers.toHeaders())
     return request.build()
+}
+
+private suspend fun NetworkRequestBody.readByteString(): ByteString {
+    val buffer = Buffer()
+    writeTo(buffer)
+    return buffer.readByteString()
 }
 
 private fun Response.toNetworkResponse(request: NetworkRequest): NetworkResponse {

--- a/coil-network-okhttp/src/commonTest/kotlin/coil3/network/okhttp/OkHttpNetworkFetcherTest.kt
+++ b/coil-network-okhttp/src/commonTest/kotlin/coil3/network/okhttp/OkHttpNetworkFetcherTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.assertIs
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
+import okio.ByteString
 
 class OkHttpNetworkFetcherTest : AbstractNetworkFetcherTest() {
 
@@ -33,7 +34,7 @@ class OkHttpNetworkFetcherTest : AbstractNetworkFetcherTest() {
 
     override fun newFetcher(
         path: String,
-        responseBody: ByteArray,
+        responseBody: ByteString,
         options: Options,
     ): NetworkFetcher {
         server.enqueue(MockResponse().setBody(Buffer().apply { write(responseBody) }))

--- a/internal/test-utils/src/commonMain/kotlin/coil3/test/utils/AbstractNetworkFetcherTest.kt
+++ b/internal/test-utils/src/commonMain/kotlin/coil3/test/utils/AbstractNetworkFetcherTest.kt
@@ -15,6 +15,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
 import okio.blackholeSink
 import okio.fakefilesystem.FakeFileSystem
 import okio.use
@@ -49,7 +51,7 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
     @Test
     fun basicNetworkFetch() = runTestAsync {
         val expectedSize = 1_000
-        val result = newFetcher(responseBody = ByteArray(expectedSize)).fetch()
+        val result = newFetcher(responseBody = ByteArray(expectedSize).toByteString()).fetch()
 
         assertIs<SourceFetchResult>(result)
         val actualSize = result.source.use { it.source().readAll(blackholeSink()) }
@@ -59,7 +61,7 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
     @Test
     fun mimeTypeIsParsedCorrectlyFromContentType() = runTestAsync {
         val expectedSize = 1_000
-        val fetcher = newFetcher(responseBody = ByteArray(expectedSize))
+        val fetcher = newFetcher(responseBody = ByteArray(expectedSize).toByteString())
 
         val url1 = "https://example.com/image.jpg"
         val type1 = "image/svg+xml"
@@ -86,7 +88,7 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
     fun noDiskCache_fetcherReturnsASourceResult() = runTestAsync {
         val expectedSize = 1_000
         val path = "image.jpg"
-        val result = newFetcher(path, ByteArray(expectedSize)).fetch()
+        val result = newFetcher(path, ByteArray(expectedSize).toByteString()).fetch()
 
         assertIs<SourceFetchResult>(result)
         val actualSize = result.source.use { it.source().readAll(blackholeSink()) }
@@ -97,7 +99,7 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
     fun noCachedFile_fetcherReturnsTheFile() = runTestAsync {
         val expectedSize = 1_000
         val path = "image.jpg"
-        val result = newFetcher(path, ByteArray(expectedSize)).fetch()
+        val result = newFetcher(path, ByteArray(expectedSize).toByteString()).fetch()
 
         assertIs<SourceFetchResult>(result)
         val file = assertNotNull(result.source.fileOrNull())
@@ -119,14 +121,14 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
         val path = "image.jpg"
 
         // Run the fetcher once to create the disk cache file.
-        var result = newFetcher(path, ByteArray(expectedSize)).fetch()
+        var result = newFetcher(path, ByteArray(expectedSize).toByteString()).fetch()
         assertIs<SourceFetchResult>(result)
         assertNotNull(result.source.fileOrNull())
         var actualSize = result.source.use { it.source().readAll(blackholeSink()) }
         assertEquals(expectedSize.toLong(), actualSize)
 
         // Run the fetcher a second time.
-        result = newFetcher(path, ByteArray(expectedSize)).fetch()
+        result = newFetcher(path, ByteArray(expectedSize).toByteString()).fetch()
         assertIs<SourceFetchResult>(result)
         val file = assertNotNull(result.source.fileOrNull())
         actualSize = result.source.use { it.source().readAll(blackholeSink()) }
@@ -143,7 +145,7 @@ abstract class AbstractNetworkFetcherTest : AndroidJUnit4Test() {
 
     abstract fun newFetcher(
         path: String = "image.jpg",
-        responseBody: ByteArray = byteArrayOf(),
+        responseBody: ByteString = ByteString.EMPTY,
         options: Options = Options(context),
     ): NetworkFetcher
 }


### PR DESCRIPTION
Converting this back into a type that doesn't require closing as we can't guarantee it won't be leaked (for example if the request is cancelled before reaching `fetcher.fetch`). In some instances we may also need to replay the network request.

Also exposes an `ImageRequest.httpBody` method so this can be set.