### PR TITLE
Lazily register component callbacks and the network observer on Android.

### DIFF
--- a/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
+++ b/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
@@ -17,11 +17,12 @@ class SystemCallbacksTest {
 
     @Test
     fun imageLoaderIsFreedWithoutShutdown() {
-        val systemCallbacks = SystemCallbacks() as AndroidSystemCallbacks
-        systemCallbacks.register(ImageLoader(context) as RealImageLoader)
+        val imageLoader = ImageLoader(context) as RealImageLoader
+        val systemCallbacks = SystemCallbacks(imageLoader) as AndroidSystemCallbacks
+        systemCallbacks.registerMemoryPressureCallbacks()
 
         val bitmaps = mutableListOf<Bitmap>()
-        while (systemCallbacks.imageLoader?.get() != null) {
+        while (systemCallbacks.imageLoader.get() != null) {
             // Request that garbage collection occur.
             Runtime.getRuntime().gc()
 
@@ -33,7 +34,7 @@ class SystemCallbacksTest {
         // Ensure that the next system callback is called.
         systemCallbacks.onTrimMemory(TRIM_MEMORY_BACKGROUND)
 
-        assertTrue(systemCallbacks.isShutdown)
+        assertTrue(systemCallbacks.shutdown)
     }
 
     @Test
@@ -43,9 +44,9 @@ class SystemCallbacksTest {
             .build()
         val imageLoader = ImageLoader.Builder(context)
             .memoryCache(memoryCache)
-            .build()
-        val systemCallbacks = SystemCallbacks() as AndroidSystemCallbacks
-        systemCallbacks.register(imageLoader as RealImageLoader)
+            .build() as RealImageLoader
+        val systemCallbacks = SystemCallbacks(imageLoader) as AndroidSystemCallbacks
+        systemCallbacks.registerMemoryPressureCallbacks()
 
         memoryCache[MemoryCache.Key("1")] = MemoryCache.Value(
             image = createBitmap(1000, 1000, Bitmap.Config.ARGB_8888)

--- a/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
+++ b/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
@@ -17,8 +17,9 @@ class SystemCallbacksTest {
 
     @Test
     fun imageLoaderIsFreedWithoutShutdown() {
-        val imageLoader = ImageLoader(context) as RealImageLoader
-        val systemCallbacks = SystemCallbacks(imageLoader) as AndroidSystemCallbacks
+        val systemCallbacks = SystemCallbacks(
+            imageLoader = ImageLoader(context) as RealImageLoader,
+        ) as AndroidSystemCallbacks
         systemCallbacks.registerMemoryPressureCallbacks()
         systemCallbacks.isOnline
 

--- a/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
+++ b/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
@@ -17,11 +17,15 @@ class SystemCallbacksTest {
 
     @Test
     fun imageLoaderIsFreedWithoutShutdown() {
-        val systemCallbacks = SystemCallbacks(
-            imageLoader = ImageLoader(context) as RealImageLoader,
-        ) as AndroidSystemCallbacks
+        var imageLoader: RealImageLoader?
+        imageLoader = ImageLoader(context) as RealImageLoader
+        val systemCallbacks = SystemCallbacks(imageLoader) as AndroidSystemCallbacks
         systemCallbacks.registerMemoryPressureCallbacks()
         systemCallbacks.isOnline
+
+        // Clear the local reference.
+        @Suppress("UNUSED_VALUE")
+        imageLoader = null
 
         val bitmaps = mutableListOf<Bitmap>()
         while (systemCallbacks.imageLoader.get() != null) {

--- a/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
+++ b/coil-core/src/androidInstrumentedTest/kotlin/coil3/util/SystemCallbacksTest.kt
@@ -20,6 +20,7 @@ class SystemCallbacksTest {
         val imageLoader = ImageLoader(context) as RealImageLoader
         val systemCallbacks = SystemCallbacks(imageLoader) as AndroidSystemCallbacks
         systemCallbacks.registerMemoryPressureCallbacks()
+        systemCallbacks.isOnline
 
         val bitmaps = mutableListOf<Bitmap>()
         while (systemCallbacks.imageLoader.get() != null) {

--- a/coil-core/src/androidUnitTest/kotlin/coil3/intercept/EngineInterceptorTest.kt
+++ b/coil-core/src/androidUnitTest/kotlin/coil3/intercept/EngineInterceptorTest.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import coil3.EventListener
 import coil3.ImageLoader
+import coil3.RealImageLoader
 import coil3.asCoilImage
 import coil3.decode.DataSource
 import coil3.intercept.EngineInterceptor.ExecuteResult
@@ -79,10 +80,12 @@ class EngineInterceptorTest : RobolectricTest() {
             .components {
                 add(Keyer { _: Any, _ -> key })
             }
-            .build()
+            .build() as RealImageLoader
+        val systemCallbacks = SystemCallbacks(imageLoader)
         return EngineInterceptor(
             imageLoader = imageLoader,
-            requestService = RequestService(imageLoader, SystemCallbacks(), null),
+            systemCallbacks = systemCallbacks,
+            requestService = RequestService(imageLoader, systemCallbacks, null),
             logger = null,
         )
     }

--- a/coil-core/src/androidUnitTest/kotlin/coil3/memory/MemoryCacheServiceTest.kt
+++ b/coil-core/src/androidUnitTest/kotlin/coil3/memory/MemoryCacheServiceTest.kt
@@ -3,6 +3,7 @@ package coil3.memory
 import android.graphics.Bitmap
 import coil3.EventListener
 import coil3.ImageLoader
+import coil3.RealImageLoader
 import coil3.asCoilImage
 import coil3.key.Keyer
 import coil3.memory.MemoryCacheService.Companion.EXTRA_IS_SAMPLED
@@ -517,10 +518,11 @@ class MemoryCacheServiceTest : RobolectricTest() {
             .components {
                 add(Keyer { _: Any, _ -> key })
             }
-            .build()
+            .build() as RealImageLoader
+        val systemCallbacks = SystemCallbacks(imageLoader)
         return MemoryCacheService(
             imageLoader = imageLoader,
-            requestService = RequestService(imageLoader, SystemCallbacks(), null),
+            requestService = RequestService(imageLoader, systemCallbacks, null),
             logger = null
         )
     }

--- a/coil-core/src/androidUnitTest/kotlin/coil3/request/RequestServiceTest.kt
+++ b/coil-core/src/androidUnitTest/kotlin/coil3/request/RequestServiceTest.kt
@@ -28,7 +28,7 @@ class RequestServiceTest : RobolectricTest() {
     @Before
     fun before() {
         val imageLoader = ImageLoader(context) as RealImageLoader
-        service = RequestService(imageLoader, SystemCallbacks(), null)
+        service = RequestService(imageLoader, SystemCallbacks(imageLoader), null)
     }
 
     @Test

--- a/coil-core/src/commonMain/kotlin/coil3/util/SystemCallbacks.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/util/SystemCallbacks.kt
@@ -2,12 +2,13 @@ package coil3.util
 
 import coil3.RealImageLoader
 
-internal expect fun SystemCallbacks(): SystemCallbacks
+internal expect fun SystemCallbacks(
+    imageLoader: RealImageLoader,
+): SystemCallbacks
 
 internal interface SystemCallbacks {
     val isOnline: Boolean
-    val isShutdown: Boolean
 
-    fun register(imageLoader: RealImageLoader)
+    fun registerMemoryPressureCallbacks()
     fun shutdown()
 }

--- a/coil-core/src/nonAndroidMain/kotlin/coil3/util/SystemCallbacks.kt
+++ b/coil-core/src/nonAndroidMain/kotlin/coil3/util/SystemCallbacks.kt
@@ -1,7 +1,6 @@
 package coil3.util
 
 import coil3.RealImageLoader
-import kotlinx.atomicfu.atomic
 
 internal actual fun SystemCallbacks(
     imageLoader: RealImageLoader,

--- a/coil-core/src/nonAndroidMain/kotlin/coil3/util/SystemCallbacks.kt
+++ b/coil-core/src/nonAndroidMain/kotlin/coil3/util/SystemCallbacks.kt
@@ -3,16 +3,14 @@ package coil3.util
 import coil3.RealImageLoader
 import kotlinx.atomicfu.atomic
 
-internal actual fun SystemCallbacks(): SystemCallbacks = NoopSystemCallbacks()
+internal actual fun SystemCallbacks(
+    imageLoader: RealImageLoader,
+): SystemCallbacks = NoopSystemCallbacks()
 
-// TODO: Listen for memory-pressure events to trim the memory cache on non-Android platforms.
 private class NoopSystemCallbacks : SystemCallbacks {
     override val isOnline get() = true
-    override var isShutdown by atomic(false)
 
-    override fun register(imageLoader: RealImageLoader) {}
-
-    override fun shutdown() {
-        isShutdown = true
-    }
+    // TODO: Listen for memory-pressure events to trim the memory cache on non-Android platforms.
+    override fun registerMemoryPressureCallbacks() {}
+    override fun shutdown() {}
 }


### PR DESCRIPTION
Registers these checks immediately before our first write to the memory cache and before our first fetch. Both registrations occur on a background thread and guard against leaking the `ImageLoader` reference.

Resolves: https://github.com/coil-kt/coil/issues/2097