### PR TITLE
Support extracting video image by frame index

### DIFF
--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -24,7 +24,7 @@ imageView.load("/path/to/video.mp4") {
 }
 ```
 
-For specifying the exact frame number, use `videoFrameIndex`:
+For specifying the exact frame number, use `videoFrameIndex` (requires API level 28):
 
 ```kotlin
 imageView.load("/path/to/video.mp4") {

--- a/coil-video/README.md
+++ b/coil-video/README.md
@@ -16,15 +16,31 @@ val imageLoader = ImageLoader.Builder(context)
     .build()
 ```
 
-To specify the time code of the frame to extract from a video, use `videoFrameMillis` or `videoFrameMicros`:
+To specify the time of the frame to extract from a video, use `videoFrameMillis` or `videoFrameMicros`:
 
 ```kotlin
 imageView.load("/path/to/video.mp4") {
-    videoFrameMillis(1000)
+    videoFrameMillis(1000)  // extracts the frame at 1 second of the video
 }
 ```
 
-If a frame time isn't specified, the first frame of the video is decoded.
+For specifying the exact frame number, use `videoFrameIndex`:
+
+```kotlin
+imageView.load("/path/to/video.mp4") {
+    videoFrameIndex(1234)  // extracts the 1234th frame of the video
+}
+```
+
+To select a video frame based on a percentage of the video's total duration, use `videoFramePercent`:
+
+```kotlin
+imageView.load("/path/to/video.mp4") {
+    videoFramePercent(0.5)  // extracts the frame in the middle of the video's duration
+}
+```
+
+If no frame position is specified, the first frame of the video will be decoded.
 
 The `ImageLoader` will automatically detect any videos and extract their frames if the request's filename/URI ends with a [valid video extension](https://developer.android.com/guide/topics/media/media-formats#video-formats). If it does not, you can set the `Decoder` explicitly for the request:
 

--- a/coil-video/api/coil-video.api
+++ b/coil-video/api/coil-video.api
@@ -1,4 +1,7 @@
 public final class coil3/video/ImageRequestsKt {
+	public static final fun getVideoFrameIndex (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
+	public static final fun getVideoFrameIndex (Lcoil3/request/ImageRequest;)I
+	public static final fun getVideoFrameIndex (Lcoil3/request/Options;)I
 	public static final fun getVideoFrameMicros (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getVideoFrameMicros (Lcoil3/request/ImageRequest;)J
 	public static final fun getVideoFrameMicros (Lcoil3/request/Options;)J
@@ -8,6 +11,7 @@ public final class coil3/video/ImageRequestsKt {
 	public static final fun getVideoFramePercent (Lcoil3/Extras$Key$Companion;)Lcoil3/Extras$Key;
 	public static final fun getVideoFramePercent (Lcoil3/request/ImageRequest;)D
 	public static final fun getVideoFramePercent (Lcoil3/request/Options;)D
+	public static final fun videoFrameIndex (Lcoil3/request/ImageRequest$Builder;I)Lcoil3/request/ImageRequest$Builder;
 	public static final fun videoFrameMicros (Lcoil3/request/ImageRequest$Builder;J)Lcoil3/request/ImageRequest$Builder;
 	public static final fun videoFrameMillis (Lcoil3/request/ImageRequest$Builder;J)Lcoil3/request/ImageRequest$Builder;
 	public static final fun videoFrameOption (Lcoil3/request/ImageRequest$Builder;I)Lcoil3/request/ImageRequest$Builder;

--- a/coil-video/src/androidTest/java/coil3/video/VideoFrameDecoderTest.kt
+++ b/coil-video/src/androidTest/java/coil3/video/VideoFrameDecoderTest.kt
@@ -99,8 +99,8 @@ class VideoFrameDecoderTest {
 
     @Test
     fun specificFrameIndex() = runTest(timeout = 1.minutes) {
-        // MediaMetadataRetriever does not work on the emulator pre-API 23.
-        assumeTrue(SDK_INT >= 23)
+        // MediaMetadataRetriever#getFrameAtIndex does not work on the emulator pre-API 28.
+        assumeTrue(SDK_INT >= 28)
 
         val result = VideoFrameDecoder(
             source = ImageSource(

--- a/coil-video/src/androidTest/java/coil3/video/VideoFrameDecoderTest.kt
+++ b/coil-video/src/androidTest/java/coil3/video/VideoFrameDecoderTest.kt
@@ -98,6 +98,32 @@ class VideoFrameDecoderTest {
     }
 
     @Test
+    fun specificFrameIndex() = runTest(timeout = 1.minutes) {
+        // MediaMetadataRetriever does not work on the emulator pre-API 23.
+        assumeTrue(SDK_INT >= 23)
+
+        val result = VideoFrameDecoder(
+            source = ImageSource(
+                source = context.assets.open("video.mp4").source().buffer(),
+                fileSystem = FileSystem.SYSTEM,
+            ),
+            options = Options(
+                context = context,
+                extras = Extras.Builder()
+                    .set(Extras.Key.videoFrameIndex, 807)
+                    .build(),
+            )
+        ).decode()
+
+        val actual = result.image.bitmap
+        assertNotNull(actual)
+        assertFalse(result.isSampled)
+
+        val expected = context.decodeBitmapAsset("video_frame_2.jpg")
+        actual.assertIsSimilarTo(expected)
+    }
+
+    @Test
     fun rotation() = runTest(timeout = 1.minutes) {
         // MediaMetadataRetriever does not work on the emulator pre-API 23.
         assumeTrue(SDK_INT >= 23)

--- a/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
@@ -32,9 +32,9 @@ import coil3.toAndroidUri
 import coil3.util.heightPx
 import coil3.util.widthPx
 import coil3.video.MediaDataSourceFetcher.MediaSourceMetadata
+import coil3.video.internal.getFrameAtIndex
 import coil3.video.internal.getFrameAtTime
 import coil3.video.internal.getScaledFrameAtTime
-import coil3.video.internal.getFrameAtIndex
 import coil3.video.internal.use
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong

--- a/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
@@ -90,9 +90,7 @@ class VideoFrameDecoder(
 
         val frameMicros = computeFrameMicros(retriever)
         val (dstWidth, dstHeight) = dstSize
-        val rawBitmap: Bitmap?
-
-        rawBitmap = if (SDK_INT >= 28 && options.videoFrameIndex >= 0) {
+        val rawBitmap: Bitmap? = if (SDK_INT >= 28 && options.videoFrameIndex >= 0) {
             retriever.getFrameAtIndex(
                 frameIndex = options.videoFrameIndex,
                 config = options.bitmapConfig,

--- a/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
+++ b/coil-video/src/main/java/coil3/video/VideoFrameDecoder.kt
@@ -34,6 +34,7 @@ import coil3.util.widthPx
 import coil3.video.MediaDataSourceFetcher.MediaSourceMetadata
 import coil3.video.internal.getFrameAtTime
 import coil3.video.internal.getScaledFrameAtTime
+import coil3.video.internal.getFrameAtIndex
 import coil3.video.internal.use
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
@@ -89,7 +90,17 @@ class VideoFrameDecoder(
 
         val frameMicros = computeFrameMicros(retriever)
         val (dstWidth, dstHeight) = dstSize
-        val rawBitmap: Bitmap? = if (SDK_INT >= 27 && dstWidth is Pixels && dstHeight is Pixels) {
+        val rawBitmap: Bitmap?
+
+        rawBitmap = if (SDK_INT >= 28 && options.videoFrameIndex >= 0) {
+            retriever.getFrameAtIndex(
+                frameIndex = options.videoFrameIndex,
+                config = options.bitmapConfig,
+            )?.also {
+                srcWidth = it.width
+                srcHeight = it.height
+            }
+        } else if (SDK_INT >= 27 && dstWidth is Pixels && dstHeight is Pixels) {
             retriever.getScaledFrameAtTime(
                 timeUs = frameMicros,
                 option = options.videoFrameOption,

--- a/coil-video/src/main/java/coil3/video/imageRequests.kt
+++ b/coil-video/src/main/java/coil3/video/imageRequests.kt
@@ -10,6 +10,32 @@ import coil3.getExtra
 import coil3.request.ImageRequest
 import coil3.request.Options
 
+// region videoFrameIndex
+
+/**
+ * Set the the frame index to extract from a video.
+ *
+ * When both [videoFrameIndex] and other videoFrame-prefixed properties are set,
+ * [videoFrameIndex] will take precedence.
+ */
+fun ImageRequest.Builder.videoFrameIndex(frameIndex: Int) = apply {
+    require(frameIndex >= 0) { "frameIndex must be >= 0." }
+    memoryCacheKeyExtra("coil#videoFrameIndex", frameIndex.toString())
+    extras[videoFrameIndexKey] = frameIndex
+}
+
+val ImageRequest.videoFrameIndex: Int
+    get() = getExtra(videoFrameIndexKey)
+
+val Options.videoFrameIndex: Int
+    get() = getExtra(videoFrameIndexKey)
+
+val Extras.Key.Companion.videoFrameIndex: Extras.Key<Int>
+    get() = videoFrameIndexKey
+
+private val videoFrameIndexKey = Extras.Key(default = -1)
+
+// endregion
 // region videoFrameMicros
 
 /**

--- a/coil-video/src/main/java/coil3/video/imageRequests.kt
+++ b/coil-video/src/main/java/coil3/video/imageRequests.kt
@@ -5,6 +5,7 @@ import android.media.MediaMetadataRetriever.OPTION_CLOSEST
 import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
 import android.media.MediaMetadataRetriever.OPTION_NEXT_SYNC
 import android.media.MediaMetadataRetriever.OPTION_PREVIOUS_SYNC
+import androidx.annotation.RequiresApi
 import coil3.Extras
 import coil3.getExtra
 import coil3.request.ImageRequest
@@ -18,6 +19,7 @@ import coil3.request.Options
  * When both [videoFrameIndex] and other videoFrame-prefixed properties are set,
  * [videoFrameIndex] will take precedence.
  */
+@RequiresApi(28)
 fun ImageRequest.Builder.videoFrameIndex(frameIndex: Int) = apply {
     require(frameIndex >= 0) { "frameIndex must be >= 0." }
     memoryCacheKeyExtra("coil#videoFrameIndex", frameIndex.toString())
@@ -25,12 +27,15 @@ fun ImageRequest.Builder.videoFrameIndex(frameIndex: Int) = apply {
 }
 
 val ImageRequest.videoFrameIndex: Int
+    @RequiresApi(28)
     get() = getExtra(videoFrameIndexKey)
 
 val Options.videoFrameIndex: Int
+    @RequiresApi(28)
     get() = getExtra(videoFrameIndexKey)
 
 val Extras.Key.Companion.videoFrameIndex: Extras.Key<Int>
+    @RequiresApi(28)
     get() = videoFrameIndexKey
 
 private val videoFrameIndexKey = Extras.Key(default = -1)

--- a/coil-video/src/main/java/coil3/video/internal/utils.kt
+++ b/coil-video/src/main/java/coil3/video/internal/utils.kt
@@ -50,4 +50,3 @@ internal fun MediaMetadataRetriever.getFrameAtIndex(
     frameIndex: Int,
     config: Bitmap.Config,
 ): Bitmap? = getFrameAtIndex(frameIndex, BitmapParams().apply { preferredConfig = config })
-

--- a/coil-video/src/main/java/coil3/video/internal/utils.kt
+++ b/coil-video/src/main/java/coil3/video/internal/utils.kt
@@ -44,3 +44,10 @@ internal fun MediaMetadataRetriever.getScaledFrameAtTime(
 } else {
     getScaledFrameAtTime(timeUs, option, dstWidth, dstHeight)
 }
+
+@RequiresApi(28)
+internal fun MediaMetadataRetriever.getFrameAtIndex(
+    frameIndex: Int,
+    config: Bitmap.Config,
+): Bitmap? = getFrameAtIndex(frameIndex, BitmapParams().apply { preferredConfig = config })
+


### PR DESCRIPTION
This fixes #2180.

This changeset adds the `videoFrameIndex` option to the `VideoFrameDecoder`, which allows extracting an image from videos by its index (frame number).
