### PR TITLE
fix VP8X feature flags byte offset

### DIFF
--- a/coil-gif/src/main/java/coil3/gif/decodeUtils.kt
+++ b/coil-gif/src/main/java/coil3/gif/decodeUtils.kt
@@ -42,8 +42,8 @@ fun DecodeUtils.isWebP(source: BufferedSource): Boolean {
 fun DecodeUtils.isAnimatedWebP(source: BufferedSource): Boolean {
     return isWebP(source) &&
         source.rangeEquals(12, WEBP_HEADER_VPX8) &&
-        source.request(17) &&
-        (source.buffer[16] and 0b00000010) > 0
+        source.request(21) &&
+        (source.buffer[20] and 0b00000010) > 0
 }
 
 /**


### PR DESCRIPTION
VP8X chunk byte format
12..15&nbsp;&nbsp;&nbsp;&nbsp;"VP8X": 4-bytes tags, describing the extended-VP8 chunk
16..19&nbsp;&nbsp;&nbsp;&nbsp;Size of the VP8X chunk starting at offset 20
20....&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;VP8X bytes

References:
https://developers.google.com/speed/webp/docs/riff_container#extended_file_format
