### PR TITLE
Improve RealImageLoader.execute to properly call async request

### DIFF
--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -123,26 +123,25 @@ internal class RealImageLoader(
         }
     }
 
-    override suspend fun execute(request: ImageRequest) = coroutineScope {
-        // We don't use the async call that returns the job for Compose to micro-optimize the performance.
-        // The job is only needed in case of the Views implementation.
-
+    override suspend fun execute(request: ImageRequest) =
         if (request.target is ViewTarget<*>) {
-            // Start executing the request on the main thread.
-            val job = async(Dispatchers.Main.immediate) {
-                executeMain(request, REQUEST_TYPE_EXECUTE)
-            }
-            // Update the current request attached to the view and await the result.
-            request.target.view.requestManager.getDisposable(job)
+            // We don't use the async call that returns the job for Compose to micro-optimize the performance.
+            // The job is only needed in case of the Views implementation.
+            coroutineScope {            // Start executing the request on the main thread.
+                val job = async(Dispatchers.Main.immediate) {
+                    executeMain(request, REQUEST_TYPE_EXECUTE)
+                }
+                // Update the current request attached to the view and await the result.
+                request.target.view.requestManager.getDisposable(job)
 
-            job.await()
+                job.await()
+            }
         } else {
             // Start executing the request on the main thread.
             withContext(Dispatchers.Main.immediate) {
                 executeMain(request, REQUEST_TYPE_EXECUTE)
             }
         }
-    }
 
     @MainThread
     private suspend fun executeMain(initialRequest: ImageRequest, type: Int): ImageResult {

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -124,23 +124,17 @@ internal class RealImageLoader(
     }
 
     override suspend fun execute(request: ImageRequest) = coroutineScope {
-        // Added this dispatcher to allow running async in parallel.
-        // This code is run from  AsyncImagePainter.onRemembered, which uses Dispatchers.Main.immediate
-        // That's why the async request will be sequential and not in parallel.
-        // TODO: this dispatcher probably needs to be passed in, or maybe called somewhere else!
-        withContext(Dispatchers.Default) {
-            // Start executing the request on the main thread.
-            val job = async(Dispatchers.Main.immediate) {
-                executeMain(request, REQUEST_TYPE_EXECUTE)
-            }
-
-            // Update the current request attached to the view and await the result.
-            if (request.target is ViewTarget<*>) {
-                request.target.view.requestManager.getDisposable(job)
-            }
-
-            job.await()
+        // Start executing the request on the main thread.
+        val job = async(Dispatchers.Main.immediate) {
+            executeMain(request, REQUEST_TYPE_EXECUTE)
         }
+
+        // Update the current request attached to the view and await the result.
+        if (request.target is ViewTarget<*>) {
+            request.target.view.requestManager.getDisposable(job)
+        }
+
+        job.await()
     }
 
     @MainThread

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -172,7 +172,7 @@ internal class RealImageLoader(
 
             // Resolve the size.
             eventListener.resolveSizeStart(request)
-            val size = request.sizeResolver.size()
+            val size = request.sizeResolver.size() // TODO this shows up as taking the most time
             eventListener.resolveSizeEnd(request, size)
 
             // Execute the interceptor chain.

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -179,7 +179,7 @@ internal class RealImageLoader(
 
             // Resolve the size.
             eventListener.resolveSizeStart(request)
-            val size = request.sizeResolver.size() // TODO this shows up as taking the most time
+            val size = request.sizeResolver.size()
             eventListener.resolveSizeEnd(request, size)
 
             // Execute the interceptor chain.

--- a/coil-base/src/main/java/coil/RealImageLoader.kt
+++ b/coil-base/src/main/java/coil/RealImageLoader.kt
@@ -124,17 +124,24 @@ internal class RealImageLoader(
     }
 
     override suspend fun execute(request: ImageRequest) = coroutineScope {
-        // Start executing the request on the main thread.
-        val job = async(Dispatchers.Main.immediate) {
-            executeMain(request, REQUEST_TYPE_EXECUTE)
-        }
+        // We don't use the async call that returns the job for Compose to micro-optimize the performance.
+        // The job is only needed in case of the Views implementation.
 
-        // Update the current request attached to the view and await the result.
         if (request.target is ViewTarget<*>) {
+            // Start executing the request on the main thread.
+            val job = async(Dispatchers.Main.immediate) {
+                executeMain(request, REQUEST_TYPE_EXECUTE)
+            }
+            // Update the current request attached to the view and await the result.
             request.target.view.requestManager.getDisposable(job)
-        }
 
-        job.await()
+            job.await()
+        } else {
+            // Start executing the request on the main thread.
+            withContext(Dispatchers.Main.immediate) {
+                executeMain(request, REQUEST_TYPE_EXECUTE)
+            }
+        }
     }
 
     @MainThread

--- a/coil-benchmark/build.gradle.kts
+++ b/coil-benchmark/build.gradle.kts
@@ -7,10 +7,16 @@ plugins {
 }
 
 setupTestModule(name = "coil.benchmark", config = true) {
-    val targetProject = System.getProperty("project", "view")
+    // TODO: temporary, should pass instead
+    val targetProject = "compose" //System.getProperty("project", "view")
     defaultConfig {
         minSdk = 23
         buildConfigField("String", "PROJECT", "\"$targetProject\"")
+        // TODO temporary, should pass with run configuration
+        testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
+        // TODO just temporary
+        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "LOW-BATTERY"
+        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"]= "MethodTracing"
     }
     buildTypes {
         create("benchmark") {
@@ -39,6 +45,8 @@ dependencies {
     implementation(libs.androidx.test.espresso)
     implementation(libs.androidx.test.junit)
     implementation(libs.androidx.test.uiautomator)
+    implementation("androidx.tracing:tracing-perfetto:1.0.0")
+    implementation("androidx.tracing:tracing-perfetto-binary:1.0.0")
 }
 
 androidComponents {

--- a/coil-benchmark/build.gradle.kts
+++ b/coil-benchmark/build.gradle.kts
@@ -7,14 +7,16 @@ plugins {
 }
 
 setupTestModule(name = "coil.benchmark", config = true) {
-    // TODO: temporary, should pass instead
-    val targetProject = "compose" // System.getProperty("project", "view")
+    val targetProject = System.getProperty("project", "view")
     defaultConfig {
         minSdk = 23
         buildConfigField("String", "PROJECT", "\"$targetProject\"")
-        // TODO temporary, should pass with run configuration
-//        testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
-//        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "MethodTracing"
+
+        // Enables Composition Tracing for benchmarks
+        // testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
+        // Enables Method tracing for benchmarks. Be aware this skews the performance results,
+        // so don't use it for measuring exact timinig
+        // testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "MethodTracing"
     }
     buildTypes {
         create("benchmark") {
@@ -43,8 +45,8 @@ dependencies {
     implementation(libs.androidx.test.espresso)
     implementation(libs.androidx.test.junit)
     implementation(libs.androidx.test.uiautomator)
-    implementation("androidx.tracing:tracing-perfetto:1.0.0")
-    implementation("androidx.tracing:tracing-perfetto-binary:1.0.0")
+    implementation(libs.androidx.tracing.perfetto)
+    implementation(libs.androidx.tracing.perfetto.binary)
 }
 
 androidComponents {

--- a/coil-benchmark/build.gradle.kts
+++ b/coil-benchmark/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 setupTestModule(name = "coil.benchmark", config = true) {
     // TODO: temporary, should pass instead
-    val targetProject = "compose" //System.getProperty("project", "view")
+    val targetProject = "compose" // System.getProperty("project", "view")
     defaultConfig {
         minSdk = 23
         buildConfigField("String", "PROJECT", "\"$targetProject\"")
@@ -16,7 +16,7 @@ setupTestModule(name = "coil.benchmark", config = true) {
         testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
         // TODO just temporary
         testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "LOW-BATTERY"
-        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"]= "MethodTracing"
+        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "MethodTracing"
     }
     buildTypes {
         create("benchmark") {

--- a/coil-benchmark/build.gradle.kts
+++ b/coil-benchmark/build.gradle.kts
@@ -13,10 +13,8 @@ setupTestModule(name = "coil.benchmark", config = true) {
         minSdk = 23
         buildConfigField("String", "PROJECT", "\"$targetProject\"")
         // TODO temporary, should pass with run configuration
-        testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
-        // TODO just temporary
-        testInstrumentationRunnerArguments["androidx.benchmark.suppressErrors"] = "LOW-BATTERY"
-        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "MethodTracing"
+//        testInstrumentationRunnerArguments["androidx.benchmark.fullTracing.enable"] = "true"
+//        testInstrumentationRunnerArguments["androidx.benchmark.profiling.mode"] = "MethodTracing"
     }
     buildTypes {
         create("benchmark") {

--- a/coil-benchmark/src/main/java/coil/benchmark/MicrosTraceSectionMetric.kt
+++ b/coil-benchmark/src/main/java/coil/benchmark/MicrosTraceSectionMetric.kt
@@ -1,0 +1,58 @@
+package coil.benchmark
+
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.TraceMetric
+import androidx.benchmark.perfetto.ExperimentalPerfettoTraceProcessorApi
+import androidx.benchmark.perfetto.PerfettoTraceProcessor
+
+/**
+ * TraceSectionMode to give average/sum in microseconds measurements
+ */
+@OptIn(ExperimentalMetricApi::class)
+class MicrosTraceSectionMetric(
+    private val sectionName: String,
+    private vararg val mode: Mode,
+    private val label: String = sectionName,
+    private val targetPackageOnly: Boolean = true,
+) : TraceMetric() {
+
+    enum class Mode {
+        Sum,
+        Average
+    }
+
+    @ExperimentalPerfettoTraceProcessorApi
+    @Suppress("RestrictedApi")
+    override fun getResult(
+        captureInfo: CaptureInfo,
+        traceSession: PerfettoTraceProcessor.Session,
+    ): List<Measurement> {
+        val slices = traceSession.querySlices(
+            sectionName,
+            packageName = if (targetPackageOnly) captureInfo.targetPackageName else null,
+        )
+
+        return mode.flatMap { m ->
+            when (m) {
+                Mode.Sum -> listOf(
+                    Measurement(
+                        name = sectionName + "_µs",
+                        // note, this duration assumes non-reentrant slices
+                        data = slices.sumOf { it.dur } / 1_000.0,
+                    ),
+                    Measurement(
+                        name = sectionName + "Count",
+                        data = slices.size.toDouble(),
+                    ),
+                )
+
+                Mode.Average -> listOf(
+                    Measurement(
+                        name = label + "Average_µs",
+                        data = slices.sumOf { it.dur } / 1_000.0 / slices.size,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/coil-benchmark/src/main/java/coil/benchmark/MicrosTraceSectionMetric.kt
+++ b/coil-benchmark/src/main/java/coil/benchmark/MicrosTraceSectionMetric.kt
@@ -6,7 +6,7 @@ import androidx.benchmark.perfetto.ExperimentalPerfettoTraceProcessorApi
 import androidx.benchmark.perfetto.PerfettoTraceProcessor
 
 /**
- * TraceSectionMode to give average/sum in microseconds measurements
+ * TraceSectionMetric to give average/sum in microseconds measurements.
  */
 @OptIn(ExperimentalMetricApi::class)
 class MicrosTraceSectionMetric(

--- a/coil-benchmark/src/main/java/coil/benchmark/ScrollBenchmark.kt
+++ b/coil-benchmark/src/main/java/coil/benchmark/ScrollBenchmark.kt
@@ -1,0 +1,95 @@
+package coil.benchmark
+
+import android.graphics.Point
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.ExperimentalMetricApi
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.StartupMode
+import androidx.benchmark.macro.StartupTimingMetric
+import androidx.benchmark.macro.TraceMetric
+import androidx.benchmark.macro.TraceSectionMetric
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.benchmark.perfetto.ExperimentalPerfettoTraceProcessorApi
+import androidx.benchmark.perfetto.PerfettoTraceProcessor
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.uiautomator.By
+import coil.benchmark.BuildConfig.PROJECT
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScrollBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    @Test
+    fun baselineProfile() {
+        startup(CompilationMode.Partial(BaselineProfileMode.Require))
+    }
+
+    @Test
+    fun fullCompilation() {
+        startup(CompilationMode.Full())
+    }
+
+    @OptIn(ExperimentalMetricApi::class)
+    private fun startup(compilationMode: CompilationMode) {
+        benchmarkRule.measureRepeated(
+            packageName = "sample.$PROJECT",
+            metrics = listOf(
+                FrameTimingMetric(),
+                StartupTimingMetric(),
+                TraceSectionMetric(
+                    "coil.compose.rememberAsyncImagePainter%",
+                    TraceSectionMetric.Mode.Sum,
+                ),
+                AverageTraceSectionMetric("coil.compose.rememberAsyncImagePainter%"),
+            ),
+            iterations = 1,
+            startupMode = StartupMode.COLD,
+            compilationMode = compilationMode,
+            measureBlock = {
+                startActivityAndWait()
+                val list = device.findObject(By.res("list"))
+                list.setGestureMargin(device.displayWidth / 5)
+                list.drag(Point(list.visibleBounds.centerX(), list.visibleBounds.top))
+                Thread.sleep(300)
+            },
+        )
+    }
+}
+
+
+@OptIn(ExperimentalMetricApi::class)
+class AverageTraceSectionMetric(
+    private val sectionName: String,
+    private val label: String = sectionName,
+    private val targetPackageOnly: Boolean = true,
+) : TraceMetric() {
+
+    @ExperimentalPerfettoTraceProcessorApi
+    @Suppress("RestrictedApi")
+    override fun getResult(
+        captureInfo: CaptureInfo,
+        traceSession: PerfettoTraceProcessor.Session,
+    ): List<Measurement> {
+        val slices = traceSession.querySlices(
+            sectionName,
+            packageName = if (targetPackageOnly) captureInfo.targetPackageName else null,
+        )
+
+        return listOf(
+            Measurement(
+                name = label + "AverageMs",
+                data = slices.sumOf { it.dur } / 1_000_000.0 / slices.size,
+            ),
+        )
+
+    }
+}

--- a/coil-benchmark/src/main/java/coil/benchmark/ScrollBenchmark.kt
+++ b/coil-benchmark/src/main/java/coil/benchmark/ScrollBenchmark.kt
@@ -65,7 +65,6 @@ class ScrollBenchmark {
     }
 }
 
-
 @OptIn(ExperimentalMetricApi::class)
 class AverageTraceSectionMetric(
     private val sectionName: String,
@@ -90,6 +89,5 @@ class AverageTraceSectionMetric(
                 data = slices.sumOf { it.dur } / 1_000_000.0 / slices.size,
             ),
         )
-
     }
 }

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -10,7 +10,7 @@ public final class coil/compose/AsyncImagePainter : androidx/compose/ui/graphics
 	public static final field Companion Lcoil/compose/AsyncImagePainter$Companion;
 	public final fun getImageLoader ()Lcoil/ImageLoader;
 	public fun getIntrinsicSize-NH-jbRc ()J
-	public final fun getRequest ()Lcoil/request/ImageRequest;
+	public final fun getRequest (Landroidx/compose/runtime/Composer;I)Lcoil/request/ImageRequest;
 	public final fun getState ()Lcoil/compose/AsyncImagePainter$State;
 	public fun onAbandoned ()V
 	public fun onForgotten ()V

--- a/coil-compose-base/api/coil-compose-base.api
+++ b/coil-compose-base/api/coil-compose-base.api
@@ -10,7 +10,7 @@ public final class coil/compose/AsyncImagePainter : androidx/compose/ui/graphics
 	public static final field Companion Lcoil/compose/AsyncImagePainter$Companion;
 	public final fun getImageLoader ()Lcoil/ImageLoader;
 	public fun getIntrinsicSize-NH-jbRc ()J
-	public final fun getRequest (Landroidx/compose/runtime/Composer;I)Lcoil/request/ImageRequest;
+	public final fun getRequest ()Lcoil/request/ImageRequest;
 	public final fun getState ()Lcoil/compose/AsyncImagePainter$State;
 	public fun onAbandoned ()V
 	public fun onForgotten ()V

--- a/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
+++ b/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.util.trace
 import coil.ImageLoader
 import coil.compose.AsyncImagePainter.Companion.DefaultTransform
 import coil.compose.AsyncImagePainter.State
@@ -197,7 +198,7 @@ private fun rememberAsyncImagePainter(
     onState: ((State) -> Unit)?,
     contentScale: ContentScale,
     filterQuality: FilterQuality,
-): AsyncImagePainter {
+): AsyncImagePainter = trace("rememberAsyncImagePainter") {
     val request = requestOf(state.model)
     validateRequest(request)
 
@@ -282,9 +283,9 @@ class AsyncImagePainter internal constructor(
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun onRemembered() {
+    override fun onRemembered() = trace("AsyncImagePainter.onRemembered") {
         // Short circuit if we're already remembered.
-        if (rememberScope != null) return
+        if (rememberScope != null) return@trace
 
         // Create a new scope to observe state and execute requests while we're remembered.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
@@ -297,7 +298,7 @@ class AsyncImagePainter internal constructor(
         if (isPreview) {
             val request = request.newBuilder().defaults(imageLoader.defaults).build()
             updateState(State.Loading(request.placeholder?.toPainter()))
-            return
+            return@trace
         }
 
         // Observe the current request and execute any emissions.

--- a/coil-sample-compose/build.gradle.kts
+++ b/coil-sample-compose/build.gradle.kts
@@ -42,5 +42,5 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.compose.material)
-    implementation("androidx.compose.runtime:runtime-tracing:1.0.0-beta01")
+    implementation(libs.androidx.compose.runtime.tracing)
 }

--- a/coil-sample-compose/build.gradle.kts
+++ b/coil-sample-compose/build.gradle.kts
@@ -42,4 +42,5 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.compose.material)
+    implementation("androidx.compose.runtime:runtime-tracing:1.0.0-beta01")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ okhttp = "4.12.0"
 okio = "3.8.0"
 roborazzi = "1.7.0"
 perfetto = "1.0.0"
+runtimeTracing = "1.0.0-beta01"
 
 [plugins]
 binaryCompatibility = "org.jetbrains.kotlinx.binary-compatibility-validator:0.14.0"
@@ -26,6 +27,7 @@ accompanist-drawablepainter = "com.google.accompanist:accompanist-drawablepainte
 
 androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing", version.ref = "runtimeTracing" }
 androidx-appcompat-resources = "androidx.appcompat:appcompat-resources:1.6.1"
 androidx-annotation = "androidx.annotation:annotation:1.7.1"
 androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.2.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ ktlint = "1.0.1"
 okhttp = "4.12.0"
 okio = "3.8.0"
 roborazzi = "1.7.0"
+perfetto = "1.0.0"
 
 [plugins]
 binaryCompatibility = "org.jetbrains.kotlinx.binary-compatibility-validator:0.14.0"
@@ -43,6 +44,8 @@ androidx-test-junit = "androidx.test.ext:junit-ktx:1.1.5"
 androidx-test-rules = "androidx.test:rules:1.5.0"
 androidx-test-runner = "androidx.test:runner:1.5.2"
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.2.0"
+androidx-tracing-perfetto = { module = "androidx.tracing:tracing-perfetto", version.ref = "perfetto" }
+androidx-tracing-perfetto-binary = { module = "androidx.tracing:tracing-perfetto-binary", version.ref = "perfetto" }
 androidx-vectordrawable-animated = "androidx.vectordrawable:vectordrawable-animated:1.1.0"
 
 compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-appcompat-resources = "androidx.appcompat:appcompat-resources:1.6.1"
 androidx-annotation = "androidx.annotation:annotation:1.7.1"
-androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.2.3"
+androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.2.4"
 androidx-collection = "androidx.collection:collection:1.4.0"
 androidx-constraintlayout = "androidx.constraintlayout:constraintlayout:2.1.4"
 androidx-core = "androidx.core:core-ktx:1.12.0"


### PR DESCRIPTION
I was investigating the performance of `rememberAsyncImagePainter` and found out the `AsyncImagePainter.onRemembered` is the longest call inside ~0.25ms for each image.
<img width="1053" alt="image" src="https://github.com/coil-kt/coil/assets/3973717/8843fdb7-1678-4576-9a55-03288408e5da">

When I was investigating more, I think the reason of this is that the `RealImageLoader.execute` request uses `async` call with dispatcher `Main.immediate`, but the coroutine is already called with `Main.immediate`. If I understand things correclty, this can't be called in parallel and therefore is called sequentially, hence the duration.

This should improve #1866 .

before
```
ScrollBenchmark_fullCompilation
coil.compose.rememberAsyncImagePainter%AverageMs   min     0,5,   median     0,6,   max     0,7
coil.compose.rememberAsyncImagePainter%Count       min   156,0,   median   173,0,   max   190,0
coil.compose.rememberAsyncImagePainter%Ms          min    81,0,   median    99,9,   max   128,2
timeToInitialDisplayMs                             min   525,2,   median   547,1,   max   579,6
frameDurationCpuMs                                 P50     10,5,   P90     31,0,   P95     42,1,   P99    315,3
frameOverrunMs                                     P50     -7,5,   P90     17,1,   P95     63,4,   P99  1 170,9
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```

after
```
ScrollBenchmark_fullCompilation
coil.compose.rememberAsyncImagePainter%AverageMs   min     0,3,   median     0,4,   max     0,5
coil.compose.rememberAsyncImagePainter%Count       min   154,0,   median   174,0,   max   184,0
coil.compose.rememberAsyncImagePainter%Ms          min    51,4,   median    70,6,   max    83,1
timeToInitialDisplayMs                             min   521,4,   median   563,9,   max   605,9
frameDurationCpuMs                                 P50      9,6,   P90     30,7,   P95     45,1,   P99    301,4
frameOverrunMs                                     P50     -8,1,   P90     22,8,   P95     52,3,   P99  1 172,8
Traces: Iteration 0 1 2 3 4 5 6 7 8 9
```

From the benchmarks, I can see that the frame duration was improved slightly for the scroll.
```
before : frameDurationCpuMs  P50     10,5,   P90     31,0,   P95     42,1,   P99    315,3
after    : frameDurationCpuMs  P50      9,6, (-9%)   P90     30,7, (-1%)   P95     45,1, (+6%)  P99    301,4 (-5%)
```

This solution is probably not sufficient as the dispatcher probably needs to be passed, or called somewhere else, or even this might be done differently all together.

I have experimented with this in 2.x branch, but I see a similar code is in 3.x.