### PR TITLE
[BEHAVIOR CHANGE] Don't automatically wait for the draw size in AsyncImagePainter.

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,6 +4,7 @@
     <inspection_tool class="BlockingMethodInNonBlockingContext" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CanBeParameter" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CascadeIf" enabled="false" level="INFO" enabled_by_default="false" />
+    <inspection_tool class="ConstPropertyName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="DeprecatedCallableAddReplaceWith" enabled="false" level="INFO" enabled_by_default="false" />
     <inspection_tool class="EditorConfigKeyCorrectness" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="FunctionName" enabled="false" level="WEAK WARNING" enabled_by_default="false" />

--- a/coil-compose-core/api/android/coil-compose-core.api
+++ b/coil-compose-core/api/android/coil-compose-core.api
@@ -84,6 +84,14 @@ public final class coil3/compose/ComposableSingletons$SubcomposeAsyncImageKt {
 	public final fun getLambda-1$coil_compose_core_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public abstract interface class coil3/compose/DrawScopeSizeResolver : coil3/size/SizeResolver {
+	public abstract fun connect (Lkotlinx/coroutines/flow/Flow;)V
+}
+
+public final class coil3/compose/DrawScopeSizeResolverKt {
+	public static final fun DrawScopeSizeResolver ()Lcoil3/compose/DrawScopeSizeResolver;
+}
+
 public abstract interface class coil3/compose/EqualityDelegate {
 	public abstract fun equals (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public abstract fun hashCode (Ljava/lang/Object;)I

--- a/coil-compose-core/api/jvm/coil-compose-core.api
+++ b/coil-compose-core/api/jvm/coil-compose-core.api
@@ -84,6 +84,14 @@ public final class coil3/compose/ComposableSingletons$SubcomposeAsyncImageKt {
 	public final fun getLambda-1$coil_compose_core ()Lkotlin/jvm/functions/Function3;
 }
 
+public abstract interface class coil3/compose/DrawScopeSizeResolver : coil3/size/SizeResolver {
+	public abstract fun connect (Lkotlinx/coroutines/flow/Flow;)V
+}
+
+public final class coil3/compose/DrawScopeSizeResolverKt {
+	public static final fun DrawScopeSizeResolver ()Lcoil3/compose/DrawScopeSizeResolver;
+}
+
 public final class coil3/compose/DrawablePainter : androidx/compose/ui/graphics/painter/Painter {
 	public static final field $stable I
 	public fun <init> (Lcoil3/DrawableImage;)V

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
@@ -49,7 +49,6 @@ import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.placeholder
 import coil3.test.utils.ComposeTestActivity
-import coil3.test.utils.context
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -114,13 +113,6 @@ class AsyncImagePainterTest {
 
         waitForRequestComplete()
 
-        // Assert that the loaded image is the lesser of the image source and the display size.
-        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
-        assertLoadedBitmapSize(
-            width = displaySize.coerceAtMost(1024).toDp(),
-            height = displaySize.coerceAtMost(1326).toDp(),
-        )
-
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(128.dp)
@@ -180,13 +172,6 @@ class AsyncImagePainterTest {
 
         waitForRequestComplete()
 
-        // Assert that the loaded image is the lesser of the image source and the display size.
-        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
-        assertLoadedBitmapSize(
-            width = displaySize.coerceAtMost(1024).toDp(),
-            height = displaySize.coerceAtMost(1326).toDp(),
-        )
-
         composeTestRule.onNodeWithTag(Image)
             .assertWidthIsEqualTo(128.dp, tolerance = 1.dp)
             .assertHeightIsEqualTo(166.dp, tolerance = 1.dp)
@@ -245,13 +230,6 @@ class AsyncImagePainterTest {
         }
 
         waitForRequestComplete()
-
-        // Assert that the loaded image is the lesser of the image source and the display size.
-        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
-        assertLoadedBitmapSize(
-            width = displaySize.coerceAtMost(1024).toDp(),
-            height = displaySize.coerceAtMost(1326).toDp(),
-        )
 
         composeTestRule.onNodeWithTag(Image)
             .assertWidthIsEqualTo(128.dp)

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
@@ -113,7 +113,12 @@ class AsyncImagePainterTest {
 
         waitForRequestComplete()
 
-        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+        // Assert that the loaded image is the lesser of the image source and the display size.
+        val (displayWidth, displayHeight) = displaySize
+        assertLoadedBitmapSize(
+            width = displayWidth.coerceAtMost(1024).toDp(),
+            height = displayHeight.coerceAtMost(1326).toDp(),
+        )
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
@@ -174,7 +179,12 @@ class AsyncImagePainterTest {
 
         waitForRequestComplete()
 
-        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+        // Assert that the loaded image is the lesser of the image source and the display size.
+        val (displayWidth, displayHeight) = displaySize
+        assertLoadedBitmapSize(
+            width = displayWidth.coerceAtMost(1024).toDp(),
+            height = displayHeight.coerceAtMost(1326).toDp(),
+        )
 
         composeTestRule.onNodeWithTag(Image)
             .assertWidthIsEqualTo(128.dp, tolerance = 1.dp)
@@ -235,7 +245,12 @@ class AsyncImagePainterTest {
 
         waitForRequestComplete()
 
-        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+        // Assert that the loaded image is the lesser of the image source and the display size.
+        val (displayWidth, displayHeight) = displaySize
+        assertLoadedBitmapSize(
+            width = displayWidth.coerceAtMost(1024).toDp(),
+            height = displayHeight.coerceAtMost(1326).toDp(),
+        )
 
         composeTestRule.onNodeWithTag(Image)
             .assertWidthIsEqualTo(128.dp)

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
@@ -49,6 +49,7 @@ import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.placeholder
 import coil3.test.utils.ComposeTestActivity
+import coil3.test.utils.context
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -114,10 +115,10 @@ class AsyncImagePainterTest {
         waitForRequestComplete()
 
         // Assert that the loaded image is the lesser of the image source and the display size.
-        val (displayWidth, displayHeight) = displaySize
+        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
         assertLoadedBitmapSize(
-            width = displayWidth.coerceAtMost(1024).toDp(),
-            height = displayHeight.coerceAtMost(1326).toDp(),
+            width = displaySize.coerceAtMost(1024).toDp(),
+            height = displaySize.coerceAtMost(1326).toDp(),
         )
 
         composeTestRule.onNodeWithTag(Image)
@@ -180,10 +181,10 @@ class AsyncImagePainterTest {
         waitForRequestComplete()
 
         // Assert that the loaded image is the lesser of the image source and the display size.
-        val (displayWidth, displayHeight) = displaySize
+        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
         assertLoadedBitmapSize(
-            width = displayWidth.coerceAtMost(1024).toDp(),
-            height = displayHeight.coerceAtMost(1326).toDp(),
+            width = displaySize.coerceAtMost(1024).toDp(),
+            height = displaySize.coerceAtMost(1326).toDp(),
         )
 
         composeTestRule.onNodeWithTag(Image)
@@ -246,10 +247,10 @@ class AsyncImagePainterTest {
         waitForRequestComplete()
 
         // Assert that the loaded image is the lesser of the image source and the display size.
-        val (displayWidth, displayHeight) = displaySize
+        val displaySize = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
         assertLoadedBitmapSize(
-            width = displayWidth.coerceAtMost(1024).toDp(),
-            height = displayHeight.coerceAtMost(1326).toDp(),
+            width = displaySize.coerceAtMost(1024).toDp(),
+            height = displaySize.coerceAtMost(1326).toDp(),
         )
 
         composeTestRule.onNodeWithTag(Image)

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImagePainterTest.kt
@@ -102,7 +102,39 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = "https://example.com/image",
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(128.dp, 166.dp)
+                    .testTag(Image),
+            )
+        }
+
+        waitForRequestComplete()
+
+        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(166.dp)
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
+    @Test
+    fun basicLoad_http_drawScopeSizeResolver() {
+        assumeSupportsCaptureToImage()
+
+        composeTestRule.setContent {
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data("https://example.com/image")
+                        .size(DrawScopeSizeResolver())
+                        .build(),
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -131,7 +163,39 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = R.drawable.sample,
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(128.dp, 166.dp)
+                    .testTag(Image),
+            )
+        }
+
+        waitForRequestComplete()
+
+        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertWidthIsEqualTo(128.dp, tolerance = 1.dp)
+            .assertHeightIsEqualTo(166.dp, tolerance = 1.dp)
+            .assertIsDisplayed()
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
+    @Test
+    fun basicLoad_drawableId_drawScopeSizeResolver() {
+        assumeSupportsCaptureToImage()
+
+        composeTestRule.setContent {
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(R.drawable.sample)
+                        .size(DrawScopeSizeResolver())
+                        .build(),
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -160,7 +224,39 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = resourceUri(R.drawable.sample),
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
+                ),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(128.dp, 166.dp)
+                    .testTag(Image),
+            )
+        }
+
+        waitForRequestComplete()
+
+        assertLoadedBitmapSize(1024.toDp(), 1326.toDp())
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertWidthIsEqualTo(128.dp)
+            .assertHeightIsEqualTo(166.dp)
+            .assertIsDisplayed()
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
+    @Test
+    fun basicLoad_drawableUri_drawScopeSizeResolver() {
+        assumeSupportsCaptureToImage()
+
+        composeTestRule.setContent {
+            Image(
+                painter = rememberAsyncImagePainter(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(resourceUri(R.drawable.sample))
+                        .size(DrawScopeSizeResolver())
+                        .build(),
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -191,6 +287,7 @@ class AsyncImagePainterTest {
             override fun onSuccess(request: ImageRequest, result: SuccessResult) {
                 requestCompleted = true
             }
+
             override fun onError(request: ImageRequest, result: ErrorResult) {
                 requestThrowable = result.throwable
             }
@@ -228,7 +325,7 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = data,
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -269,7 +366,7 @@ class AsyncImagePainterTest {
         composeTestRule.setContent {
             val painter = rememberAsyncImagePainter(
                 model = "https://example.com/image",
-                imageLoader = imageLoader
+                imageLoader = imageLoader,
             )
 
             Image(
@@ -277,7 +374,7 @@ class AsyncImagePainterTest {
                 contentDescription = null,
                 modifier = Modifier
                     .size(size)
-                    .testTag(Image)
+                    .testTag(Image),
             )
 
             LaunchedEffect(painter) {
@@ -309,7 +406,7 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = "https://example.com/image",
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier.testTag(Image),
@@ -329,13 +426,13 @@ class AsyncImagePainterTest {
         composeTestRule.setContent {
             LazyColumn(
                 modifier = Modifier
-                    .size(240.dp, 200.dp)
+                    .size(240.dp, 200.dp),
             ) {
                 item {
                     Image(
                         painter = rememberAsyncImagePainter(
                             model = "https://example.com/image",
-                            imageLoader = imageLoader
+                            imageLoader = imageLoader,
                         ),
                         contentDescription = null,
                         modifier = Modifier
@@ -365,7 +462,7 @@ class AsyncImagePainterTest {
                         .data("https://example.com/noimage")
                         .error(R.drawable.red_rectangle)
                         .build(),
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -397,7 +494,7 @@ class AsyncImagePainterTest {
                             .data("https://example.com/image")
                             .placeholder(R.drawable.red_rectangle)
                             .build(),
-                        imageLoader = imageLoader
+                        imageLoader = imageLoader,
                     ),
                     contentDescription = null,
                     modifier = Modifier
@@ -426,7 +523,7 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = "https://example.com/noimage",
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -450,7 +547,7 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = painterResource(R.drawable.sample),
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier.size(128.dp),
@@ -478,7 +575,7 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = ColorPainter(Color.Magenta),
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier.size(128.dp),
@@ -498,7 +595,7 @@ class AsyncImagePainterTest {
                         .placeholder(R.drawable.red_rectangle)
                         .crossfade(true)
                         .build(),
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
                 contentDescription = null,
                 modifier = Modifier
@@ -557,12 +654,12 @@ class AsyncImagePainterTest {
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .verticalScroll(rememberScrollState())
+                        .verticalScroll(rememberScrollState()),
                 ) {
                     Image(
                         painter = rememberAsyncImagePainter(
                             model = "https://example.com/image",
-                            imageLoader = imageLoader
+                            imageLoader = imageLoader,
                         ),
                         contentDescription = null,
                         modifier = Modifier
@@ -627,7 +724,7 @@ class AsyncImagePainterTest {
                     onSuccess = { successCount.getAndIncrement() },
                     onError = { errorCount.getAndIncrement() },
                 ),
-                contentDescription = null
+                contentDescription = null,
             )
         }
 
@@ -656,7 +753,7 @@ class AsyncImagePainterTest {
                     onSuccess = { successCount.getAndIncrement() },
                     onError = { errorCount.getAndIncrement() },
                 ),
-                contentDescription = null
+                contentDescription = null,
             )
         }
 
@@ -676,9 +773,9 @@ class AsyncImagePainterTest {
             Image(
                 painter = rememberAsyncImagePainter(
                     model = "https://example.com/image",
-                    imageLoader = imageLoader
+                    imageLoader = imageLoader,
                 ),
-                contentDescription = null
+                contentDescription = null,
             )
         }
 

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
@@ -1,10 +1,10 @@
 package coil3.compose
 
-import coil3.size.Size as CoilSize
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.internal.toCoilSizeOrNull
+import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
 import kotlin.js.JsName
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
@@ -1,10 +1,10 @@
 package coil3.compose
 
+import coil3.size.Size as CoilSize
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import coil3.annotation.ExperimentalCoilApi
 import coil3.compose.internal.toCoilSizeOrNull
-import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
 import kotlin.js.JsName
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
@@ -15,9 +15,7 @@ import kotlinx.coroutines.flow.mapNotNull
 
 @ExperimentalCoilApi
 @JsName("newDrawScopeSizeResolver")
-fun DrawScopeSizeResolver(): DrawScopeSizeResolver {
-    return RealDrawScopeSizeResolver()
-}
+fun DrawScopeSizeResolver(): DrawScopeSizeResolver = RealDrawScopeSizeResolver()
 
 /**
  * A special [SizeResolver] that waits until [AsyncImagePainter.onDraw] to return the

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
@@ -1,0 +1,50 @@
+package coil3.compose
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import coil3.annotation.ExperimentalCoilApi
+import coil3.compose.internal.toCoilSizeOrNull
+import coil3.size.Size as CoilSize
+import coil3.size.SizeResolver
+import kotlin.js.JsName
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.mapNotNull
+
+@ExperimentalCoilApi
+@JsName("newDrawScopeSizeResolver")
+fun DrawScopeSizeResolver(): DrawScopeSizeResolver {
+    return RealDrawScopeSizeResolver()
+}
+
+/**
+ * A special [SizeResolver] that waits until [AsyncImagePainter.onDraw] to return the
+ * [DrawScope]'s size.
+ */
+@ExperimentalCoilApi
+interface DrawScopeSizeResolver : SizeResolver {
+    fun connect(sizes: Flow<Size>)
+}
+
+private class RealDrawScopeSizeResolver : DrawScopeSizeResolver {
+    private val sizes = MutableSharedFlow<Flow<Size>>(
+        replay = 1,
+        onBufferOverflow = DROP_OLDEST,
+    )
+
+    override fun connect(sizes: Flow<Size>) {
+        this.sizes.tryEmit(sizes)
+    }
+
+    override suspend fun size(): CoilSize {
+        return sizes
+            .mapNotNull { sizes ->
+                sizes
+                    .mapNotNull { it.toCoilSizeOrNull() }
+                    .first()
+            }
+            .first()
+    }
+}

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.Role
@@ -180,6 +181,15 @@ internal fun Constraints.constrainWidth(width: Float) =
 
 internal fun Constraints.constrainHeight(height: Float) =
     height.coerceIn(minHeight.toFloat(), maxHeight.toFloat())
+
+internal fun Size.toCoilSizeOrNull() = when {
+    isUnspecified -> CoilSize.ORIGINAL
+    isPositive -> CoilSize(
+        width = if (width.isFinite()) Dimension(width.roundToInt()) else Dimension.Undefined,
+        height = if (height.isFinite()) Dimension(height.roundToInt()) else Dimension.Undefined,
+    )
+    else -> null
+}
 
 internal inline fun Float.takeOrElse(block: () -> Float) = if (isFinite()) this else block()
 

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
@@ -1,5 +1,6 @@
 package coil3.compose.internal
 
+import coil3.size.Size as CoilSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
@@ -25,7 +26,6 @@ import coil3.request.ImageRequest
 import coil3.request.NullRequestDataException
 import coil3.size.Dimension
 import coil3.size.Scale
-import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
 import kotlin.math.roundToInt
 
@@ -196,7 +196,5 @@ internal inline fun Float.takeOrElse(block: () -> Float) = if (isFinite()) this 
 internal fun Size.toIntSize() = IntSize(width.roundToInt(), height.roundToInt())
 
 internal val Size.isPositive get() = width >= 0.5 && height >= 0.5
-
-internal val ZeroConstraints = Constraints.fixed(0, 0)
 
 internal val OriginalSizeResolver = SizeResolver(CoilSize.ORIGINAL)

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
@@ -1,6 +1,5 @@
 package coil3.compose.internal
 
-import coil3.size.Size as CoilSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.Stable
@@ -26,6 +25,7 @@ import coil3.request.ImageRequest
 import coil3.request.NullRequestDataException
 import coil3.size.Dimension
 import coil3.size.Scale
+import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
 import kotlin.math.roundToInt
 

--- a/internal/test-paparazzi/src/test/java/coil3/paparazzi/PaparazziTest.kt
+++ b/internal/test-paparazzi/src/test/java/coil3/paparazzi/PaparazziTest.kt
@@ -15,7 +15,6 @@ import coil3.compose.rememberAsyncImagePainter
 import coil3.decode.ImageSource
 import coil3.request.ImageRequest
 import coil3.request.target
-import coil3.size.Size
 import coil3.test.FakeImageLoaderEngine
 import coil3.test.intercept
 import kotlin.test.assertTrue
@@ -104,11 +103,7 @@ class PaparazziTest {
         paparazzi.snapshot {
             Image(
                 painter = rememberAsyncImagePainter(
-                    // TODO: Figure out how to avoid having to specify an immediate size.
-                    model = ImageRequest.Builder(paparazzi.context)
-                        .data(url)
-                        .size(Size.ORIGINAL)
-                        .build(),
+                    model = url,
                     imageLoader = imageLoader,
                 ),
                 contentDescription = null,

--- a/internal/test-roborazzi/src/test/java/coil3/roborazzi/RoborazziComposeTest.kt
+++ b/internal/test-roborazzi/src/test/java/coil3/roborazzi/RoborazziComposeTest.kt
@@ -12,8 +12,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.compose.rememberAsyncImagePainter
-import coil3.request.ImageRequest
-import coil3.size.Size
 import coil3.test.FakeImageLoaderEngine
 import coil3.test.intercept
 import coil3.test.utils.ComposeTestActivity
@@ -81,12 +79,8 @@ class RoborazziComposeTest {
 
         composeTestRule.setContent {
             Image(
-                // TODO: Figure out how to avoid having to specify an immediate size.
                 painter = rememberAsyncImagePainter(
-                    model = ImageRequest.Builder(composeTestRule.activity)
-                        .data(url)
-                        .size(Size.ORIGINAL)
-                        .build(),
+                    model = url,
                     imageLoader = imageLoader,
                 ),
                 contentDescription = null,


### PR DESCRIPTION
Relates to: https://github.com/coil-kt/coil/issues/1910

(fixes this issue on the 3.x branch)