### PR TITLE
Prevent setting request.lifecycle in Compose.

### DIFF
--- a/coil-compose-core/api/android/coil-compose-core.api
+++ b/coil-compose-core/api/android/coil-compose-core.api
@@ -113,6 +113,7 @@ public final class coil3/compose/EqualityDelegateKt {
 public final class coil3/compose/ImagePainter : androidx/compose/ui/graphics/painter/Painter {
 	public static final field $stable I
 	public fun <init> (Lcoil3/Image;)V
+	public final fun getImage ()Lcoil3/Image;
 	public fun getIntrinsicSize-NH-jbRc ()J
 }
 

--- a/coil-compose-core/api/jvm/coil-compose-core.api
+++ b/coil-compose-core/api/jvm/coil-compose-core.api
@@ -113,6 +113,7 @@ public final class coil3/compose/EqualityDelegateKt {
 public final class coil3/compose/ImagePainter : androidx/compose/ui/graphics/painter/Painter {
 	public static final field $stable I
 	public fun <init> (Lcoil3/Image;)V
+	public final fun getImage ()Lcoil3/Image;
 	public fun getIntrinsicSize-NH-jbRc ()J
 }
 

--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
@@ -17,16 +17,12 @@ import coil3.request.SuccessResult
 import coil3.request.lifecycle
 import coil3.request.transitionFactory
 import coil3.transition.CrossfadeTransition
-import coil3.transition.Transition
 import coil3.transition.TransitionTarget
 import com.google.accompanist.drawablepainter.DrawablePainter
 
 internal actual fun validateRequestProperties(request: ImageRequest) {
     require(request.target == null) { "request.target must be null." }
     require(request.lifecycle == null) { "request.lifecycle must be null." }
-    require(request.transitionFactory == Transition.Factory.NONE) {
-        "request.target must be Transition.Factory.NONE."
-    }
 }
 
 internal actual fun Image.toPainter(

--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
@@ -12,11 +12,22 @@ import coil3.Image
 import coil3.PlatformContext
 import coil3.asDrawable
 import coil3.compose.internal.CrossfadePainter
+import coil3.request.ImageRequest
 import coil3.request.SuccessResult
+import coil3.request.lifecycle
 import coil3.request.transitionFactory
 import coil3.transition.CrossfadeTransition
+import coil3.transition.Transition
 import coil3.transition.TransitionTarget
 import com.google.accompanist.drawablepainter.DrawablePainter
+
+internal actual fun validateRequestProperties(request: ImageRequest) {
+    require(request.target == null) { "request.target must be null." }
+    require(request.lifecycle == null) { "request.lifecycle must be null." }
+    require(request.transitionFactory == Transition.Factory.NONE) {
+        "request.target must be Transition.Factory.NONE."
+    }
+}
 
 internal actual fun Image.toPainter(
     context: PlatformContext,

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -410,13 +410,16 @@ private fun validateRequest(request: ImageRequest) {
         is ImageVector -> unsupportedData("ImageVector")
         is Painter -> unsupportedData("Painter")
     }
-    require(request.target == null) { "request.target must be null." }
+    validateRequestProperties(request)
 }
 
 private fun unsupportedData(
     name: String,
     description: String = "If you wish to display this $name, use androidx.compose.foundation.Image.",
 ): Nothing = throw IllegalArgumentException("Unsupported type: $name. $description")
+
+/** Validate platform-specific properties of an [ImageRequest]. */
+internal expect fun validateRequestProperties(request: ImageRequest)
 
 /** Convert this [Image] into a [Painter] using Compose primitives if possible. */
 internal expect fun Image.toPainter(

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/ImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/ImagePainter.kt
@@ -14,23 +14,29 @@ import coil3.annotation.ExperimentalCoilApi
  */
 @ExperimentalCoilApi
 class ImagePainter(
-    private val image: Image,
+    val image: Image,
 ) : Painter() {
-
     override val intrinsicSize: Size
-        get() = Size(
-            width = image.width.let { if (it == -1) Float.NaN else it.toFloat() },
-            height = image.height.let { if (it == -1) Float.NaN else it.toFloat() },
-        )
+        get() = Size(intrinsicWidth, intrinsicHeight)
+
+    private val intrinsicWidth: Float
+        get() = image.width.toDimension()
+
+    private val intrinsicHeight: Float
+        get() = image.height.toDimension()
 
     override fun DrawScope.onDraw() {
         scale(
-            scaleX = size.width / intrinsicSize.width,
-            scaleY = size.height / intrinsicSize.height,
+            scaleX = size.width / intrinsicWidth,
+            scaleY = size.height / intrinsicHeight,
             pivot = Offset.Zero,
         ) {
             image.draw(drawContext.canvas.nativeCanvas)
         }
+    }
+
+    private fun Int.toDimension(): Float {
+        return if (this >= 0) toFloat() else Float.NaN
     }
 }
 

--- a/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
+++ b/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
@@ -10,9 +10,14 @@ import coil3.Image
 import coil3.PlatformContext
 import coil3.compose.internal.CrossfadePainter
 import coil3.decode.DataSource
+import coil3.request.ImageRequest
 import coil3.request.SuccessResult
 import coil3.request.crossfadeMillis
 import coil3.toBitmap
+
+internal actual fun validateRequestProperties(request: ImageRequest) {
+    require(request.target == null) { "request.target must be null." }
+}
 
 internal actual fun Image.toPainter(
     context: PlatformContext,


### PR DESCRIPTION
request.lifecycle requires main thread access and isn't really necessary for Compose.