### PR TITLE
Only disable enforceMinimumFrameDelay on SDK_INT < 34 by default for AnimatedImageDecoder.

### DIFF
--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -10,7 +10,6 @@ public final class coil3/gif/AnimatedImageDecoder$Factory : coil3/decode/Decoder
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lcoil3/fetch/SourceFetchResult;Lcoil3/request/Options;Lcoil3/ImageLoader;)Lcoil3/decode/Decoder;
-	public final fun getEnforceMinimumFrameDelay ()Z
 }
 
 public abstract interface class coil3/gif/AnimatedTransformation {

--- a/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
+++ b/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
@@ -51,7 +51,8 @@ import okio.FileSystem
 class AnimatedImageDecoder @JvmOverloads constructor(
     private val source: ImageSource,
     private val options: Options,
-    private val enforceMinimumFrameDelay: Boolean = true,
+    // https://android.googlesource.com/platform/frameworks/base/+/2be87bb707e2c6d75f668c4aff6697b85fbf5b15
+    private val enforceMinimumFrameDelay: Boolean = SDK_INT < 34,
 ) : Decoder {
 
     override suspend fun decode(): DecodeResult {
@@ -173,7 +174,8 @@ class AnimatedImageDecoder @JvmOverloads constructor(
     }
 
     class Factory @JvmOverloads constructor(
-        val enforceMinimumFrameDelay: Boolean = true,
+        // https://android.googlesource.com/platform/frameworks/base/+/2be87bb707e2c6d75f668c4aff6697b85fbf5b15
+        private val enforceMinimumFrameDelay: Boolean = SDK_INT < 34,
     ) : Decoder.Factory {
 
         override fun create(

--- a/coil-gif/src/main/java/coil3/gif/internal/FrameDelayRewritingSource.kt
+++ b/coil-gif/src/main/java/coil3/gif/internal/FrameDelayRewritingSource.kt
@@ -2,7 +2,6 @@
 
 package coil3.gif.internal
 
-import android.os.Build.VERSION.SDK_INT
 import coil3.decode.DecodeUtils
 import coil3.decode.ImageSource
 import coil3.gif.isGif
@@ -96,8 +95,7 @@ internal fun maybeWrapImageSourceToRewriteFrameDelay(
     source: ImageSource,
     enforceMinimumFrameDelay: Boolean,
 ): ImageSource {
-    // https://android.googlesource.com/platform/frameworks/base/+/2be87bb707e2c6d75f668c4aff6697b85fbf5b15
-    if (enforceMinimumFrameDelay && SDK_INT < 34 && DecodeUtils.isGif(source.source())) {
+    if (enforceMinimumFrameDelay && DecodeUtils.isGif(source.source())) {
         // Wrap the source to rewrite its frame delay as it's read.
         return ImageSource(
             source = FrameDelayRewritingSource(source.source()).buffer(),


### PR DESCRIPTION
Resolves: https://github.com/coil-kt/coil/issues/2287