### PR TITLE
Add observeDefaultNetwork to coil 2.x

### DIFF
--- a/coil-base/api/coil-base.api
+++ b/coil-base/api/coil-base.api
@@ -133,6 +133,7 @@ public final class coil/ImageLoader$Builder {
 	public final fun memoryCachePolicy (Lcoil/request/CachePolicy;)Lcoil/ImageLoader$Builder;
 	public final fun networkCachePolicy (Lcoil/request/CachePolicy;)Lcoil/ImageLoader$Builder;
 	public final fun networkObserverEnabled (Z)Lcoil/ImageLoader$Builder;
+	public final fun observeDefaultNetwork (Z)Lcoil/ImageLoader$Builder;
 	public final fun okHttpClient (Lkotlin/jvm/functions/Function0;)Lcoil/ImageLoader$Builder;
 	public final fun okHttpClient (Lokhttp3/OkHttpClient;)Lcoil/ImageLoader$Builder;
 	public final fun placeholder (I)Lcoil/ImageLoader$Builder;

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -526,7 +526,7 @@ interface ImageLoader {
          * Configure ConnectivityManager to call registerDefaultNetworkCallback.
          *
          * NOTE: by default this is false, and ConnectivityManager calls registerNetworkCallback instead.
-         * Additionally, this will only work on min-sdk 24 (N) and above.
+         * Additionally, this will only work on devices running sdk 24 (N) and above.
          */
         fun observeDefaultNetwork(observeDefaultNetwork: Boolean) = apply {
             this.options = this.options.copy(observeDefaultNetwork = observeDefaultNetwork)

--- a/coil-base/src/main/java/coil/ImageLoader.kt
+++ b/coil-base/src/main/java/coil/ImageLoader.kt
@@ -523,6 +523,16 @@ interface ImageLoader {
         }
 
         /**
+         * Configure ConnectivityManager to call registerDefaultNetworkCallback.
+         *
+         * NOTE: by default this is false, and ConnectivityManager calls registerNetworkCallback instead.
+         * Additionally, this will only work on min-sdk 24 (N) and above.
+         */
+        fun observeDefaultNetwork(observeDefaultNetwork: Boolean) = apply {
+            this.options = this.options.copy(observeDefaultNetwork = observeDefaultNetwork)
+        }
+
+        /**
          * Create a new [ImageLoader] instance.
          */
         fun build(): ImageLoader {

--- a/coil-base/src/main/java/coil/util/ImageLoaderOptions.kt
+++ b/coil-base/src/main/java/coil/util/ImageLoaderOptions.kt
@@ -15,7 +15,8 @@ internal class ImageLoaderOptions(
     val networkObserverEnabled: Boolean = true,
     val respectCacheHeaders: Boolean = true,
     val bitmapFactoryMaxParallelism: Int = DEFAULT_MAX_PARALLELISM,
-    val bitmapFactoryExifOrientationPolicy: ExifOrientationPolicy = ExifOrientationPolicy.RESPECT_PERFORMANCE
+    val bitmapFactoryExifOrientationPolicy: ExifOrientationPolicy = ExifOrientationPolicy.RESPECT_PERFORMANCE,
+    val observeDefaultNetwork: Boolean = false,
 ) {
 
     fun copy(
@@ -24,11 +25,13 @@ internal class ImageLoaderOptions(
         respectCacheHeaders: Boolean = this.respectCacheHeaders,
         bitmapFactoryMaxParallelism: Int = this.bitmapFactoryMaxParallelism,
         bitmapFactoryExifOrientationPolicy: ExifOrientationPolicy = this.bitmapFactoryExifOrientationPolicy,
+        observeDefaultNetwork: Boolean = this.observeDefaultNetwork,
     ) = ImageLoaderOptions(
         addLastModifiedToFileCacheKey,
         networkObserverEnabled,
         respectCacheHeaders,
         bitmapFactoryMaxParallelism,
-        bitmapFactoryExifOrientationPolicy
+        bitmapFactoryExifOrientationPolicy,
+        observeDefaultNetwork,
     )
 }

--- a/coil-base/src/main/java/coil/util/SystemCallbacks.kt
+++ b/coil-base/src/main/java/coil/util/SystemCallbacks.kt
@@ -49,7 +49,11 @@ internal class SystemCallbacks(
         if (networkObserver != null) return@withImageLoader
 
         val networkObserver = if (imageLoader.options.networkObserverEnabled) {
-            NetworkObserver(imageLoader.context, this, imageLoader.logger)
+            NetworkObserver(
+                imageLoader.context,
+                this,
+                imageLoader.logger,
+                imageLoader.options.observeDefaultNetwork)
         } else {
             EmptyNetworkObserver()
         }


### PR DESCRIPTION
Hi,

As per the discussion in #2374 and #2379 - I have added `observeDefaultNetwork` to ImageLoader via ImageLoaderOptions.

I have run ./test.sh but received two failures on the connected tests - I also get these same failures if I run ./test.sh on the 2.x branch with no changes - maybe I needed to use a specific emulator?

```
> Task :coil-compose-base:connectedDebugAndroidTest

coil.compose.AsyncImageTest > fillMaxWidth_infiniteConstraint[Pixel_Fold_API_35(AVD) - 15] FAILED 
        java.lang.IllegalStateException: The images are not visually similar. Expected: 0.9; Actual: 0.0025799457433266612.
        at coil.util.BitmapsKt.assertIsSimilarTo(Bitmaps.kt:114)

Pixel_Fold_API_35(AVD) - 15 Tests 29/41 completed. (0 skipped) (2 failed)

> Task :coil-compose-base:connectedDebugAndroidTest

coil.compose.AsyncImageTest > fillMaxWidth_boundedConstraint[Pixel_Fold_API_35(AVD) - 15] FAILED 
        java.lang.AssertionError: Actual height is 640.7619.dp, expected 1089.1428.dp (tolerance: 0.5.dp)
        at coil.compose.utils.UtilsKt.assertIsEqualTo-cWfXhoU(Utils.kt:116)
```

Please let me know if there's anything further I can refactor or improve 🙇‍♀️ 

Thank you,
