### PR TITLE
Fix some broken links in docs

### DIFF
--- a/coil-gif/README.md
+++ b/coil-gif/README.md
@@ -24,7 +24,7 @@ val imageLoader = ImageLoader.Builder(context)
 
 And that's it! The `ImageLoader` will automatically detect any GIFs using their file headers and decode them correctly.
 
-To transform the pixel data of each frame of a GIF, see [AnimatedTransformation](/coil/api/coil-gif/coil3.transform/-animated-transformation).
+To transform the pixel data of each frame of a GIF, see [AnimatedTransformation](/coil/api/coil-gif/coil3.gif/-animated-transformation).
 
 !!! Note
     Coil includes two separate decoders to support decoding GIFs. `GifDecoder` supports all API levels, but is slower. `ImageDecoderDecoder` is powered by Android's [ImageDecoder](https://developer.android.com/reference/android/graphics/ImageDecoder) API which is only available on API 28 and above. `ImageDecoderDecoder` is faster than `GifDecoder` and supports decoding animated WebP images and animated HEIF image sequences.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -41,7 +41,7 @@ val imageLoader = ImageLoader.Builder(context)
 ```
 
 !!! Note
-    If you already have a built `OkHttpClient`, use [`newBuilder()`](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#customize-your-client-with-newbuilder) to build a new client that shares resources with the original.
+    If you already have a built `OkHttpClient`, use [`newBuilder()`](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/#customize-your-client-with-newbuilder) to build a new client that shares resources with the original.
 
 #### Headers
 

--- a/docs/transformations.md
+++ b/docs/transformations.md
@@ -4,7 +4,7 @@ Transformations allow you to modify the pixel data of an image before the `Drawa
 
 By default, Coil comes packaged with 2 transformations: [circle crop](/coil/api/coil-core/coil3.transform/-circle-crop-transformation/) and [rounded corners](/coil/api/coil-core/coil3.transform/-rounded-corners-transformation/).
 
-Transformations only modify the pixel data for static images. Adding a transformation to an `ImageRequest` that produces an animated image will convert it to a static image so the transformation can be applied. To transform the pixel data of each frame of an animated image, see [AnimatedTransformation](/coil/api/coil-gif/coil3.transform/-animated-transformation/).
+Transformations only modify the pixel data for static images. Adding a transformation to an `ImageRequest` that produces an animated image will convert it to a static image so the transformation can be applied. To transform the pixel data of each frame of an animated image, see [AnimatedTransformation](/coil/api/coil-gif/coil3.gif/-animated-transformation/).
 
 Custom transformations should implement `equals` and `hashCode` to ensure that two `ImageRequest`s with the same properties and using the same transformation are equal.
 

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -9,6 +9,6 @@ By default, Coil comes packaged with 2 transitions:
 - [`CrossfadeTransition.Factory`](/coil/api/coil-core/coil3.transition/-crossfade-transition/) which crossfades from the current drawable to the success/error drawable.
 - [`Transition.Factory.NONE`](/coil/api/coil-core/coil3.transition/-transition/-factory/-companion/-n-o-n-e) which sets the drawable on the `Target` immediately without animating.
 
-Take a look at the [`CrossfadeTransition` source code](https://github.com/coil-kt/coil/blob/main/coil-core/src/main/java/coil/transition/CrossfadeTransition.kt) for an example of how to write a custom `Transition`.
+Take a look at the [`CrossfadeTransition` source code](https://github.com/coil-kt/coil/blob/main/coil-core/src/androidMain/kotlin/coil3/transition/CrossfadeTransition.kt) for an example of how to write a custom `Transition`.
 
 See the [API documentation](/coil/api/coil-core/coil3.transition/-transition/) for more information.

--- a/docs/upgrading_to_coil3.md
+++ b/docs/upgrading_to_coil3.md
@@ -54,7 +54,7 @@ implementation("io.coil-kt.coil3:coil-network-ktor2:[coil-version]")
 implementation("io.ktor:ktor-client-android:[ktor-version]")
 ```
 
-Check out the [`samples`](https://github.com/coil-kt/coil/tree/3.x/samples/compose) repository for examples.
+Check out the [`samples`](https://github.com/coil-kt/coil/tree/main/samples/compose) repository for examples.
 
 **IMPORTANT**: `Cache-Control` header support is no longer enabled by default. In subsequent alphas, it will be possible to re-enable it, but it will be opt-in. `NetworkFetcher.Factory` now also supports custom `CacheStrategy` implementations to allow custom cache resolution behaviour.
 


### PR DESCRIPTION
Some 404 links I found in the docs

There are also some in the changelogs like to `Precision.kt` for [0.9.0](https://github.com/coil-kt/coil/blob/main/CHANGELOG.md#090---december-30-2019). Not sure if it makes sense to retroactively change a changelog