### PR TITLE
Don't manually close ImageDecoder.

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -33,9 +33,8 @@ internal class StaticImageDecoder(
 ) : Decoder {
 
     override suspend fun decode() = parallelismLock.withPermit {
-        var isSampled = false
-
-        try {
+        closeable.use {
+            var isSampled = false
             val bitmap = source.decodeBitmap { info, _ ->
                 // Configure the output image's size.
                 val (srcWidth, srcHeight) = info.size
@@ -69,12 +68,10 @@ internal class StaticImageDecoder(
                 // Configure any other attributes.
                 configureImageDecoderProperties()
             }
-            DecodeResult(
+            return@withPermit DecodeResult(
                 image = bitmap.asImage(),
                 isSampled = isSampled,
             )
-        } finally {
-            closeable.close()
         }
     }
 

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -34,6 +34,7 @@ internal class StaticImageDecoder(
 
     override suspend fun decode() = parallelismLock.withPermit {
         var isSampled = false
+
         try {
             val bitmap = source.decodeBitmap { info, _ ->
                 // Configure the output image's size.

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -46,7 +46,8 @@ internal class StaticImageDecoder(
                     maxSize = options.maxBitmapSize,
                 )
                 if (srcWidth > 0 && srcHeight > 0 &&
-                    (srcWidth != dstWidth || srcHeight != dstHeight)) {
+                    (srcWidth != dstWidth || srcHeight != dstHeight)
+                ) {
                     val multiplier = DecodeUtils.computeSizeMultiplier(
                         srcWidth = srcWidth,
                         srcHeight = srcHeight,

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -34,12 +34,8 @@ internal class StaticImageDecoder(
 
     override suspend fun decode() = parallelismLock.withPermit {
         var isSampled = false
-        var imageDecoder: ImageDecoder? = null
         try {
             val bitmap = source.decodeBitmap { info, _ ->
-                // Capture the image decoder to manually close it later.
-                imageDecoder = this
-
                 // Configure the output image's size.
                 val (srcWidth, srcHeight) = info.size
                 val (dstWidth, dstHeight) = DecodeUtils.computeDstSize(
@@ -77,7 +73,6 @@ internal class StaticImageDecoder(
                 isSampled = isSampled,
             )
         } finally {
-            imageDecoder?.close()
             closeable.close()
         }
     }

--- a/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
+++ b/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
@@ -60,13 +60,9 @@ class AnimatedImageDecoder(
     override suspend fun decode(): DecodeResult {
         var isSampled = false
         val drawable = runInterruptible {
-            var imageDecoder: ImageDecoder? = null
             val source = maybeWrapImageSourceToRewriteFrameDelay(source, enforceMinimumFrameDelay)
-            try {
+            source.use {
                 source.toImageDecoderSource().decodeDrawable { info, _ ->
-                    // Capture the image decoder to manually close it later.
-                    imageDecoder = this
-
                     // Configure the output image's size.
                     val (srcWidth, srcHeight) = info.size
                     val (dstWidth, dstHeight) = DecodeUtils.computeDstSize(
@@ -99,9 +95,6 @@ class AnimatedImageDecoder(
                     // Configure any other attributes.
                     configureImageDecoderProperties()
                 }
-            } finally {
-                imageDecoder?.close()
-                source.close()
             }
         }
         return DecodeResult(

--- a/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
+++ b/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
@@ -72,7 +72,8 @@ class AnimatedImageDecoder(
                         maxSize = options.maxBitmapSize,
                     )
                     if (srcWidth > 0 && srcHeight > 0 &&
-                        (srcWidth != dstWidth || srcHeight != dstHeight)) {
+                        (srcWidth != dstWidth || srcHeight != dstHeight)
+                    ) {
                         val multiplier = DecodeUtils.computeSizeMultiplier(
                             srcWidth = srcWidth,
                             srcHeight = srcHeight,

--- a/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
+++ b/coil-gif/src/main/java/coil3/gif/AnimatedImageDecoder.kt
@@ -60,8 +60,7 @@ class AnimatedImageDecoder(
     override suspend fun decode(): DecodeResult {
         var isSampled = false
         val drawable = runInterruptible {
-            val source = maybeWrapImageSourceToRewriteFrameDelay(source, enforceMinimumFrameDelay)
-            source.use {
+            maybeWrapImageSourceToRewriteFrameDelay(source, enforceMinimumFrameDelay).use { source ->
                 source.toImageDecoderSource().decodeDrawable { info, _ ->
                     // Configure the output image's size.
                     val (srcWidth, srcHeight) = info.size
@@ -117,7 +116,7 @@ class AnimatedImageDecoder(
         }
         if (metadata is ContentMetadata) {
             return if (SDK_INT >= 29) {
-                // ImageDecoder will seek inner fd to startOffset
+                // ImageDecoder will seek inner fd to startOffset.
                 ImageDecoder.createSource { metadata.assetFileDescriptor }
             } else {
                 ImageDecoder.createSource(options.context.contentResolver, metadata.uri.toAndroidUri())


### PR DESCRIPTION
This is explicitly recommended against by the `ImageDecoder.close` method documentation.