### PR TITLE
Config nullability

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/util/bitmaps.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/util/bitmaps.kt
@@ -44,10 +44,7 @@ val Bitmap.Config.isHardware: Boolean
 
 /**
  * Guard against null bitmap configs.
- *
- * Don't believe the nullability annotation: [Bitmap.getConfig] is null for static GIF images.
  */
-@Suppress("USELESS_ELVIS")
 internal val Bitmap.safeConfig: Bitmap.Config
     get() = config ?: Bitmap.Config.ARGB_8888
 


### PR DESCRIPTION
With API 35, the nullability of config was fixed, so we can remove this elvis suppression and comment!