### PR TITLE
Fix AsyncImage not rendering when parent composable uses IntrinsicSize.

### DIFF
--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -793,6 +794,66 @@ class AsyncImageTest {
         assertEquals(2, onStartCount.get())
     }
 
+    /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
+    @Test
+    fun minIntrinsicSize() {
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .width(IntrinsicSize.Min)
+                    .height(IntrinsicSize.Min),
+            ) {
+                AsyncImage(
+                    model = "https://example.com/image",
+                    contentDescription = null,
+                    imageLoader = imageLoader,
+                    modifier = Modifier
+                        .testTag(Image),
+                )
+            }
+        }
+
+        waitForRequestComplete()
+        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(SampleWidth.toDp())
+            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
+    /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
+    @Test
+    fun maxIntrinsicSize() {
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .width(IntrinsicSize.Max)
+                    .height(IntrinsicSize.Max),
+            ) {
+                AsyncImage(
+                    model = "https://example.com/image",
+                    contentDescription = null,
+                    imageLoader = imageLoader,
+                    modifier = Modifier
+                        .testTag(Image),
+                )
+            }
+        }
+
+        waitForRequestComplete()
+        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(SampleWidth.toDp())
+            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
     private fun waitForRequestComplete(finishedRequests: Int = 1) = waitUntil {
         requestTracker.finishedRequests >= finishedRequests
     }
@@ -832,7 +893,9 @@ class AsyncImageTest {
 
     private fun Dp.toPx() = with(composeTestRule.density) { toPx().toInt() }
 
-    private fun Double.toDp() = with(composeTestRule.density) { toInt().toDp() }
+    private fun Int.toDp() = with(composeTestRule.density) { toDp() }
+
+    private fun Double.toDp() = toInt().toDp()
 
     private val displaySize: IntSize
         get() = composeTestRule.activity.findViewById<View>(android.R.id.content)!!

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -798,6 +798,8 @@ class AsyncImageTest {
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun minIntrinsicSize() {
+        assumeSupportsCaptureToImage()
+
         val dstWidth = 100.dp
         val dstHeight = 150.dp
 
@@ -839,6 +841,8 @@ class AsyncImageTest {
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun maxIntrinsicSize() {
+        assumeSupportsCaptureToImage()
+
         val dstWidth = 100.dp
         val dstHeight = 150.dp
 
@@ -880,6 +884,8 @@ class AsyncImageTest {
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun mixedIntrinsicSize() {
+        assumeSupportsCaptureToImage()
+
         val dstWidth = 100.dp
         val dstHeight = 150.dp
 

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -819,14 +819,14 @@ class AsyncImageTest {
         val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
         val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
 
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(expectedWidthPx.toDp())
             .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample)
+            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
@@ -854,14 +854,14 @@ class AsyncImageTest {
         val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
         val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
 
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(expectedWidthPx.toDp())
             .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample)
+            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
@@ -889,14 +889,14 @@ class AsyncImageTest {
         val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
         val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
 
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
             .assertWidthIsEqualTo(expectedWidthPx.toDp())
             .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample)
+            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
     }
 
     private fun waitForRequestComplete(finishedRequests: Int = 1) = waitUntil {

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -854,6 +854,36 @@ class AsyncImageTest {
             .assertIsSimilarTo(R.drawable.sample)
     }
 
+    /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
+    @Test
+    fun mixedIntrinsicSize() {
+        composeTestRule.setContent {
+            Box(
+                modifier = Modifier
+                    .width(IntrinsicSize.Max)
+                    .height(IntrinsicSize.Min),
+            ) {
+                AsyncImage(
+                    model = "https://example.com/image",
+                    contentDescription = null,
+                    imageLoader = imageLoader,
+                    modifier = Modifier
+                        .testTag(Image),
+                )
+            }
+        }
+
+        waitForRequestComplete()
+        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertIsDisplayed()
+            .assertWidthIsEqualTo(SampleWidth.toDp())
+            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .captureToImage()
+            .assertIsSimilarTo(R.drawable.sample)
+    }
+
     private fun waitForRequestComplete(finishedRequests: Int = 1) = waitUntil {
         requestTracker.finishedRequests >= finishedRequests
     }

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -807,6 +807,7 @@ class AsyncImageTest {
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
+                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )
@@ -841,6 +842,7 @@ class AsyncImageTest {
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
+                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )
@@ -875,6 +877,7 @@ class AsyncImageTest {
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
+                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
@@ -115,7 +116,7 @@ class AsyncImageTest {
 
         waitForRequestComplete()
 
-        assertLoadedBitmapSize(128.dp.toPx(), 166.dp.toPx())
+        assertLoadedBitmapSize(128.dp.toPx().toInt(), 166.dp.toPx().toInt())
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
@@ -797,17 +798,20 @@ class AsyncImageTest {
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun minIntrinsicSize() {
+        val dstWidth = 100.dp
+        val dstHeight = 150.dp
+
         composeTestRule.setContent {
             Box(
                 modifier = Modifier
                     .width(IntrinsicSize.Min)
-                    .height(IntrinsicSize.Min),
+                    .height(IntrinsicSize.Min)
+                    .sizeIn(maxWidth = dstWidth, maxHeight = dstHeight),
             ) {
                 AsyncImage(
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
-                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )
@@ -816,33 +820,39 @@ class AsyncImageTest {
 
         waitForRequestComplete()
 
-        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
-        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
-
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
+        val scale = DecodeUtils.computeSizeMultiplier(
+            srcWidth = SampleWidth.toFloat(),
+            srcHeight = SampleHeight.toFloat(),
+            dstWidth = dstWidth.toPx(),
+            dstHeight = dstHeight.toPx(),
+            scale = Scale.FIT,
+        ).coerceAtMost(1f)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(expectedWidthPx.toDp())
-            .assertHeightIsEqualTo(expectedHeightPx.toDp())
+            .assertWidthIsEqualTo((scale * SampleWidth).toDp())
+            .assertHeightIsEqualTo((scale * SampleHeight).toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
+            .assertIsSimilarTo(R.drawable.sample)
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun maxIntrinsicSize() {
+        val dstWidth = 100.dp
+        val dstHeight = 150.dp
+
         composeTestRule.setContent {
             Box(
                 modifier = Modifier
                     .width(IntrinsicSize.Max)
-                    .height(IntrinsicSize.Max),
+                    .height(IntrinsicSize.Max)
+                    .sizeIn(maxWidth = dstWidth, maxHeight = dstHeight),
             ) {
                 AsyncImage(
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
-                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )
@@ -851,33 +861,39 @@ class AsyncImageTest {
 
         waitForRequestComplete()
 
-        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
-        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
-
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
+        val scale = DecodeUtils.computeSizeMultiplier(
+            srcWidth = SampleWidth.toFloat(),
+            srcHeight = SampleHeight.toFloat(),
+            dstWidth = dstWidth.toPx(),
+            dstHeight = dstHeight.toPx(),
+            scale = Scale.FIT,
+        ).coerceAtMost(1f)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(expectedWidthPx.toDp())
-            .assertHeightIsEqualTo(expectedHeightPx.toDp())
+            .assertWidthIsEqualTo((scale * SampleWidth).toDp())
+            .assertHeightIsEqualTo((scale * SampleHeight).toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
+            .assertIsSimilarTo(R.drawable.sample)
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/2573 */
     @Test
     fun mixedIntrinsicSize() {
+        val dstWidth = 100.dp
+        val dstHeight = 150.dp
+
         composeTestRule.setContent {
             Box(
                 modifier = Modifier
                     .width(IntrinsicSize.Max)
-                    .height(IntrinsicSize.Min),
+                    .height(IntrinsicSize.Min)
+                    .sizeIn(maxWidth = dstWidth, maxHeight = dstHeight),
             ) {
                 AsyncImage(
                     model = "https://example.com/image",
                     contentDescription = null,
                     imageLoader = imageLoader,
-                    contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .testTag(Image),
                 )
@@ -886,17 +902,20 @@ class AsyncImageTest {
 
         waitForRequestComplete()
 
-        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
-        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
-
-        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx, scale = Scale.FILL)
+        val scale = DecodeUtils.computeSizeMultiplier(
+            srcWidth = SampleWidth.toFloat(),
+            srcHeight = SampleHeight.toFloat(),
+            dstWidth = dstWidth.toPx(),
+            dstHeight = dstHeight.toPx(),
+            scale = Scale.FIT,
+        ).coerceAtMost(1f)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(expectedWidthPx.toDp())
-            .assertHeightIsEqualTo(expectedHeightPx.toDp())
+            .assertWidthIsEqualTo((scale * SampleWidth).toDp())
+            .assertHeightIsEqualTo((scale * SampleHeight).toDp())
             .captureToImage()
-            .assertIsSimilarTo(R.drawable.sample, scale = Scale.FILL)
+            .assertIsSimilarTo(R.drawable.sample)
     }
 
     private fun waitForRequestComplete(finishedRequests: Int = 1) = waitUntil {
@@ -936,11 +955,13 @@ class AsyncImageTest {
         )
     }
 
-    private fun Dp.toPx() = with(composeTestRule.density) { toPx().toInt() }
+    private fun Dp.toPx() = with(composeTestRule.density) { toPx() }
 
     private fun Int.toDp() = with(composeTestRule.density) { toDp() }
 
-    private fun Double.toDp() = toInt().toDp()
+    private fun Float.toDp() = with(composeTestRule.density) { toDp() }
+
+    private fun Double.toDp() = with(composeTestRule.density) { toFloat().toDp() }
 
     private val displaySize: IntSize
         get() = composeTestRule.activity.findViewById<View>(android.R.id.content)!!

--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -814,12 +814,16 @@ class AsyncImageTest {
         }
 
         waitForRequestComplete()
-        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
+        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
+
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(SampleWidth.toDp())
-            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .assertWidthIsEqualTo(expectedWidthPx.toDp())
+            .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
             .assertIsSimilarTo(R.drawable.sample)
     }
@@ -844,12 +848,16 @@ class AsyncImageTest {
         }
 
         waitForRequestComplete()
-        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
+        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
+
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(SampleWidth.toDp())
-            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .assertWidthIsEqualTo(expectedWidthPx.toDp())
+            .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
             .assertIsSimilarTo(R.drawable.sample)
     }
@@ -874,12 +882,16 @@ class AsyncImageTest {
         }
 
         waitForRequestComplete()
-        assertLoadedBitmapSize(SampleWidth, SampleHeight)
+
+        val expectedWidthPx = displaySize.width.toDouble().coerceAtMost(SampleWidth.toDouble())
+        val expectedHeightPx = expectedWidthPx * SampleHeight / SampleWidth
+
+        assertSampleLoadedBitmapSize(expectedWidthPx, expectedHeightPx)
 
         composeTestRule.onNodeWithTag(Image)
             .assertIsDisplayed()
-            .assertWidthIsEqualTo(SampleWidth.toDp())
-            .assertHeightIsEqualTo(SampleHeight.toDp())
+            .assertWidthIsEqualTo(expectedWidthPx.toDp())
+            .assertHeightIsEqualTo(expectedHeightPx.toDp())
             .captureToImage()
             .assertIsSimilarTo(R.drawable.sample)
     }

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/DrawScopeSizeResolver.kt
@@ -3,7 +3,7 @@ package coil3.compose
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import coil3.annotation.ExperimentalCoilApi
-import coil3.compose.internal.toCoilSizeOrNull
+import coil3.compose.internal.toSizeOrNull
 import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
 import kotlin.js.JsName
@@ -30,20 +30,20 @@ interface DrawScopeSizeResolver : SizeResolver {
 }
 
 private class RealDrawScopeSizeResolver : DrawScopeSizeResolver {
-    private val sizes = MutableSharedFlow<Flow<Size>>(
+    private val latestSize = MutableSharedFlow<Flow<Size>>(
         replay = 1,
         onBufferOverflow = DROP_OLDEST,
     )
 
     override fun connect(sizes: Flow<Size>) {
-        this.sizes.tryEmit(sizes)
+        latestSize.tryEmit(sizes)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override suspend fun size(): CoilSize {
-        return sizes
+        return latestSize
             .transformLatest { emitAll(it) }
-            .mapNotNull { it.toCoilSizeOrNull() }
+            .mapNotNull { it.toSizeOrNull() }
             .first()
     }
 }

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import coil3.compose.AsyncImage
 import coil3.compose.SubcomposeAsyncImage
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 /**
@@ -104,10 +105,9 @@ internal class ContentPainterNode(
         height: Int,
     ): Int {
         return if (painter.intrinsicSize.isSpecified) {
-            val constraints = Constraints(maxHeight = height)
-            val layoutWidth = measurable.minIntrinsicWidth(modifyConstraints(constraints).maxHeight)
-            val scaledSize = calculateScaledSize(Size(layoutWidth.toFloat(), height.toFloat()))
-            maxOf(scaledSize.width.roundToInt(), layoutWidth)
+            val constraints = modifyConstraints(Constraints(maxHeight = height))
+            val layoutWidth = measurable.minIntrinsicWidth(height)
+            max(constraints.minWidth, layoutWidth)
         } else {
             measurable.minIntrinsicWidth(height)
         }
@@ -118,10 +118,9 @@ internal class ContentPainterNode(
         height: Int,
     ): Int {
         return if (painter.intrinsicSize.isSpecified) {
-            val constraints = Constraints(maxHeight = height)
-            val layoutWidth = measurable.maxIntrinsicWidth(modifyConstraints(constraints).maxHeight)
-            val scaledSize = calculateScaledSize(Size(layoutWidth.toFloat(), height.toFloat()))
-            maxOf(scaledSize.width.roundToInt(), layoutWidth)
+            val constraints = modifyConstraints(Constraints(maxHeight = height))
+            val layoutWidth = measurable.maxIntrinsicWidth(height)
+            max(constraints.minWidth, layoutWidth)
         } else {
             measurable.maxIntrinsicWidth(height)
         }
@@ -132,11 +131,9 @@ internal class ContentPainterNode(
         width: Int,
     ): Int {
         return if (painter.intrinsicSize.isSpecified) {
-            val constraints = Constraints(maxWidth = width)
-            val layoutHeight =
-                measurable.minIntrinsicHeight(modifyConstraints(constraints).maxWidth)
-            val scaledSize = calculateScaledSize(Size(width.toFloat(), layoutHeight.toFloat()))
-            maxOf(scaledSize.height.roundToInt(), layoutHeight)
+            val constraints = modifyConstraints(Constraints(maxWidth = width))
+            val layoutHeight = measurable.minIntrinsicHeight(width)
+            max(constraints.minHeight, layoutHeight)
         } else {
             measurable.minIntrinsicHeight(width)
         }
@@ -147,11 +144,9 @@ internal class ContentPainterNode(
         width: Int,
     ): Int {
         return if (painter.intrinsicSize.isSpecified) {
-            val constraints = Constraints(maxWidth = width)
-            val layoutHeight =
-                measurable.maxIntrinsicHeight(modifyConstraints(constraints).maxWidth)
-            val scaledSize = calculateScaledSize(Size(width.toFloat(), layoutHeight.toFloat()))
-            maxOf(scaledSize.height.roundToInt(), layoutHeight)
+            val constraints = modifyConstraints(Constraints(maxWidth = width))
+            val layoutHeight = measurable.maxIntrinsicHeight(width)
+            max(constraints.minHeight, layoutHeight)
         } else {
             measurable.maxIntrinsicHeight(width)
         }

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
@@ -170,14 +170,22 @@ internal fun ContentScale.toScale() = when (this) {
 
 @Stable
 internal fun Constraints.toSize(): CoilSize {
-    val width = if (hasBoundedWidth) Dimension(maxWidth) else Dimension.Undefined
-    val height = if (hasBoundedHeight) Dimension(maxHeight) else Dimension.Undefined
-    return CoilSize(width, height)
+    return CoilSize(maxWidth.toDimension(), maxHeight.toDimension())
 }
 
 @Stable
-internal fun Constraints.toSizeOrNull(): CoilSize? {
-    return if (isZero) null else toSize()
+internal fun Size.toSizeOrNull() = when {
+    isUnspecified -> CoilSize.ORIGINAL
+    isPositive -> CoilSize(width.toDimension(), height.toDimension())
+    else -> null
+}
+
+private fun Int.toDimension(): Dimension {
+    return if (this != Int.MAX_VALUE) Dimension(this) else Dimension.Undefined
+}
+
+private fun Float.toDimension(): Dimension {
+    return if (isFinite()) Dimension(roundToInt()) else Dimension.Undefined
 }
 
 internal fun Constraints.constrainWidth(width: Float) =
@@ -185,15 +193,6 @@ internal fun Constraints.constrainWidth(width: Float) =
 
 internal fun Constraints.constrainHeight(height: Float) =
     height.coerceIn(minHeight.toFloat(), maxHeight.toFloat())
-
-internal fun Size.toCoilSizeOrNull() = when {
-    isUnspecified -> CoilSize.ORIGINAL
-    isPositive -> CoilSize(
-        width = if (width.isFinite()) Dimension(width.roundToInt()) else Dimension.Undefined,
-        height = if (height.isFinite()) Dimension(height.roundToInt()) else Dimension.Undefined,
-    )
-    else -> null
-}
 
 internal inline fun Float.takeOrElse(block: () -> Float) = if (isFinite()) this else block()
 


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/2573