### PR TITLE
Don't fill the available space in AsyncImage when the painter has no child painter.

### DIFF
--- a/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
+++ b/coil-compose-core/src/androidInstrumentedTest/kotlin/coil3/compose/AsyncImageTest.kt
@@ -1019,6 +1019,33 @@ class AsyncImageTest {
         assertEquals(1, requestTracker.finishedRequests)
     }
 
+    @Test
+    fun zeroHeightWhenAsyncImageIsEmpty() {
+        composeTestRule.setContent {
+            Column(Modifier.fillMaxSize()) {
+                AsyncImage(
+                    model = ImageRequest.Builder(context)
+                        .data(Unit)
+                        // Skip waiting for the constraints which will always be empty.
+                        .size(100)
+                        .build(),
+                    contentDescription = null,
+                    imageLoader = imageLoader,
+                    contentScale = ContentScale.FillWidth,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(Image),
+                )
+            }
+        }
+
+        waitForRequestComplete()
+
+        composeTestRule.onNodeWithTag(Image)
+            .assertWidthIsEqualTo(context.resources.displayMetrics.widthPixels.toDp())
+            .assertHeightIsEqualTo(0.dp)
+    }
+
     private fun waitForRequestComplete(finishedRequests: Int = 1) = waitUntil {
         requestTracker.finishedRequests >= finishedRequests
     }

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
@@ -182,18 +182,11 @@ internal class ContentPainterNode(
             return constraints
         }
 
-        // Fill the available space if the painter has no intrinsic size.
-        val hasBoundedSize = constraints.hasBoundedWidth && constraints.hasBoundedHeight
+        // Changed from `PainterModifier`:
+        // The painter has no intrinsic size so we can't support scaling.
         val intrinsicSize = painter.intrinsicSize
         if (intrinsicSize.isUnspecified) {
-            if (hasBoundedSize) {
-                return constraints.copy(
-                    minWidth = constraints.maxWidth,
-                    minHeight = constraints.maxHeight,
-                )
-            } else {
-                return constraints
-            }
+            return constraints
         }
 
         // Changed from `PainterModifier`:
@@ -201,7 +194,9 @@ internal class ContentPainterNode(
         // least one dimension is a fixed pixel value. Else, use the intrinsic size of the painter.
         val dstWidth: Float
         val dstHeight: Float
-        if (hasBoundedSize && (hasFixedWidth || hasFixedHeight)) {
+        if ((hasFixedWidth || hasFixedHeight) &&
+            (constraints.hasBoundedWidth && constraints.hasBoundedHeight)
+        ) {
             dstWidth = constraints.maxWidth.toFloat()
             dstHeight = constraints.maxHeight.toFloat()
         } else {


### PR DESCRIPTION
Resolves: https://github.com/coil-kt/coil/issues/2349