### PR TITLE
Revert "fix(deps): update dependency org.jetbrains.compose:compose-gradle-plugin to v1.7.0 (#2554)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,15 +161,6 @@ allprojects {
         }
     }
 
-    // https://youtrack.jetbrains.com/issue/CMP-5831
-    configurations.all {
-        resolutionStrategy.eachDependency {
-            if (requested.group == "org.jetbrains.kotlinx" && requested.name == "atomicfu") {
-                useVersion(libs.versions.atomicfu.get())
-            }
-        }
-    }
-
     applyOkioJsTestWorkaround()
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ androidx-tracing-perfetto = "1.0.0"
 androidx-runtime-tracing = "1.7.4"
 atomicfu = "0.26.0"
 coroutines = "1.9.0"
-jetbrains-compose = "1.7.0"
+jetbrains-compose = "1.6.11"
 kotlin = "2.0.21"
 ktlint = "1.3.1"
 ktor2 = "2.3.12"
@@ -15,7 +15,7 @@ okhttp = "4.12.0"
 okio = "3.9.1"
 paparazzi = "1.3.4"
 roborazzi = "1.29.0"
-skiko = "0.8.15"
+skiko = "0.8.4"
 
 [plugins]
 baselineProfile = { id = "androidx.baselineprofile", version.ref = "androidx-benchmark" }
@@ -27,7 +27,7 @@ spotless = "com.diffplug.spotless:6.25.0"
 
 [libraries]
 gradlePlugin-android = "com.android.tools.build:gradle:8.7.1"
-gradlePlugin-atomicFu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
+gradlePlugin-atomicFu = "org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.25.0"
 gradlePlugin-jetbrainsCompose = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jetbrains-compose" }
 gradlePlugin-composeCompiler = { module = "org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin", version.ref = "kotlin" }
 gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/internal/test-utils/src/jvmCommonMain/kotlin/coil3/test/utils/AbstractSvgDecoderTest.kt
+++ b/internal/test-utils/src/jvmCommonMain/kotlin/coil3/test/utils/AbstractSvgDecoderTest.kt
@@ -108,7 +108,7 @@ abstract class AbstractSvgDecoderTest(
         assertTrue(result.isSampled)
 
         val expected = decodeBitmapResource("instacart_logo.png")
-        result.image.toBitmap().assertIsSimilarTo(expected, threshold = 0.95)
+        result.image.toBitmap().assertIsSimilarTo(expected)
     }
 
     /** Regression test: https://github.com/coil-kt/coil/issues/1246 */


### PR DESCRIPTION
This reverts commit 3e1ef17c1bbe2c82ea1bb20f96693de15b4b69be.

We should wait until 3.1 to ship a big update like this.