### PR TITLE
Pass throwable to logger when logging errors

### DIFF
--- a/coil-core/src/commonMain/kotlin/coil3/RealImageLoader.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/RealImageLoader.kt
@@ -200,9 +200,12 @@ internal class RealImageLoader(
         eventListener: EventListener,
     ) {
         val request = result.request
-        options.logger?.log(TAG, Logger.Level.Info) {
-            "🚨 Failed - ${request.data} - ${result.throwable}"
-        }
+        options.logger?.log(
+            TAG, 
+            Logger.Level.Error,
+            "🚨 Failed - ${request.data} - ${result.throwable}",
+            throwable,
+        )
         transition(result, target, eventListener) {
             target?.onError(result.image)
         }


### PR DESCRIPTION
When an image fails to load, a registered Logger should receive the throwable describing what happened. Unfortunately, RealImageLoader's implementation does not do this, so as far as I can tell there is no reason a  logger would ever be called with a non-null throwable argument.

This is a quick and dirty proof of concept of what a fix might look like. I suspect the string was previously generaetd in a lambda to avoid generating the string in cases where it won't actually be used (a performance benefit), and this PR as currently implemented loses that benefit. I would also add an extension function that both lambdifies the string and doesn't lose the throwable before merging this.