### PR TITLE
Fix AsyncImageModelEqualityDelegate.Default comparing equality for non-ImageRequest models.

### DIFF
--- a/coil-compose-core/build.gradle.kts
+++ b/coil-compose-core/build.gradle.kts
@@ -22,6 +22,12 @@ kotlin {
                 api(compose.foundation)
             }
         }
+        commonTest {
+            dependencies {
+                implementation(projects.internal.testUtils)
+                implementation(libs.kotlin.test)
+            }
+        }
         androidMain {
             dependencies {
                 implementation(libs.google.drawablepainter)

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/LocalAsyncImageModelEqualityDelegate.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/LocalAsyncImageModelEqualityDelegate.kt
@@ -33,8 +33,8 @@ interface AsyncImageModelEqualityDelegate {
 
             override fun equals(self: Any?, other: Any?): Boolean {
                 if (this === other) return true
-                return self is ImageRequest &&
-                    other is ImageRequest &&
+                if (self !is ImageRequest || other !is ImageRequest) return self == other
+                return self.context == other.context &&
                     self.context == other.context &&
                     self.data == other.data &&
                     self.memoryCacheKey == other.memoryCacheKey &&

--- a/coil-compose-core/src/commonTest/kotlin/coil3/compose/AsyncImageModelEqualityDelegateTest.kt
+++ b/coil-compose-core/src/commonTest/kotlin/coil3/compose/AsyncImageModelEqualityDelegateTest.kt
@@ -1,0 +1,54 @@
+package coil3.compose
+
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.test.utils.context
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AsyncImageModelEqualityDelegateTest {
+    private val equalityDelegate = AsyncImageModelEqualityDelegate.Default
+
+    @Test
+    fun string_Equals() {
+        val model1 = "https://example.com/image.jpg"
+        val model2 = "https://example.com/image.jpg"
+        assertTrue { equalityDelegate.equals(model1, model2) }
+    }
+
+    @Test
+    fun string_NotEquals() {
+        val model1 = "https://example.com/image.jpg"
+        val model2 = "https://example.com/other_image.jpg"
+        assertFalse { equalityDelegate.equals(model1, model2) }
+    }
+
+    @Test
+    fun ImageRequest_Equals() {
+        val request1 = ImageRequest.Builder(context)
+            .data("https://example.com/image.jpg")
+            .crossfade(true)
+            .build()
+        val request2 = ImageRequest.Builder(context)
+            .data("https://example.com/image.jpg")
+            .crossfade(false)
+            .build()
+        assertTrue { equalityDelegate.equals(request1, request2) }
+    }
+
+    @Test
+    fun ImageRequest_NotEquals() {
+        val request1 = ImageRequest.Builder(context)
+            .data("https://example.com/image.jpg")
+            .memoryCacheKey("one")
+            .crossfade(true)
+            .build()
+        val request2 = ImageRequest.Builder(context)
+            .data("https://example.com/image.jpg")
+            .memoryCacheKey("two")
+            .crossfade(false)
+            .build()
+        assertFalse { equalityDelegate.equals(request1, request2) }
+    }
+}

--- a/coil-compose-core/src/commonTest/kotlin/coil3/compose/AsyncImageModelEqualityDelegateTest.kt
+++ b/coil-compose-core/src/commonTest/kotlin/coil3/compose/AsyncImageModelEqualityDelegateTest.kt
@@ -2,12 +2,13 @@ package coil3.compose
 
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class AsyncImageModelEqualityDelegateTest {
+class AsyncImageModelEqualityDelegateTest : RobolectricTest() {
     private val equalityDelegate = AsyncImageModelEqualityDelegate.Default
 
     @Test


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/2640
