### PR TITLE
StaticImageDecoder ignores partial image by default

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -75,7 +75,7 @@ class StaticImageDecoder(
                 // Configure any other attributes.
                 configureImageDecoderProperties()
             }
-            return@withPermit DecodeResult(
+            DecodeResult(
                 image = bitmap.asImage(),
                 isSampled = isSampled,
             )
@@ -83,6 +83,7 @@ class StaticImageDecoder(
     }
 
     private fun ImageDecoder.configureImageDecoderProperties() {
+        onPartialImageListener = ImageDecoder.OnPartialImageListener { true }
         allocator = if (options.bitmapConfig.isHardware) {
             ImageDecoder.ALLOCATOR_HARDWARE
         } else {


### PR DESCRIPTION
to match BitmapFactoryDecoder behaviour
Close https://github.com/coil-kt/coil/issues/2612

