### PR TITLE
Corrected Korean Readme typos and made Korean more natural

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -1,4 +1,4 @@
-﻿![Coil](logo.svg)
+![Coil](logo.svg)
 
 [Android](https://www.android.com/) 및 [Compose Multiplatform](https://www.jetbrains.com/lp/compose-multiplatform/)을 위한 이미지 로딩 라이브러리입니다. Coil의 특징은 다음과 같습니다.
 
@@ -7,18 +7,18 @@
 - **사용하기 쉬움**: Coil의 API는 Kotlin의 언어 기능을 활용하여 단순성과 최소한의 보일러플레이트를 제공합니다.
 - **현대적**: Coil은 Kotlin을 우선으로 하며 Compose, Coroutines, Okio, OkHttp, Ktor를 포함한 최신 라이브러리와 상호 운용됩니다.
 
-코일은 **Co**routine **I**mage **L**oader**의 약자입니다.
+코일은 **Co**routine **I**mage **L**oader의 약자입니다.
 
 ## 빠른 시작
 
-Compose 라이브러리와 [네트워킹 라이브러리](https://coil-kt.github.io/coil/network/ 가져오기:
+Compose 라이브러리와 [네트워킹 라이브러리](https://coil-kt.github.io/coil/network/)를 불러오세요. :
 
 ```kotlin
-구현("io.coil-kt.coil3:coil-compose:3.0.3")
-구현("io.coil-kt.coil3:coil-network-okhttp:3.0.3")
+implementation("io.coil-kt.coil3:coil-compose:3.0.3")
+implementation("io.coil-kt.coil3:coil-network-okhttp:3.0.3")
 ```
 
-이미지를 로드하려면 `AsyncImage`를 사용하세요. 구성 가능:
+이미지를 로드하려면 `AsyncImage` Composable을 사용하세요. :
 
 ```kotlin
 AsyncImage(


### PR DESCRIPTION
## What's Changed
- Markdown was not applied correctly.
- The code in `build.gradle.kts` was also translated, but code should not be translated.
- Additionally, some Korean text was made more natural.