### PR TITLE
Pass Extras to NetworkClient via NetworkRequest

### DIFF
--- a/coil-network-core/api/android/coil-network-core.api
+++ b/coil-network-core/api/android/coil-network-core.api
@@ -111,12 +111,17 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;)Lcoil3/network/NetworkRequest;
 	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
+	public final fun getExtras ()Lcoil3/Extras;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;

--- a/coil-network-core/api/coil-network-core.klib.api
+++ b/coil-network-core/api/coil-network-core.klib.api
@@ -115,9 +115,12 @@ final class coil3.network/NetworkHeaders { // coil3.network/NetworkHeaders|null[
 
 final class coil3.network/NetworkRequest { // coil3.network/NetworkRequest|null[0]
     constructor <init>(kotlin/String, kotlin/String = ..., coil3.network/NetworkHeaders = ..., coil3.network/NetworkRequestBody? = ...) // coil3.network/NetworkRequest.<init>|<init>(kotlin.String;kotlin.String;coil3.network.NetworkHeaders;coil3.network.NetworkRequestBody?){}[0]
+    constructor <init>(kotlin/String, kotlin/String = ..., coil3.network/NetworkHeaders = ..., coil3.network/NetworkRequestBody? = ..., coil3/Extras = ...) // coil3.network/NetworkRequest.<init>|<init>(kotlin.String;kotlin.String;coil3.network.NetworkHeaders;coil3.network.NetworkRequestBody?;coil3.Extras){}[0]
 
     final val body // coil3.network/NetworkRequest.body|{}body[0]
         final fun <get-body>(): coil3.network/NetworkRequestBody? // coil3.network/NetworkRequest.body.<get-body>|<get-body>(){}[0]
+    final val extras // coil3.network/NetworkRequest.extras|{}extras[0]
+        final fun <get-extras>(): coil3/Extras // coil3.network/NetworkRequest.extras.<get-extras>|<get-extras>(){}[0]
     final val headers // coil3.network/NetworkRequest.headers|{}headers[0]
         final fun <get-headers>(): coil3.network/NetworkHeaders // coil3.network/NetworkRequest.headers.<get-headers>|<get-headers>(){}[0]
     final val method // coil3.network/NetworkRequest.method|{}method[0]
@@ -126,6 +129,7 @@ final class coil3.network/NetworkRequest { // coil3.network/NetworkRequest|null[
         final fun <get-url>(): kotlin/String // coil3.network/NetworkRequest.url.<get-url>|<get-url>(){}[0]
 
     final fun copy(kotlin/String = ..., kotlin/String = ..., coil3.network/NetworkHeaders = ..., coil3.network/NetworkRequestBody? = ...): coil3.network/NetworkRequest // coil3.network/NetworkRequest.copy|copy(kotlin.String;kotlin.String;coil3.network.NetworkHeaders;coil3.network.NetworkRequestBody?){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., coil3.network/NetworkHeaders = ..., coil3.network/NetworkRequestBody? = ..., coil3/Extras = ...): coil3.network/NetworkRequest // coil3.network/NetworkRequest.copy|copy(kotlin.String;kotlin.String;coil3.network.NetworkHeaders;coil3.network.NetworkRequestBody?;coil3.Extras){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // coil3.network/NetworkRequest.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // coil3.network/NetworkRequest.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // coil3.network/NetworkRequest.toString|toString(){}[0]

--- a/coil-network-core/api/jvm/coil-network-core.api
+++ b/coil-network-core/api/jvm/coil-network-core.api
@@ -111,12 +111,17 @@ public final class coil3/network/NetworkHeaders$Companion {
 }
 
 public final class coil3/network/NetworkRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final synthetic fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;)Lcoil3/network/NetworkRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;)Lcoil3/network/NetworkRequest;
 	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
+	public static synthetic fun copy$default (Lcoil3/network/NetworkRequest;Ljava/lang/String;Ljava/lang/String;Lcoil3/network/NetworkHeaders;Lcoil3/network/NetworkRequestBody;Lcoil3/Extras;ILjava/lang/Object;)Lcoil3/network/NetworkRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBody ()Lcoil3/network/NetworkRequestBody;
+	public final fun getExtras ()Lcoil3/Extras;
 	public final fun getHeaders ()Lcoil3/network/NetworkHeaders;
 	public final fun getMethod ()Ljava/lang/String;
 	public final fun getUrl ()Ljava/lang/String;

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkClient.kt
@@ -1,5 +1,6 @@
 package coil3.network
 
+import coil3.Extras
 import coil3.annotation.Poko
 import coil3.network.internal.HTTP_METHOD_GET
 import coil3.network.internal.HTTP_RESPONSE_OK
@@ -34,7 +35,31 @@ class NetworkRequest(
     val method: String = HTTP_METHOD_GET,
     val headers: NetworkHeaders = NetworkHeaders.EMPTY,
     val body: NetworkRequestBody? = null,
+    val extras: Extras = Extras.EMPTY,
 ) {
+    fun copy(
+        url: String = this.url,
+        method: String = this.method,
+        headers: NetworkHeaders = this.headers,
+        body: NetworkRequestBody? = this.body,
+        extras: Extras = this.extras,
+    ) = NetworkRequest(
+        url = url,
+        method = method,
+        headers = headers,
+        body = body,
+        extras = extras,
+    )
+
+    @Deprecated("Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
+    constructor(
+        url: String,
+        method: String = HTTP_METHOD_GET,
+        headers: NetworkHeaders = NetworkHeaders.EMPTY,
+        body: NetworkRequestBody? = null,
+    ) : this(url, method, headers, body)
+
+    @Deprecated("Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
     fun copy(
         url: String = this.url,
         method: String = this.method,
@@ -45,6 +70,7 @@ class NetworkRequest(
         method = method,
         headers = headers,
         body = body,
+        extras = this.extras,
     )
 }
 

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
@@ -184,6 +184,7 @@ class NetworkFetcher(
             method = options.httpMethod,
             headers = headers.build(),
             body = options.httpBody,
+            extras = options.extras,
         )
     }
 

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -49,7 +49,7 @@ class NetworkFetcherTest : RobolectricTest() {
 
         assertIs<SourceFetchResult>(result)
 
-        val expected = NetworkRequest(url, method, headers, body)
+        val expected = NetworkRequest(url, method, headers, body, options.extras)
 
         assertEquals(expected, networkClient.requests.single())
     }


### PR DESCRIPTION
With KTor client it is possible to use [onDownload](https://github.com/ktorio/ktor/blob/1ade60a8f9a04e9259acb483eadcb8574319da57/ktor-client/ktor-client-core/common/src/io/ktor/client/plugins/BodyProgress.kt#L78) method to listen on download progress without interceptors. However, this approach requires using interceptors due to impossibility to pass lambda to the NetworkClient.

This PR adds `extras` property to NetworkRequest class. Due to manual cache serialisation (i.e. no kotlinx.serialisation), it should not affect caching, as this property is not read or written by CacheStrategy. This also has a side effect: it encourages passing various request parameters via `Extras` while not being serialised into cache, which is a documentation issue but this PR does not alter any existing `NetworkClient`s, so I think it has low impact.

With `extras` passed, it is possible to write such `NetworkClient` that uses lambda passed via `extras` in `onDownload`, enabling easy progress loading listening in UI while also being generic as possible.

I should also note that writing such client is possible without this PR, but it requires copying `NetworkFetcher` for the same customisation. I haven't done that, but I think it should work, and so this PR.

Also this PR breaks binary compatibility with something that creates and copies `NetworkRequest` objects.

<details>
<summary>Various info on why I can't test this using ./test.sh</summary>

Basic verification is performed by `inspect code` in Intellij IDEA and also by these gradle tasks: ``:buildSrc:assemble :coil-bom:assemble :coil:assemble :coil-compose:assemble :coil-compose-core:assemble :coil-core:assemble :coil-gif:assemble :coil-network-cache-control:assemble :coil-network-core:assemble :coil-network-ktor2:assemble :coil-network-ktor3:assemble :coil-network-okhttp:assemble :coil-svg:assemble :coil-test:assemble :coil-video:assemble``. I can't assemble everything in this project as `:internal:assemble` sets up an emulator and my system is not configured to do that, so it fails with code 127.

The test that I touched passes on jvm, android debug and android release (not instrumented).

Then, `./test.sh`. `gradlew apiCheck spotlessCheck` works and actually found that I forgot to update API. Next line fails on `:coil:allTasks` due to `karma` not finding `chromeHeadless` (I have ungoogled-chromium and firefox-bin in my NixOS system). I also can't find any mention of `karma` in build configuration, so that I can't change it.

So, I rely on your github actions checks. If they fail, I'll need to use [act](https://github.com/nektos/act) (or other solution to run github actions locally). I think there needs a Dockerfile for running `./test.sh` or something like that.
</details>
