### PR TITLE
Fix broken transition link in docs

### DIFF
--- a/coil-compose/README.md
+++ b/coil-compose/README.md
@@ -148,7 +148,7 @@ AsyncImage(
 )
 ```
 
-Custom [`Transition`](transitions.md)s do not work with `AsyncImage`, `SubcomposeAsyncImage`, or `rememberAsyncImagePainter` as they require a `View` reference. `CrossfadeTransition` works due to special internal support.
+Custom [`Transition`](/coil/api/coil-core/coil3.transition/-transition)s do not work with `AsyncImage`, `SubcomposeAsyncImage`, or `rememberAsyncImagePainter` as they require a `View` reference. `CrossfadeTransition` works due to special internal support.
 
 That said, it's possible to create custom transitions in Compose by observing `AsyncImagePainter.state`:
 


### PR DESCRIPTION
transitions.md does not exit, it redirects to a 404 page.