### PR TITLE
Remove experimental annotation from ColorImage.

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/ColorImage.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/ColorImage.kt
@@ -1,10 +1,8 @@
 package coil3
 
 import android.graphics.Paint
-import coil3.annotation.ExperimentalCoilApi
 import coil3.annotation.Poko
 
-@ExperimentalCoilApi
 @Poko
 actual class ColorImage actual constructor(
     actual val color: Int,

--- a/coil-core/src/commonMain/kotlin/coil3/ColorImage.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/ColorImage.kt
@@ -1,7 +1,5 @@
 package coil3
 
-import coil3.annotation.ExperimentalCoilApi
-
 /**
  * An image that draws a [color].
  *
@@ -11,7 +9,6 @@ import coil3.annotation.ExperimentalCoilApi
  * @param color The ARGB hex color to draw with the format `0xAARRGGBB.toInt()`.
  *  Tip: Use Compose's color class: `ColorImage(Color.Black.toArgb())`.
  */
-@ExperimentalCoilApi
 expect class ColorImage(
     color: Int = 0xFF000000.toInt(),
     width: Int = -1,

--- a/coil-core/src/nonAndroidMain/kotlin/coil3/ColorImage.kt
+++ b/coil-core/src/nonAndroidMain/kotlin/coil3/ColorImage.kt
@@ -1,11 +1,9 @@
 package coil3
 
-import coil3.annotation.ExperimentalCoilApi
 import coil3.annotation.Poko
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.Rect
 
-@ExperimentalCoilApi
 @Poko
 actual class ColorImage actual constructor(
     actual val color: Int,


### PR DESCRIPTION
Haven't found any notable issues or bugs with its design so far.