### PR TITLE
Fix transformation with default response in FakeImageLoaderEngine

### DIFF
--- a/coil-test/src/androidUnitTest/kotlin/coil3/test/FakeImageLoaderEngineAndroidTest.kt
+++ b/coil-test/src/androidUnitTest/kotlin/coil3/test/FakeImageLoaderEngineAndroidTest.kt
@@ -35,4 +35,24 @@ class FakeImageLoaderEngineAndroidTest : RobolectricTest() {
         assertIs<SuccessResult>(result)
         assertSame(Transition.Factory.NONE, result.request.transitionFactory)
     }
+
+    @Test
+    fun `removes transition factory with default response`() = runTest {
+        val url = "https://www.example.com/image.jpg"
+        val engine = FakeImageLoaderEngine.Builder()
+            .default(ColorDrawable(Color.RED))
+            .build()
+        val imageLoader = ImageLoader.Builder(context)
+            .components { add(engine) }
+            .build()
+        val request = ImageRequest.Builder(context)
+            .data(url)
+            .crossfade(true)
+            .build()
+
+        val result = imageLoader.execute(request)
+        assertIs<SuccessResult>(result)
+        assertSame(Transition.Factory.NONE, result.request.transitionFactory)
+    }
+
 }

--- a/coil-test/src/commonMain/kotlin/coil3/test/FakeImageLoaderEngine.kt
+++ b/coil-test/src/commonMain/kotlin/coil3/test/FakeImageLoaderEngine.kt
@@ -55,17 +55,17 @@ class FakeImageLoaderEngine private constructor(
 
     override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
         val request = requestTransformer.transform(chain.request)
-        val requestValue = RequestValue(request, chain.size)
+        val newChain = chain.withRequest(request)
+        val requestValue = RequestValue(request, newChain.size)
         _requests.emit(requestValue)
 
         var result: ImageResult? = null
         for (interceptor in interceptors) {
-            val newChain = chain.withRequest(request)
             result = interceptor.intercept(newChain)
             if (result != null) break
         }
         if (result == null) {
-            result = defaultInterceptor.intercept(chain)
+            result = defaultInterceptor.intercept(newChain)
         }
 
         _results.emit(ResultValue(requestValue, result))


### PR DESCRIPTION
When using the default interceptor for a default response, the chain used was not the transformed one. This caused the Request to not have a NONE Transition.Factory, and causing tests to still running transitions.

For example this caused issues with our Paparazzi tests where, requests with default result where still having the crossfade animation causing the tests to be flaky.

Please run `./test.sh` before submitting to ensure your pull request passes the automated checks.
