### PR TITLE
Add R8 -dontwarn coil3.PlatformContext rule to coil-core.

### DIFF
--- a/coil-core/build.gradle.kts
+++ b/coil-core/build.gradle.kts
@@ -10,7 +10,11 @@ plugins {
 }
 
 addAllMultiplatformTargets(libs.versions.skiko)
-androidLibrary(name = "coil3.core")
+androidLibrary(name = "coil3.core") {
+    defaultConfig {
+        consumerProguardFiles("shrinker-rules.pro")
+    }
+}
 
 kotlin {
     sourceSets {

--- a/coil-core/shrinker-rules.pro
+++ b/coil-core/shrinker-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn coil3.PlatformContext


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/2637

TLDR: R8 warns about a missing reference to `coil3.PlatformContext` even though it [shouldn't exist on Android](https://github.com/coil-kt/coil/blob/main/coil-core/src/androidMain/kotlin/coil3/PlatformContext.kt#L3). This hides the warning for consumers.