### PR TITLE
Refactor circle and rounded corners transformations to share a common paint.

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/transform/CircleCropTransformation.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/CircleCropTransformation.kt
@@ -19,7 +19,7 @@ class CircleCropTransformation : Transformation() {
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
         val outputSize = minOf(input.width, input.height)
         return createBitmap(outputSize, outputSize, input.safeConfig).applyCanvas {
-            val paint = newBitmapShaderPaint(input, outputSize, outputSize)
+            val paint = newScaledShaderPaint(input, outputSize, outputSize)
             val radius = outputSize / 2f
             drawCircle(radius, radius, radius, paint)
         }

--- a/coil-core/src/androidMain/kotlin/coil3/transform/CircleCropTransformation.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/CircleCropTransformation.kt
@@ -1,9 +1,6 @@
 package coil3.transform
 
 import android.graphics.Bitmap
-import android.graphics.Paint
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import coil3.size.Size
@@ -20,17 +17,11 @@ class CircleCropTransformation : Transformation() {
     override val cacheKey = "${this::class.qualifiedName}"
 
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
-
-        val minSize = minOf(input.width, input.height)
-        val radius = minSize / 2f
-        val output = createBitmap(minSize, minSize, input.safeConfig)
-        output.applyCanvas {
+        val outputSize = minOf(input.width, input.height)
+        return createBitmap(outputSize, outputSize, input.safeConfig).applyCanvas {
+            val paint = newBitmapShaderPaint(input, outputSize, outputSize)
+            val radius = outputSize / 2f
             drawCircle(radius, radius, radius, paint)
-            paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
-            drawBitmap(input, radius - input.width / 2f, radius - input.height / 2f, paint)
         }
-
-        return output
     }
 }

--- a/coil-core/src/androidMain/kotlin/coil3/transform/RoundedCornersTransformation.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/RoundedCornersTransformation.kt
@@ -50,7 +50,7 @@ class RoundedCornersTransformation(
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
         val (outputWidth, outputHeight) = calculateOutputSize(input, size)
         return createBitmap(outputWidth, outputHeight, input.safeConfig).applyCanvas {
-            val paint = newBitmapShaderPaint(input, outputWidth, outputHeight)
+            val paint = newScaledShaderPaint(input, outputWidth, outputHeight)
             if (topLeft == topRight && topRight == bottomLeft && bottomLeft == bottomRight) {
                 drawRoundRect(0f, 0f, outputWidth.toFloat(), outputHeight.toFloat(), topLeft, topLeft, paint)
             } else {

--- a/coil-core/src/androidMain/kotlin/coil3/transform/RoundedCornersTransformation.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/RoundedCornersTransformation.kt
@@ -1,14 +1,8 @@
 package coil3.transform
 
 import android.graphics.Bitmap
-import android.graphics.BitmapShader
-import android.graphics.Color
-import android.graphics.Matrix
-import android.graphics.Paint
 import android.graphics.Path
-import android.graphics.PorterDuff
 import android.graphics.RectF
-import android.graphics.Shader
 import androidx.annotation.Px
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
@@ -54,43 +48,23 @@ class RoundedCornersTransformation(
     override val cacheKey = "${this::class.qualifiedName}-$topLeft,$topRight,$bottomLeft,$bottomRight"
 
     override suspend fun transform(input: Bitmap, size: Size): Bitmap {
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
-
         val (outputWidth, outputHeight) = calculateOutputSize(input, size)
-
-        val output = createBitmap(outputWidth, outputHeight, input.safeConfig)
-        output.applyCanvas {
-            drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
-
-            val matrix = Matrix()
-            val multiplier = DecodeUtils.computeSizeMultiplier(
-                srcWidth = input.width,
-                srcHeight = input.height,
-                dstWidth = outputWidth,
-                dstHeight = outputHeight,
-                scale = Scale.FILL,
-            ).toFloat()
-            val dx = (outputWidth - multiplier * input.width) / 2
-            val dy = (outputHeight - multiplier * input.height) / 2
-            matrix.setTranslate(dx, dy)
-            matrix.preScale(multiplier, multiplier)
-
-            val shader = BitmapShader(input, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
-            shader.setLocalMatrix(matrix)
-            paint.shader = shader
-
-            val radii = floatArrayOf(
-                topLeft, topLeft,
-                topRight, topRight,
-                bottomRight, bottomRight,
-                bottomLeft, bottomLeft,
-            )
-            val rect = RectF(0f, 0f, width.toFloat(), height.toFloat())
-            val path = Path().apply { addRoundRect(rect, radii, Path.Direction.CW) }
-            drawPath(path, paint)
+        return createBitmap(outputWidth, outputHeight, input.safeConfig).applyCanvas {
+            val paint = newBitmapShaderPaint(input, outputWidth, outputHeight)
+            if (topLeft == topRight && topRight == bottomLeft && bottomLeft == bottomRight) {
+                drawRoundRect(0f, 0f, outputWidth.toFloat(), outputHeight.toFloat(), topLeft, topLeft, paint)
+            } else {
+                val radii = floatArrayOf(
+                    topLeft, topLeft,
+                    topRight, topRight,
+                    bottomRight, bottomRight,
+                    bottomLeft, bottomLeft,
+                )
+                val rect = RectF(0f, 0f, outputWidth.toFloat(), outputHeight.toFloat())
+                val path = Path().apply { addRoundRect(rect, radii, Path.Direction.CW) }
+                drawPath(path, paint)
+            }
         }
-
-        return output
     }
 
     private fun calculateOutputSize(input: Bitmap, size: Size): IntPair {

--- a/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
@@ -11,7 +11,7 @@ import coil3.size.Scale
 /**
  * Create a [Paint] that draws [input] centered and scaled to fit inside the output dimensions.
  */
-internal fun newBitmapShaderPaint(
+internal fun newScaledShaderPaint(
     input: Bitmap,
     outputWidth: Int,
     outputHeight: Int,

--- a/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
@@ -1,0 +1,37 @@
+package coil3.transform
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Shader
+import coil3.decode.DecodeUtils
+import coil3.size.Scale
+
+/**
+ * Create a [Paint] that draws [input] centered and scaled inside the output dimensions.
+ */
+internal fun newBitmapShaderPaint(
+    input: Bitmap,
+    outputWidth: Int,
+    outputHeight: Int,
+): Paint {
+    val matrix = Matrix()
+    val multiplier = DecodeUtils.computeSizeMultiplier(
+        srcWidth = input.width,
+        srcHeight = input.height,
+        dstWidth = outputWidth,
+        dstHeight = outputHeight,
+        scale = Scale.FILL,
+    ).toFloat()
+    val dx = (outputWidth - multiplier * input.width) / 2
+    val dy = (outputHeight - multiplier * input.height) / 2
+    matrix.setTranslate(dx, dy)
+    matrix.preScale(multiplier, multiplier)
+
+    val paint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
+    val shader = BitmapShader(input, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+    shader.setLocalMatrix(matrix)
+    paint.shader = shader
+    return paint
+}

--- a/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transform/transformations.kt
@@ -9,7 +9,7 @@ import coil3.decode.DecodeUtils
 import coil3.size.Scale
 
 /**
- * Create a [Paint] that draws [input] centered and scaled inside the output dimensions.
+ * Create a [Paint] that draws [input] centered and scaled to fit inside the output dimensions.
  */
 internal fun newBitmapShaderPaint(
     input: Bitmap,


### PR DESCRIPTION
@romainguy tipped me off that we could refactor the two provided transformations (`CircleCropTransformation` and `RoundedCornersTransformation`) so that they share common code.

There are existing regression tests for these transformations.