### PR TITLE
Enable Java 11 bytecode for Compose artifacts.

### DIFF
--- a/coil-compose-core/build.gradle.kts
+++ b/coil-compose-core/build.gradle.kts
@@ -1,5 +1,8 @@
 import coil3.addAllMultiplatformTargets
 import coil3.androidLibrary
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
@@ -65,4 +68,13 @@ baselineProfile {
 
 dependencies {
     baselineProfile(projects.internal.benchmark)
+}
+
+// Compose 1.8.0 requires JVM 11.
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget = JvmTarget.JVM_11
 }

--- a/coil-compose/build.gradle.kts
+++ b/coil-compose/build.gradle.kts
@@ -1,5 +1,8 @@
 import coil3.addAllMultiplatformTargets
 import coil3.androidLibrary
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
@@ -21,4 +24,13 @@ kotlin {
             }
         }
     }
+}
+
+// Compose 1.8.0 requires JVM 11.
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget = JvmTarget.JVM_11
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -39,25 +39,9 @@ Set `logger(DebugLogger())` when [constructing your `ImageLoader`](getting_start
 !!! Note
     `DebugLogger` should only be used in debug builds.
 
-## How do I target Java 8?
+## How do I target Java 8 or Java 11?
 
 Coil requires [Java 8 bytecode](https://developer.android.com/studio/write/java8-support). This is enabled by default on the Android Gradle Plugin `4.2.0` and later and the Kotlin Gradle Plugin `1.5.0` and later. If you're using older versions of those plugins add the following to your Gradle build script:
-
-Gradle (`.gradle`):
-
-```groovy
-android {
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-```
-
-Gradle Kotlin DSL (`.gradle.kts`):
 
 ```kotlin
 android {
@@ -67,6 +51,20 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+}
+```
+
+As of Coil `3.2.0`, Java 11 bytecode is required for `coil-compose` and `coil-compose-core`:
+
+```kotlin
+android {
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
     }
 }
 ```

--- a/samples/compose/build.gradle.kts
+++ b/samples/compose/build.gradle.kts
@@ -1,7 +1,10 @@
 import coil3.androidApplication
 import coil3.applyCoilHierarchyTemplate
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.application")
@@ -126,4 +129,13 @@ afterEvaluate {
         named("jsBrowserProductionWebpack").configure(configureJs)
         named("wasmJsBrowserProductionWebpack").configure(configureJs)
     }
+}
+
+// Compose 1.8.0 requires JVM 11.
+tasks.withType<JavaCompile>().configureEach {
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget = JvmTarget.JVM_11
 }


### PR DESCRIPTION
Compose 1.8.0 requires Java 11 bytecode so we need to enable it as well. I think we should keep non-Compose artifacts using Java 8 bytecode to avoid forcing everyone to update.