### PR TITLE
`StaticImageDecoder` behaves like `RESPECT_PERFORMANCE`

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
@@ -2,7 +2,6 @@ package coil3
 
 import android.os.Build.VERSION.SDK_INT
 import coil3.decode.BitmapFactoryDecoder
-import coil3.decode.ExifOrientationStrategy.Companion.RESPECT_ALL
 import coil3.decode.ExifOrientationStrategy.Companion.RESPECT_PERFORMANCE
 import coil3.decode.StaticImageDecoder
 import coil3.fetch.AssetUriFetcher

--- a/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
@@ -89,7 +89,7 @@ internal actual fun ComponentRegistry.Builder.addAndroidComponents(
 
     // Decoders
     val parallelismLock = Semaphore(options.bitmapFactoryMaxParallelism)
-    if (enableStaticImageDecoder(options)) {
+    if (options.enableStaticImageDecoder()) {
         add(
             StaticImageDecoder.Factory(
                 parallelismLock = parallelismLock,
@@ -104,11 +104,8 @@ internal actual fun ComponentRegistry.Builder.addAndroidComponents(
     )
 }
 
-private fun enableStaticImageDecoder(options: RealImageLoader.Options): Boolean {
+private fun RealImageLoader.Options.enableStaticImageDecoder(): Boolean {
     // Require API 29 for ImageDecoder support as API 28 has framework bugs:
     // https://github.com/element-hq/element-android/pull/7184
-    return SDK_INT >= 29 &&
-        options.imageDecoderEnabled &&
-        // ImageDecoder always rotates the image according to its EXIF data.
-        options.bitmapFactoryExifOrientationStrategy.let { it == RESPECT_PERFORMANCE || it == RESPECT_ALL }
+    return SDK_INT >= 29 && imageDecoderEnabled && bitmapFactoryExifOrientationStrategy == RESPECT_PERFORMANCE
 }


### PR DESCRIPTION
Note that this will not resolve** https://github.com/coil-kt/coil/issues/2952
As `BitmapFactory` will not return correct mimetype for ARW image.

Fixes: https://github.com/coil-kt/coil/issues/2952