### PR TITLE
Use kotlinx.io's new Okio interop module.

### DIFF
--- a/coil-network-ktor2/src/nonJvmCommonMain/kotlin/coil3/network/ktor2/internal/utils.nonJvmCommon.kt
+++ b/coil-network-ktor2/src/nonJvmCommonMain/kotlin/coil3/network/ktor2/internal/utils.nonJvmCommon.kt
@@ -14,7 +14,6 @@ internal actual suspend fun ByteReadChannel.writeTo(sink: BufferedSink) {
         val packet = readRemaining(buffer.size.toLong())
         if (packet.isEmpty) break
 
-        // TODO: Figure out how to remove 'buffer' and read directly into 'sink'.
         val bytesRead = packet.remaining.toInt()
         packet.readFully(buffer, 0, bytesRead)
         sink.write(buffer, 0, bytesRead)

--- a/coil-network-ktor3/build.gradle.kts
+++ b/coil-network-ktor3/build.gradle.kts
@@ -19,6 +19,11 @@ kotlin {
                 api(libs.ktor3.core)
             }
         }
+        named("nonJvmCommonMain") {
+            dependencies {
+                implementation(libs.kotlinx.io.okio)
+            }
+        }
         commonTest {
             dependencies {
                 implementation(projects.internal.testUtils)

--- a/coil-network-ktor3/src/nonJvmCommonMain/kotlin/coil3/network/ktor3/internal/utils.nonJvmCommon.kt
+++ b/coil-network-ktor3/src/nonJvmCommonMain/kotlin/coil3/network/ktor3/internal/utils.nonJvmCommon.kt
@@ -1,27 +1,15 @@
 package coil3.network.ktor3.internal
 
 import io.ktor.utils.io.ByteReadChannel
-import io.ktor.utils.io.core.readFully
-import io.ktor.utils.io.core.remaining
-import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.asByteWriteChannel
+import io.ktor.utils.io.copyAndClose
+import kotlinx.io.okio.asKotlinxIoRawSink
 import okio.BufferedSink
 import okio.FileSystem
 import okio.Path
 
 internal actual suspend fun ByteReadChannel.writeTo(sink: BufferedSink) {
-    val buffer = ByteArray(OKIO_BUFFER_SIZE)
-
-    while (!isClosedForRead) {
-        val packet = readRemaining(buffer.size.toLong())
-        if (packet.exhausted()) break
-
-        // TODO: Figure out how to remove 'buffer' and read directly into 'sink'.
-        val bytesRead = packet.remaining.toInt()
-        packet.readFully(buffer, 0, bytesRead)
-        sink.write(buffer, 0, bytesRead)
-    }
-
-    closedCause?.let { throw it }
+    copyAndClose(sink.asKotlinxIoRawSink().asByteWriteChannel())
 }
 
 internal actual suspend fun ByteReadChannel.writeTo(fileSystem: FileSystem, path: Path) {
@@ -29,6 +17,3 @@ internal actual suspend fun ByteReadChannel.writeTo(fileSystem: FileSystem, path
         writeTo(this)
     }
 }
-
-// Okio uses 8 KB internally.
-private const val OKIO_BUFFER_SIZE = 8 * 1024

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,7 +75,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
 
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
-kotlinx-io-okio = "org.jetbrains.kotlinx:kotlinx-io-okio:0.7.0"
+kotlinx-io-okio = "org.jetbrains.kotlinx:kotlinx-io-okio:0.8.0"
 kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 
 ktor2-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
 
 kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.2"
+kotlinx-io-okio = "org.jetbrains.kotlinx:kotlinx-io-okio:0.7.0"
 kotlinx-serialization-json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1"
 
 ktor2-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor2" }


### PR DESCRIPTION
Need to figure out why this causes `ClosedByteChannelException` on non-JVM platforms ~and add a regression test~.

Reverts coil-kt/coil#2957

EDIT: Fixed in kotlinx.io [here](https://github.com/Kotlin/kotlinx-io/pull/453).