### PR TITLE
chore(deps): update android drawable painter to 0.37.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ve
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 google-material = "com.google.android.material:material:1.12.0"
-google-drawablepainter = "com.google.accompanist:accompanist-drawablepainter:0.36.0"
+google-drawablepainter = "com.google.accompanist:accompanist-drawablepainter:0.37.3"
 
 junit = "junit:junit:4.13.2"
 


### PR DESCRIPTION
Update Accompanist DrawablePainter to v0.37.3 to fix AnimatedImageDrawable position off on systems below Android 12.
The root cause is AnimatedImageDrawable (for gif/webp) didn't implement the behavior needed for setBounds, so we use a workaround (scale) in this specific case to make the position and size correct.

The details are in this PR
https://github.com/google/accompanist/pull/1817

This addresses following issues, so we can simply use AsyncImage for gif and animated webp now.
https://github.com/coil-kt/coil/issues/815
https://github.com/coil-kt/coil/issues/1844
...
lots of similar closed issues about GIF sizes seem related.

---
✅ Please run `./test.sh` before submitting to ensure your pull request passes the automated checks.
