### PR TITLE
Implement InFlightRequestStrategy and DeDupeInFlightRequestStrategy

### DIFF
--- a/coil-network-core/src/commonMain/kotlin/coil3/network/InFlightRequestStrategy.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/InFlightRequestStrategy.kt
@@ -1,0 +1,61 @@
+package coil3.network
+
+import coil3.fetch.FetchResult
+import kotlin.jvm.JvmField
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okio.Closeable
+import okio.use
+
+interface InFlightRequestStrategy {
+    suspend fun apply(key: String, block: (suspend () -> FetchResult)): FetchResult {
+        return block()
+    }
+
+    companion object {
+        @JvmField
+        val DEFAULT: InFlightRequestStrategy = object : InFlightRequestStrategy {}
+    }
+}
+
+class DeDupeInFlightRequestStrategy() : InFlightRequestStrategy {
+    private val inFlightRequests = mutableMapOf<String, InFlightRequest>()
+    private val mutex: Mutex = Mutex()
+
+    override suspend fun apply(
+        key: String,
+        block: (suspend () -> FetchResult),
+    ): FetchResult {
+        var shouldWait = false
+        val request = mutex.withLock {
+            inFlightRequests[key]?.also { shouldWait = true } ?: addRequest(key)
+        }
+
+        if (shouldWait) {
+            request.deferrable.await()
+        }
+
+        return request.use {
+            block()
+        }.also {
+            mutex.withLock {
+                inFlightRequests.remove(key)
+            }
+        }
+    }
+
+    // must be called with the Mutex already acquired
+    private fun addRequest(key: String): InFlightRequest {
+        return InFlightRequest(key, CompletableDeferred()).also { inFlightRequests[key] = it }
+    }
+
+    data class InFlightRequest(
+        val key: String,
+        val deferrable: CompletableDeferred<Unit>,
+    ) : Closeable {
+        override fun close() {
+            deferrable.complete(Unit)
+        }
+    }
+}

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -45,6 +45,7 @@ class NetworkFetcherTest : RobolectricTest() {
             diskCache = lazyOf(null),
             cacheStrategy = lazyOf(CacheStrategy.DEFAULT),
             connectivityChecker = ConnectivityChecker(context),
+            inFlightRequestStrategy = lazyOf(InFlightRequestStrategy.DEFAULT)
         ).fetch()
 
         assertIs<SourceFetchResult>(result)

--- a/coil-network-ktor2/src/commonMain/kotlin/coil3/network/ktor2/KtorNetworkFetcher.kt
+++ b/coil-network-ktor2/src/commonMain/kotlin/coil3/network/ktor2/KtorNetworkFetcher.kt
@@ -5,6 +5,7 @@ package coil3.network.ktor2
 import coil3.PlatformContext
 import coil3.network.CacheStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkClient
 import coil3.network.NetworkFetcher
 import coil3.network.ktor2.internal.KtorNetworkClient
@@ -19,8 +20,10 @@ fun KtorNetworkFetcherFactory() = NetworkFetcher.Factory(
 @JvmName("factory")
 fun KtorNetworkFetcherFactory(
     httpClient: HttpClient,
+    inFlightRequestStrategy: InFlightRequestStrategy = InFlightRequestStrategy.DEFAULT
 ) = NetworkFetcher.Factory(
     networkClient = { httpClient.asNetworkClient() },
+    inFlightRequestStrategy = { inFlightRequestStrategy }
 )
 
 @JvmName("factory")
@@ -35,10 +38,12 @@ fun KtorNetworkFetcherFactory(
     httpClient: () -> HttpClient = { HttpClient() },
     cacheStrategy: () -> CacheStrategy = { CacheStrategy.DEFAULT },
     connectivityChecker: (PlatformContext) -> ConnectivityChecker = ::ConnectivityChecker,
+    inFlightRequestStrategy: () -> InFlightRequestStrategy = { InFlightRequestStrategy.DEFAULT }
 ) = NetworkFetcher.Factory(
     networkClient = { httpClient().asNetworkClient() },
     cacheStrategy = cacheStrategy,
     connectivityChecker = connectivityChecker,
+    inFlightRequestStrategy = inFlightRequestStrategy
 )
 
 fun HttpClient.asNetworkClient(): NetworkClient {

--- a/coil-network-ktor2/src/commonTest/kotlin/coil3/network/ktor2/KtorNetworkFetcherTest.kt
+++ b/coil-network-ktor2/src/commonTest/kotlin/coil3/network/ktor2/KtorNetworkFetcherTest.kt
@@ -1,5 +1,6 @@
 package coil3.network.ktor2
 
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.request.Options
 import coil3.test.utils.AbstractNetworkFetcherTest
@@ -20,6 +21,7 @@ class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
         path: String,
         responseBody: ByteString,
         options: Options,
+        inFlightRequestStrategy: InFlightRequestStrategy
     ): NetworkFetcher {
         val client = HttpClient(MockEngine) {
             engine {
@@ -28,7 +30,7 @@ class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
                 }
             }
         }
-        val factory = KtorNetworkFetcherFactory(client)
+        val factory = KtorNetworkFetcherFactory(client, inFlightRequestStrategy)
         return assertIs(factory.create(url(path).toUri(), options, imageLoader))
     }
 }

--- a/coil-network-ktor3/src/commonMain/kotlin/coil3/network/ktor3/KtorNetworkFetcher.kt
+++ b/coil-network-ktor3/src/commonMain/kotlin/coil3/network/ktor3/KtorNetworkFetcher.kt
@@ -5,6 +5,7 @@ package coil3.network.ktor3
 import coil3.PlatformContext
 import coil3.network.CacheStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkClient
 import coil3.network.NetworkFetcher
 import coil3.network.ktor3.internal.KtorNetworkClient
@@ -19,8 +20,10 @@ fun KtorNetworkFetcherFactory() = NetworkFetcher.Factory(
 @JvmName("factory")
 fun KtorNetworkFetcherFactory(
     httpClient: HttpClient,
+    inFlightRequestStrategy: InFlightRequestStrategy = InFlightRequestStrategy.DEFAULT
 ) = NetworkFetcher.Factory(
     networkClient = { httpClient.asNetworkClient() },
+    inFlightRequestStrategy = { inFlightRequestStrategy }
 )
 
 @JvmName("factory")
@@ -35,10 +38,12 @@ fun KtorNetworkFetcherFactory(
     httpClient: () -> HttpClient = { HttpClient() },
     cacheStrategy: () -> CacheStrategy = { CacheStrategy.DEFAULT },
     connectivityChecker: (PlatformContext) -> ConnectivityChecker = ::ConnectivityChecker,
+    inFlightRequestStrategy: () -> InFlightRequestStrategy = { InFlightRequestStrategy.DEFAULT }
 ) = NetworkFetcher.Factory(
     networkClient = { httpClient().asNetworkClient() },
     cacheStrategy = cacheStrategy,
     connectivityChecker = connectivityChecker,
+    inFlightRequestStrategy = inFlightRequestStrategy
 )
 
 fun HttpClient.asNetworkClient(): NetworkClient {

--- a/coil-network-ktor3/src/commonTest/kotlin/coil3/network/ktor3/KtorNetworkFetcherTest.kt
+++ b/coil-network-ktor3/src/commonTest/kotlin/coil3/network/ktor3/KtorNetworkFetcherTest.kt
@@ -1,5 +1,6 @@
 package coil3.network.ktor3
 
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.request.Options
 import coil3.test.utils.AbstractNetworkFetcherTest
@@ -20,6 +21,7 @@ class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
         path: String,
         responseBody: ByteString,
         options: Options,
+        inFlightRequestStrategy: InFlightRequestStrategy
     ): NetworkFetcher {
         val client = HttpClient(MockEngine) {
             engine {
@@ -28,7 +30,7 @@ class KtorNetworkFetcherTest : AbstractNetworkFetcherTest() {
                 }
             }
         }
-        val factory = KtorNetworkFetcherFactory(client)
+        val factory = KtorNetworkFetcherFactory(client, inFlightRequestStrategy)
         return assertIs(factory.create(url(path).toUri(), options, imageLoader))
     }
 }

--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/OkHttpNetworkFetcher.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/OkHttpNetworkFetcher.kt
@@ -5,6 +5,7 @@ package coil3.network.okhttp
 import coil3.PlatformContext
 import coil3.network.CacheStrategy
 import coil3.network.ConnectivityChecker
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkClient
 import coil3.network.NetworkFetcher
 import coil3.network.okhttp.internal.CallFactoryNetworkClient
@@ -43,10 +44,23 @@ fun OkHttpNetworkFetcherFactory(
 fun OkHttpNetworkFetcherFactory(
     callFactory: () -> Call.Factory = ::OkHttpClient,
     cacheStrategy: () -> CacheStrategy = { CacheStrategy.DEFAULT },
+    inFlightRequestStrategy: () -> InFlightRequestStrategy = { InFlightRequestStrategy.DEFAULT }
+) = NetworkFetcher.Factory(
+    networkClient = { callFactory().asNetworkClient() },
+    cacheStrategy = cacheStrategy,
+    inFlightRequestStrategy = inFlightRequestStrategy
+)
+
+@JvmName("factory")
+fun OkHttpNetworkFetcherFactory(
+    callFactory: () -> Call.Factory = ::OkHttpClient,
+    cacheStrategy: () -> CacheStrategy = { CacheStrategy.DEFAULT },
+    inFlightRequestStrategy: () -> InFlightRequestStrategy = { InFlightRequestStrategy.DEFAULT },
     connectivityChecker: (PlatformContext) -> ConnectivityChecker = ::ConnectivityChecker,
 ) = NetworkFetcher.Factory(
     networkClient = { callFactory().asNetworkClient() },
     cacheStrategy = cacheStrategy,
+    inFlightRequestStrategy = inFlightRequestStrategy,
     connectivityChecker = connectivityChecker,
 )
 

--- a/coil-network-okhttp/src/commonTest/kotlin/coil3/network/okhttp/OkHttpNetworkFetcherTest.kt
+++ b/coil-network-okhttp/src/commonTest/kotlin/coil3/network/okhttp/OkHttpNetworkFetcherTest.kt
@@ -1,5 +1,6 @@
 package coil3.network.okhttp
 
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.request.Options
 import coil3.test.utils.AbstractNetworkFetcherTest
@@ -37,10 +38,14 @@ class OkHttpNetworkFetcherTest : AbstractNetworkFetcherTest() {
         path: String,
         responseBody: ByteString,
         options: Options,
+        inFlightRequestStrategy: InFlightRequestStrategy
     ): NetworkFetcher {
         server.enqueue(MockResponse().setBody(Buffer().apply { write(responseBody) }))
         val client = OkHttpClient()
-        val factory = OkHttpNetworkFetcherFactory(client)
+        val factory = OkHttpNetworkFetcherFactory(
+            callFactory = { client },
+            inFlightRequestStrategy = { inFlightRequestStrategy },
+        )
         return assertIs(factory.create(url(path).toUri(), options, imageLoader))
     }
 }

--- a/internal/test-utils/src/commonMain/kotlin/coil3/test/utils/AbstractNetworkFetcherTest.kt
+++ b/internal/test-utils/src/commonMain/kotlin/coil3/test/utils/AbstractNetworkFetcherTest.kt
@@ -1,8 +1,12 @@
 package coil3.test.utils
 
 import coil3.ImageLoader
+import coil3.decode.DataSource
 import coil3.disk.DiskCache
+import coil3.fetch.FetchResult
 import coil3.fetch.SourceFetchResult
+import coil3.network.DeDupeInFlightRequestStrategy
+import coil3.network.InFlightRequestStrategy
 import coil3.network.NetworkFetcher
 import coil3.request.Options
 import kotlin.test.AfterTest
@@ -13,6 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlinx.coroutines.launch
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import okio.blackholeSink
@@ -138,11 +143,61 @@ abstract class AbstractNetworkFetcherTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun dedupe_multiple_requests() = runTestAsync {
+        val expectedSize = 1_000
+        val path = "image.jpg"
+        val inFlightRequestStrategy = DeDupeInFlightRequestStrategy()
+
+        val results = mutableListOf<FetchResult>()
+        launch {
+            for (i in 1..10) {
+                launch {
+                    val result = newFetcher(
+                        path = path,
+                        responseBody = ByteArray(expectedSize).toByteString(),
+                        inFlightRequestStrategy = inFlightRequestStrategy
+                    ).fetch()
+                    assertIs<SourceFetchResult>(result)
+                    val actualSize = result.source.use { it.source().readAll(blackholeSink()) }
+                    assertEquals(expectedSize.toLong(), actualSize)
+                    results.add(result)
+                }
+            }
+        }.join()
+
+        assertEquals(
+            1,
+            results.filterIsInstance<SourceFetchResult>()
+                .count { it.dataSource == DataSource.NETWORK },
+        )
+
+        assertEquals(
+            9,
+            results.filterIsInstance<SourceFetchResult>()
+                .count { it.dataSource == DataSource.DISK },
+        )
+
+        // Run the fetcher another time.
+        val result = newFetcher(path, ByteArray(expectedSize).toByteString()).fetch()
+        assertIs<SourceFetchResult>(result)
+        val file = assertNotNull(result.source.fileOrNull())
+        val actualSize = result.source.use { it.source().readAll(blackholeSink()) }
+        assertEquals(expectedSize.toLong(), actualSize)
+
+        // Ensure the result file is present.
+        diskCache.openSnapshot(url("image.jpg"))!!.use { snapshot ->
+            assertContains(fileSystem.list(diskCache.directory), snapshot.data)
+            assertEquals(snapshot.data, file)
+        }
+    }
+
     abstract fun url(path: String): String
 
     abstract fun newFetcher(
         path: String = "image.jpg",
         responseBody: ByteString = ByteString.EMPTY,
         options: Options = Options(context),
+        inFlightRequestStrategy: InFlightRequestStrategy = InFlightRequestStrategy.DEFAULT
     ): NetworkFetcher
 }


### PR DESCRIPTION
This fixes https://github.com/coil-kt/coil/issues/1461, to avoid multiple parallel network requests for the same URL.

I've basically created a simple `InFlightRequestStrategy` interface, with a `DEFAULT` implementation that does nothing.

And a concrete implementation `DeDupeInFlightRequestStrategy`, that check for a current in-flight request for the same url and waits for it.

Then on `NetworkFetcher` I've simply wrapped the `fetch()` method with `InFlightRequestStrategy.apply()`. 

With the DEFAULT implementation, it will just invoke the lambda (call doFetch()). And using the DeDupe strategy, it will check for in-flight requests and wait on it.

Note: I haven't update the `.api` files yet...