### PR TITLE
Fix missing ImageLoaders.executeBlocking method on JVM.

### DIFF
--- a/coil-core/api/android/coil-core.api
+++ b/coil-core/api/android/coil-core.api
@@ -207,6 +207,10 @@ public final class coil3/ImageLoader$Builder {
 	public final fun precision (Lcoil3/size/Precision;)Lcoil3/ImageLoader$Builder;
 }
 
+public final class coil3/ImageLoaders {
+	public static final fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
+}
+
 public final class coil3/ImageLoadersKt {
 	public static final fun ImageLoader (Landroid/content/Context;)Lcoil3/ImageLoader;
 	public static final fun serviceLoaderEnabled (Lcoil3/ImageLoader$Builder;Z)Lcoil3/ImageLoader$Builder;
@@ -220,7 +224,7 @@ public final class coil3/ImageLoaders_androidKt {
 }
 
 public final class coil3/ImageLoaders_nonJsCommonKt {
-	public static final fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
+	public static final synthetic fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
 }
 
 public final class coil3/Image_androidKt {

--- a/coil-core/api/jvm/coil-core.api
+++ b/coil-core/api/jvm/coil-core.api
@@ -181,13 +181,17 @@ public final class coil3/ImageLoader$Builder {
 	public final fun precision (Lcoil3/size/Precision;)Lcoil3/ImageLoader$Builder;
 }
 
+public final class coil3/ImageLoaders {
+	public static final fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
+}
+
 public final class coil3/ImageLoadersKt {
 	public static final fun ImageLoader (Lcoil3/PlatformContext;)Lcoil3/ImageLoader;
 	public static final fun serviceLoaderEnabled (Lcoil3/ImageLoader$Builder;Z)Lcoil3/ImageLoader$Builder;
 }
 
 public final class coil3/ImageLoaders_nonJsCommonKt {
-	public static final fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
+	public static final synthetic fun executeBlocking (Lcoil3/ImageLoader;Lcoil3/request/ImageRequest;)Lcoil3/request/ImageResult;
 }
 
 public final class coil3/Image_nonAndroidKt {

--- a/coil-core/src/jvmCommonMain/kotlin/coil3/imageLoaders.hidden.kt
+++ b/coil-core/src/jvmCommonMain/kotlin/coil3/imageLoaders.hidden.kt
@@ -1,0 +1,8 @@
+@file:JvmName("ImageLoaders_nonJsCommonKt")
+
+package coil3
+
+import coil3.request.ImageRequest
+
+@Deprecated("Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
+fun ImageLoader.executeBlocking(request: ImageRequest) = executeBlocking(request)

--- a/coil-core/src/nonJsCommonMain/kotlin/coil3/imageLoaders.nonJsCommon.kt
+++ b/coil-core/src/nonJsCommonMain/kotlin/coil3/imageLoaders.nonJsCommon.kt
@@ -1,8 +1,11 @@
+@file:JvmName("ImageLoaders")
+
 package coil3
 
 import coil3.annotation.WorkerThread
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
+import kotlin.jvm.JvmName
 import kotlinx.coroutines.runBlocking
 
 /**


### PR DESCRIPTION
This method was lost during the multiplatform migration, but is still referenced in [the docs](https://coil-kt.github.io/coil/java_compatibility/).

Context: https://github.com/coil-kt/coil/discussions/3013#discussioncomment-13568268