### PR TITLE
Fix CrossfadePainter.intrinsicSize changing when start is dereferenced.

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
@@ -57,8 +57,7 @@ class CrossfadePainter(
     var start: Painter? = start
         private set
 
-    override val intrinsicSize: Size
-        get() = computeIntrinsicSize()
+    override val intrinsicSize: Size = computeIntrinsicSize(start, end)
 
     override fun DrawScope.onDraw() {
         if (isDone) {
@@ -94,7 +93,7 @@ class CrossfadePainter(
         return true
     }
 
-    private fun computeIntrinsicSize(): Size {
+    private fun computeIntrinsicSize(start: Painter?, end: Painter?): Size {
         val startSize = start?.intrinsicSize ?: Size.Zero
         val endSize = end?.intrinsicSize ?: Size.Zero
 


### PR DESCRIPTION
This matches the behaviour of `CrossfadeDrawable`, which computes its size up front and doesn't change.

Fixes: https://github.com/coil-kt/coil/issues/3057