### PR TITLE
Remove the MP4 screen in the sample app on non-Android platforms.

### DIFF
--- a/samples/shared/src/androidMain/kotlin/sample/common/utils.android.kt
+++ b/samples/shared/src/androidMain/kotlin/sample/common/utils.android.kt
@@ -3,5 +3,9 @@ package sample.common
 import coil3.Extras
 import coil3.video.videoFrameMicros
 
+actual fun assetTypes(): List<AssetType> {
+    return AssetType.entries
+}
+
 actual val Extras.Key.Companion.videoFrameMicros: Extras.Key<Long>
     get() = videoFrameMicros

--- a/samples/shared/src/commonMain/kotlin/sample/common/utils.kt
+++ b/samples/shared/src/commonMain/kotlin/sample/common/utils.kt
@@ -6,9 +6,11 @@ import coil3.util.IntPair
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
+expect fun assetTypes(): List<AssetType>
+
 fun AssetType.next(): AssetType {
-    val entries = AssetType.entries
-    return entries[(entries.indexOf(this) + 1) % entries.size]
+    val types = assetTypes()
+    return types[(types.indexOf(this) + 1) % types.size]
 }
 
 fun randomColor(): Int {

--- a/samples/shared/src/nonAndroidMain/kotlin/sample/common/utils.nonAndroid.kt
+++ b/samples/shared/src/nonAndroidMain/kotlin/sample/common/utils.nonAndroid.kt
@@ -2,6 +2,11 @@ package sample.common
 
 import coil3.Extras
 
+actual fun assetTypes(): List<AssetType> {
+    // MP4 is only supported on Android.
+    return AssetType.entries - AssetType.MP4
+}
+
 actual val Extras.Key.Companion.videoFrameMicros: Extras.Key<Long>
     get() = videoFrameMicrosKey
 


### PR DESCRIPTION
Video frame decoding is only supported on Android so currently we should a screen full of error images when navigating to that screen on non-Android platforms.