### PR TITLE
Fix accidental binary incompatible change in SvgDecoder.

### DIFF
--- a/coil-svg/api/android/coil-svg.api
+++ b/coil-svg/api/android/coil-svg.api
@@ -59,6 +59,7 @@ public final class coil3/svg/SvgDecoder : coil3/decode/Decoder {
 	public final fun getDensity ()Lkotlin/jvm/functions/Function1;
 	public final fun getParser ()Lcoil3/svg/Svg$Parser;
 	public final fun getRenderToBitmap ()Z
+	public final fun getScaleToDensity ()Z
 	public final fun getUseViewBoundsAsIntrinsicSize ()Z
 }
 
@@ -75,6 +76,7 @@ public final class coil3/svg/SvgDecoder$Factory : coil3/decode/Decoder$Factory {
 	public final fun getDensity ()Lkotlin/jvm/functions/Function1;
 	public final fun getParser ()Lcoil3/svg/Svg$Parser;
 	public final fun getRenderToBitmap ()Z
+	public final fun getScaleToDensity ()Z
 	public final fun getUseViewBoundsAsIntrinsicSize ()Z
 }
 

--- a/coil-svg/api/coil-svg.klib.api
+++ b/coil-svg/api/coil-svg.klib.api
@@ -63,6 +63,8 @@ final class coil3.svg/SvgDecoder : coil3.decode/Decoder { // coil3.svg/SvgDecode
         final fun <get-parser>(): coil3.svg/Svg.Parser // coil3.svg/SvgDecoder.parser.<get-parser>|<get-parser>(){}[0]
     final val renderToBitmap // coil3.svg/SvgDecoder.renderToBitmap|{}renderToBitmap[0]
         final fun <get-renderToBitmap>(): kotlin/Boolean // coil3.svg/SvgDecoder.renderToBitmap.<get-renderToBitmap>|<get-renderToBitmap>(){}[0]
+    final val scaleToDensity // coil3.svg/SvgDecoder.scaleToDensity|{}scaleToDensity[0]
+        final fun <get-scaleToDensity>(): kotlin/Boolean // coil3.svg/SvgDecoder.scaleToDensity.<get-scaleToDensity>|<get-scaleToDensity>(){}[0]
     final val useViewBoundsAsIntrinsicSize // coil3.svg/SvgDecoder.useViewBoundsAsIntrinsicSize|{}useViewBoundsAsIntrinsicSize[0]
         final fun <get-useViewBoundsAsIntrinsicSize>(): kotlin/Boolean // coil3.svg/SvgDecoder.useViewBoundsAsIntrinsicSize.<get-useViewBoundsAsIntrinsicSize>|<get-useViewBoundsAsIntrinsicSize>(){}[0]
 
@@ -78,6 +80,8 @@ final class coil3.svg/SvgDecoder : coil3.decode/Decoder { // coil3.svg/SvgDecode
             final fun <get-parser>(): coil3.svg/Svg.Parser // coil3.svg/SvgDecoder.Factory.parser.<get-parser>|<get-parser>(){}[0]
         final val renderToBitmap // coil3.svg/SvgDecoder.Factory.renderToBitmap|{}renderToBitmap[0]
             final fun <get-renderToBitmap>(): kotlin/Boolean // coil3.svg/SvgDecoder.Factory.renderToBitmap.<get-renderToBitmap>|<get-renderToBitmap>(){}[0]
+        final val scaleToDensity // coil3.svg/SvgDecoder.Factory.scaleToDensity|{}scaleToDensity[0]
+            final fun <get-scaleToDensity>(): kotlin/Boolean // coil3.svg/SvgDecoder.Factory.scaleToDensity.<get-scaleToDensity>|<get-scaleToDensity>(){}[0]
         final val useViewBoundsAsIntrinsicSize // coil3.svg/SvgDecoder.Factory.useViewBoundsAsIntrinsicSize|{}useViewBoundsAsIntrinsicSize[0]
             final fun <get-useViewBoundsAsIntrinsicSize>(): kotlin/Boolean // coil3.svg/SvgDecoder.Factory.useViewBoundsAsIntrinsicSize.<get-useViewBoundsAsIntrinsicSize>|<get-useViewBoundsAsIntrinsicSize>(){}[0]
 

--- a/coil-svg/api/jvm/coil-svg.api
+++ b/coil-svg/api/jvm/coil-svg.api
@@ -52,6 +52,7 @@ public final class coil3/svg/SvgDecoder : coil3/decode/Decoder {
 	public final fun getDensity ()Lkotlin/jvm/functions/Function1;
 	public final fun getParser ()Lcoil3/svg/Svg$Parser;
 	public final fun getRenderToBitmap ()Z
+	public final fun getScaleToDensity ()Z
 	public final fun getUseViewBoundsAsIntrinsicSize ()Z
 }
 
@@ -68,6 +69,7 @@ public final class coil3/svg/SvgDecoder$Factory : coil3/decode/Decoder$Factory {
 	public final fun getDensity ()Lkotlin/jvm/functions/Function1;
 	public final fun getParser ()Lcoil3/svg/Svg$Parser;
 	public final fun getRenderToBitmap ()Z
+	public final fun getScaleToDensity ()Z
 	public final fun getUseViewBoundsAsIntrinsicSize ()Z
 }
 

--- a/coil-svg/src/commonMain/kotlin/coil3/svg/SvgDecoder.kt
+++ b/coil-svg/src/commonMain/kotlin/coil3/svg/SvgDecoder.kt
@@ -61,6 +61,10 @@ class SvgDecoder(
         renderToBitmap = renderToBitmap,
     )
 
+    @Deprecated("Migrate to `density`.")
+    val scaleToDensity: Boolean
+        get() = density != NO_DENSITY
+
     override suspend fun decode() = runInterruptible {
         val svg = source.source().use(parser::parse)
 
@@ -143,6 +147,10 @@ class SvgDecoder(
             useViewBoundsAsIntrinsicSize = useViewBoundsAsIntrinsicSize,
             renderToBitmap = renderToBitmap,
         )
+
+        @Deprecated("Migrate to `density`.")
+        val scaleToDensity: Boolean
+            get() = density != NO_DENSITY
 
         override fun create(
             result: SourceFetchResult,


### PR DESCRIPTION
Noticed this while reviewing the [API diff](https://github.com/coil-kt/coil/compare/3.2.0..main) since last release.