### PR TITLE
Enable Gradle's configuration cache.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=2g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+org.gradle.configuration-cache=true
 
 # Android
 android.experimental.enableScreenshotTest=true


### PR DESCRIPTION
It's now [recommended](https://gradle.org/whats-new/gradle-9/#configuration-cache) in Gradle 9.