### PR TITLE
Revert "Enable Gradle's configuration cache."

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=2g -XX:+UseParallelGC -Dfile.encoding=UTF-8
-org.gradle.configuration-cache=true
 
 # Android
 android.experimental.enableScreenshotTest=true


### PR DESCRIPTION
This breaks docs publishing.

Reverts coil-kt/coil#3111