### PR TITLE
Add check to ensure coil-core and coil-compose-core skiko versions match.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -235,3 +235,5 @@ fun Project.applyOkioJsTestWorkaround() {
         }
     }
 }
+
+apply(from = rootProject.file("gradle/verifySkikoVersionsMatch.gradle.kts"))

--- a/buildSrc/src/main/kotlin/VerifySkikoVersionsTask.kt
+++ b/buildSrc/src/main/kotlin/VerifySkikoVersionsTask.kt
@@ -1,0 +1,22 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class VerifySkikoVersionsTask : DefaultTask() {
+
+    @get:Input
+    abstract val coreRequestedSkikoVersion: Property<String>
+
+    @get:Input
+    abstract val composeRequestedSkikoVersion: Property<String>
+
+    @TaskAction
+    fun verify() {
+        val coreSkiko = coreRequestedSkikoVersion.get()
+        val composeSkiko = composeRequestedSkikoVersion.get()
+        if (coreSkiko != composeSkiko) {
+            error("Skiko version mismatch: coil-core uses $coreSkiko, coil-compose-core uses $composeSkiko. Update libs.toml to use $composeSkiko.")
+        }
+    }
+}

--- a/gradle/verifySkikoVersionsMatch.gradle.kts
+++ b/gradle/verifySkikoVersionsMatch.gradle.kts
@@ -1,49 +1,40 @@
-import org.gradle.api.Project
-
 // Verify Skiko versions match between coil-core and coil-compose-core.
-val verifySkikoVersionsMatch by tasks.registering {
+tasks.register<VerifySkikoVersionsTask>("verifySkikoVersionsMatch") {
     group = "verification"
     description = "Ensures Skiko versions in coil-core and coil-compose-core match."
 
-    doLast {
-        val core = project(":coil-core")
-        val composeCore = project(":coil-compose-core")
+    // Compute requested versions at configuration time to avoid accessing project at execution time.
+    val coreRequested = provider {
+        requestedSkikoVersionFromJvmByOrigin(project(":coil-core"), project.group.toString())
+    }
+    val composeRequested = provider {
+        requestedSkikoVersionFromJvmByOrigin(project(":coil-compose-core"), "org.jetbrains.compose")
+    }
+    coreRequestedSkikoVersion.set(coreRequested)
+    composeRequestedSkikoVersion.set(composeRequested)
+}
 
-        core.evaluationDependsOn(core.path)
-        composeCore.evaluationDependsOn(composeCore.path)
-
-        fun requestedSkikoVersionFromJvmByOrigin(project: Project, originGroupPrefix: String): String {
-            val configurationNames = listOf("jvmRuntimeClasspath", "jvmTestRuntimeClasspath")
-            for (name in configurationNames) {
-                val cfg = project.configurations.findByName(name) ?: continue
-                // Force dependency graph calculation
-                cfg.dependencies
-                val result = cfg.incoming.resolutionResult
-                result.allDependencies.forEach { dep ->
-                    val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: return@forEach
-                    val from = resolved.from
-                    val fromId = (from as? org.gradle.api.artifacts.result.ResolvedComponentResult)?.moduleVersion
-                    val requested = resolved.requested as? org.gradle.api.artifacts.component.ModuleComponentSelector ?: return@forEach
-                    if (fromId != null && fromId.group.startsWith(originGroupPrefix) && requested.group == "org.jetbrains.skiko") {
-                        return requested.version
-                    }
-                }
+private fun requestedSkikoVersionFromJvmByOrigin(targetProject: Project, originGroupPrefix: String): String {
+    val configurationNames = listOf("jvmRuntimeClasspath", "jvmTestRuntimeClasspath")
+    for (name in configurationNames) {
+        val cfg = targetProject.configurations.findByName(name) ?: continue
+        // Force dependency graph calculation
+        cfg.dependencies
+        val result = cfg.incoming.resolutionResult
+        result.allDependencies.forEach { dep ->
+            val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: return@forEach
+            val from = resolved.from
+            val fromId = (from as? org.gradle.api.artifacts.result.ResolvedComponentResult)?.moduleVersion
+            val requested = resolved.requested as? org.gradle.api.artifacts.component.ModuleComponentSelector ?: return@forEach
+            if (fromId != null && fromId.group.startsWith(originGroupPrefix) && requested.group == "org.jetbrains.skiko") {
+                return requested.version
             }
-            error("Couldn't find requested Skiko JVM dependency in ${project.path} from '$originGroupPrefix' (checked ${configurationNames.joinToString()})")
-        }
-
-        val coreSkiko = requestedSkikoVersionFromJvmByOrigin(core, project.group.toString())
-        val composeSkiko = requestedSkikoVersionFromJvmByOrigin(composeCore, "org.jetbrains.compose")
-
-        if (coreSkiko != composeSkiko) {
-            error("Skiko version mismatch: coil-core uses $coreSkiko, coil-compose-core uses $composeSkiko. Update libs.toml to use $composeSkiko.")
         }
     }
+    error("Couldn't find requested Skiko JVM dependency in ${targetProject.path} from '$originGroupPrefix' (checked ${configurationNames.joinToString()}).")
 }
 
 // Attach verification only to the root `check` task.
 tasks.matching { it.name == "check" }.configureEach {
     dependsOn(tasks.named("verifySkikoVersionsMatch"))
 }
-
-

--- a/gradle/verifySkikoVersionsMatch.gradle.kts
+++ b/gradle/verifySkikoVersionsMatch.gradle.kts
@@ -1,0 +1,49 @@
+import org.gradle.api.Project
+
+// Verify Skiko versions match between coil-core and coil-compose-core.
+val verifySkikoVersionsMatch by tasks.registering {
+    group = "verification"
+    description = "Ensures Skiko versions in coil-core and coil-compose-core match."
+
+    doLast {
+        val core = project(":coil-core")
+        val composeCore = project(":coil-compose-core")
+
+        core.evaluationDependsOn(core.path)
+        composeCore.evaluationDependsOn(composeCore.path)
+
+        fun requestedSkikoVersionFromJvmByOrigin(project: Project, originGroupPrefix: String): String {
+            val configurationNames = listOf("jvmRuntimeClasspath", "jvmTestRuntimeClasspath")
+            for (name in configurationNames) {
+                val cfg = project.configurations.findByName(name) ?: continue
+                // Force dependency graph calculation
+                cfg.dependencies
+                val result = cfg.incoming.resolutionResult
+                result.allDependencies.forEach { dep ->
+                    val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: return@forEach
+                    val from = resolved.from
+                    val fromId = (from as? org.gradle.api.artifacts.result.ResolvedComponentResult)?.moduleVersion
+                    val requested = resolved.requested as? org.gradle.api.artifacts.component.ModuleComponentSelector ?: return@forEach
+                    if (fromId != null && fromId.group.startsWith(originGroupPrefix) && requested.group == "org.jetbrains.skiko") {
+                        return requested.version
+                    }
+                }
+            }
+            error("Couldn't find requested Skiko JVM dependency in ${project.path} from '$originGroupPrefix' (checked ${configurationNames.joinToString()})")
+        }
+
+        val coreSkiko = requestedSkikoVersionFromJvmByOrigin(core, project.group.toString())
+        val composeSkiko = requestedSkikoVersionFromJvmByOrigin(composeCore, "org.jetbrains.compose")
+
+        if (coreSkiko != composeSkiko) {
+            error("Skiko version mismatch: coil-core uses $coreSkiko, coil-compose-core uses $composeSkiko. Update libs.toml to use $composeSkiko.")
+        }
+    }
+}
+
+// Attach verification only to the root `check` task.
+tasks.matching { it.name == "check" }.configureEach {
+    dependsOn(tasks.named("verifySkikoVersionsMatch"))
+}
+
+

--- a/gradle/verifySkikoVersionsMatch.gradle.kts
+++ b/gradle/verifySkikoVersionsMatch.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.artifacts.component.ModuleComponentSelector
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+
 // Verify Skiko versions match between coil-core and coil-compose-core.
 tasks.register<VerifySkikoVersionsTask>("verifySkikoVersionsMatch") {
     group = "verification"
@@ -18,14 +21,14 @@ private fun requestedSkikoVersionFromJvmByOrigin(targetProject: Project, originG
     val configurationNames = listOf("jvmRuntimeClasspath", "jvmTestRuntimeClasspath")
     for (name in configurationNames) {
         val cfg = targetProject.configurations.findByName(name) ?: continue
-        // Force dependency graph calculation
+        // Force dependency graph calculation.
         cfg.dependencies
         val result = cfg.incoming.resolutionResult
         result.allDependencies.forEach { dep ->
-            val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: return@forEach
+            val resolved = dep as? ResolvedDependencyResult ?: return@forEach
             val from = resolved.from
-            val fromId = (from as? org.gradle.api.artifacts.result.ResolvedComponentResult)?.moduleVersion
-            val requested = resolved.requested as? org.gradle.api.artifacts.component.ModuleComponentSelector ?: return@forEach
+            val fromId = (from as? ResolvedComponentResult)?.moduleVersion
+            val requested = resolved.requested as? ModuleComponentSelector ?: return@forEach
             if (fromId != null && fromId.group.startsWith(originGroupPrefix) && requested.group == "org.jetbrains.skiko") {
                 return requested.version
             }

--- a/gradle/verifySkikoVersionsMatch.gradle.kts
+++ b/gradle/verifySkikoVersionsMatch.gradle.kts
@@ -24,11 +24,10 @@ private fun requestedSkikoVersionFromJvmByOrigin(targetProject: Project, originG
         // Force dependency graph calculation.
         cfg.dependencies
         val result = cfg.incoming.resolutionResult
-        result.allDependencies.forEach { dep ->
-            val resolved = dep as? ResolvedDependencyResult ?: return@forEach
-            val from = resolved.from
-            val fromId = (from as? ResolvedComponentResult)?.moduleVersion
-            val requested = resolved.requested as? ModuleComponentSelector ?: return@forEach
+        for (dep in result.allDependencies) {
+            val resolved = dep as? ResolvedDependencyResult ?: continue
+            val fromId = (resolved.from as? ResolvedComponentResult)?.moduleVersion
+            val requested = resolved.requested as? ModuleComponentSelector ?: continue
             if (fromId != null && fromId.group.startsWith(originGroupPrefix) && requested.group == "org.jetbrains.skiko") {
                 return requested.version
             }


### PR DESCRIPTION
For stability reasons we to have `coil-core` compile with the same Skiko version as the one used by Compose. I couldn't get Gradle to automatically apply the `coil-compose-core` version (from the Compose plugin) to `coil-core` so I've added a task to `./gradlew check` to fail the build if they don't match.