### PR TITLE
Fix incorrect class name in recipes.md

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -177,7 +177,7 @@ Don't forget to register add interceptor to your `ImageLoader`!
 ```kotlin
 ImageLoader.Builder(context)
     .components {
-        add(FastlyCoilInterceptor())
+        add(UrlSizeInterceptor())
     }
     .build()
 ```


### PR DESCRIPTION
The documentation in `recipes.md`(section:- https://github.com/coil-kt/coil/blob/main/docs/recipes.md#transforming-requests) references `FastlyCoilInterceptor`, but the actual class defined in the example is `UrlSizeInterceptor`.

This PR updates the reference to match the correct class name. 
