### PR TITLE
Fix Korean README typo and improve readability

### DIFF
--- a/README-ko.md
+++ b/README-ko.md
@@ -27,7 +27,7 @@ AsyncImage(
 )
 ```
 
-Coil의 [전체 문서는 여기에서](https://coil-kt.github.io/coil/getting_started/)에서 확인하세요.
+Coil의 [전체 문서는 여기](https://coil-kt.github.io/coil/getting_started/)에서 확인하세요.
 
 ## 라이선스
 


### PR DESCRIPTION
## What's Changed
* Fixed duplicate "에서" in Korean README that made the sentence grammatically incorrect
* "Coil의 전체 문서는 여기에서에서 확인하세요" → "Coil의 전체 문서는 여기에서 확인하세요"

## Why
* The phrase "여기에서에서" contains a duplicate "에서" which is grammatically incorrect in Korean
* This is similar to writing "Check the documentation at at here" instead of "Check the documentation at here" in English
* The duplication occurs because "여기에서" (at here) already contains the postposition "에서" (at/from), making the second "에서" redundant
* This makes the documentation look unprofessional and can confuse Korean readers