### PR TITLE
Sync the Visible property to the child drawable

### DIFF
--- a/coil-core/api/android/coil-core.api
+++ b/coil-core/api/android/coil-core.api
@@ -1105,6 +1105,7 @@ public final class coil3/transition/CrossfadeDrawable : android/graphics/drawabl
 	public fun setTintBlendMode (Landroid/graphics/BlendMode;)V
 	public fun setTintList (Landroid/content/res/ColorStateList;)V
 	public fun setTintMode (Landroid/graphics/PorterDuff$Mode;)V
+	public fun setVisible (ZZ)Z
 	public fun start ()V
 	public fun stop ()V
 	public fun unregisterAnimationCallback (Landroidx/vectordrawable/graphics/drawable/Animatable2Compat$AnimationCallback;)Z

--- a/coil-core/src/androidMain/kotlin/coil3/transition/CrossfadeDrawable.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/transition/CrossfadeDrawable.kt
@@ -115,6 +115,13 @@ class CrossfadeDrawable @JvmOverloads constructor(
         maxAlpha = alpha
     }
 
+    override fun setVisible(visible: Boolean, restart: Boolean): Boolean {
+        val superChanged = super.setVisible(visible, restart)
+        val changedStart = start?.setVisible(visible, restart) == true
+        val changedEnd = end?.setVisible(visible, restart) == true
+        return superChanged or changedStart or changedEnd
+    }
+
     @Deprecated("Deprecated in Java")
     @Suppress("DEPRECATION")
     override fun getOpacity(): Int {


### PR DESCRIPTION
I customize Decoder to load webp Animated via [APNG4Android](https://github.com/penfeizhou/APNG4Android), it will automatically stop animation when drawable is not visible, but when I set crossfade to true globally and drawable is not visible, the animation will never stop