### PR TITLE
Cache non-200 network responses in the disk cache.

### DIFF
--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -1,16 +1,16 @@
 package coil3.network
 
 import coil3.Extras
-import coil3.fetch.SourceFetchResult
 import coil3.disk.DiskCache
+import coil3.fetch.SourceFetchResult
 import coil3.request.Options
 import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
 import coil3.test.utils.runTestAsync
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import okio.Buffer
 import okio.ByteString.Companion.toByteString
 import okio.fakefilesystem.FakeFileSystem

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -2,6 +2,7 @@ package coil3.network
 
 import coil3.Extras
 import coil3.fetch.SourceFetchResult
+import coil3.disk.DiskCache
 import coil3.request.Options
 import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
@@ -9,8 +10,10 @@ import coil3.test.utils.runTestAsync
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertFailsWith
 import okio.Buffer
 import okio.ByteString.Companion.toByteString
+import okio.fakefilesystem.FakeFileSystem
 
 class NetworkFetcherTest : RobolectricTest() {
 
@@ -34,7 +37,9 @@ class NetworkFetcherTest : RobolectricTest() {
         val networkClient = FakeNetworkClient(
             respond = {
                 NetworkResponse(
-                    body = NetworkResponseBody(Buffer().apply { write(ByteArray(expectedSize)) }),
+                    body = NetworkResponseBody(
+                        source = Buffer().apply { write(ByteArray(expectedSize)) },
+                    ),
                 )
             },
         )
@@ -52,6 +57,57 @@ class NetworkFetcherTest : RobolectricTest() {
         val expected = NetworkRequest(url, method, headers, body, options.extras)
 
         assertEquals(expected, networkClient.requests.single())
+    }
+
+    @Test
+    fun errorResponseIsCachedToDisk() = runTestAsync {
+        val expectedSize = 1_000
+        val url = "https://example.com/error.jpg"
+
+        val fileSystem = FakeFileSystem()
+        val diskCache = DiskCache.Builder()
+            .directory(fileSystem.workingDirectory)
+            .fileSystem(fileSystem)
+            .maxSizeBytes(Long.MAX_VALUE)
+            .build()
+
+        val networkClient = FakeNetworkClient(
+            respond = {
+                NetworkResponse(
+                    code = 400,
+                    body = NetworkResponseBody(
+                        source = Buffer().apply { write(ByteArray(expectedSize)) },
+                    ),
+                )
+            },
+        )
+
+        val fetcher = NetworkFetcher(
+            url = url,
+            options = Options(context = context),
+            networkClient = lazyOf(networkClient),
+            diskCache = lazyOf(diskCache),
+            cacheStrategy = lazyOf(CacheStrategy.DEFAULT),
+            connectivityChecker = ConnectivityChecker.ONLINE,
+        )
+
+        // A 400 response throws, but should still be cached.
+        assertFailsWith<HttpException> { fetcher.fetch() }
+
+        diskCache.openSnapshot(url)!!.use { snapshot ->
+            // Verify the cached metadata records the 400 status code.
+            val cachedResponse = diskCache.fileSystem.read(snapshot.metadata) {
+                CacheNetworkResponse.readFrom(this)
+            }
+            assertEquals(400, cachedResponse.code)
+
+            // Verify the cached data exists and has the expected size.
+            val actualSize = fileSystem.read(snapshot.data) { readByteString().size }
+            assertEquals(expectedSize, actualSize)
+        }
+
+        diskCache.shutdown()
+        fileSystem.checkNoOpenFiles()
     }
 
     class FakeNetworkClient(


### PR DESCRIPTION
This was a regression from Coil 2.0 -> 3.0.

Fixes https://github.com/coil-kt/coil/issues/3128