### PR TITLE
Relax JVM 11 bytecode requirement for Android target.

### DIFF
--- a/buildSrc/src/main/kotlin/coil3/utils.kt
+++ b/buildSrc/src/main/kotlin/coil3/utils.kt
@@ -2,6 +2,9 @@ package coil3
 
 import kotlin.math.pow
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 val publicModules = setOf(
     "coil",
@@ -48,6 +51,20 @@ val Project.versionCode: Int
 // ./gradlew coil-compose:assemble -PenableComposeMetrics=true
 val Project.enableComposeMetrics: Boolean
     get() = booleanProperty("enableComposeMetrics") { false }
+
+// Compose 1.8.0 requires JVM 11 only for the JVM target.
+fun Project.applyJvm11OnlyToJvmTarget() {
+    tasks.withType<KotlinJvmCompile>().configureEach {
+        when {
+            name.contains("kotlinjvm", ignoreCase = true) -> {
+                compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
+            }
+            name.contains("kotlinandroid", ignoreCase = true) -> {
+                compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+            }
+        }
+    }
+}
 
 private fun Project.intProperty(
     name: String,

--- a/coil-compose-core/build.gradle.kts
+++ b/coil-compose-core/build.gradle.kts
@@ -1,8 +1,6 @@
 import coil3.addAllMultiplatformTargets
 import coil3.androidLibrary
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import coil3.applyJvm11OnlyToJvmTarget
 
 plugins {
     id("com.android.library")
@@ -70,11 +68,5 @@ dependencies {
     baselineProfile(projects.internal.benchmark)
 }
 
-// Compose 1.8.0 requires JVM 11.
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_11
-}
+// Compose 1.8.0 requires JVM 11 only for the JVM target.
+applyJvm11OnlyToJvmTarget()

--- a/coil-compose/build.gradle.kts
+++ b/coil-compose/build.gradle.kts
@@ -1,8 +1,6 @@
 import coil3.addAllMultiplatformTargets
 import coil3.androidLibrary
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+import coil3.applyJvm11OnlyToJvmTarget
 
 plugins {
     id("com.android.library")
@@ -26,11 +24,5 @@ kotlin {
     }
 }
 
-// Compose 1.8.0 requires JVM 11.
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_11
-}
+// Compose 1.8.0 requires JVM 11 only for the JVM target.
+applyJvm11OnlyToJvmTarget()

--- a/internal/test-compose-screenshot/build.gradle.kts
+++ b/internal/test-compose-screenshot/build.gradle.kts
@@ -1,7 +1,4 @@
 import coil3.androidLibrary
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
@@ -36,13 +33,4 @@ dependencies {
 
 screenshotTests {
     imageDifferenceThreshold = 0.01f
-}
-
-// Compose 1.8.0 requires JVM 11.
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_11
 }

--- a/internal/test-compose-ui-multiplatform/build.gradle.kts
+++ b/internal/test-compose-ui-multiplatform/build.gradle.kts
@@ -1,10 +1,8 @@
 import coil3.addAllMultiplatformTargets
 import coil3.androidLibrary
+import coil3.applyJvm11OnlyToJvmTarget
 import coil3.skikoAwtRuntimeDependency
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.compose.ExperimentalComposeLibrary
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.library")
@@ -42,11 +40,5 @@ kotlin {
     }
 }
 
-// Compose 1.8.0 requires JVM 11.
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_11
-}
+// Compose 1.8.0 requires JVM 11 only for the JVM target.
+applyJvm11OnlyToJvmTarget()

--- a/samples/compose/build.gradle.kts
+++ b/samples/compose/build.gradle.kts
@@ -1,10 +1,8 @@
 import coil3.androidApplication
 import coil3.applyCoilHierarchyTemplate
-import org.gradle.kotlin.dsl.withType
+import coil3.applyJvm11OnlyToJvmTarget
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("com.android.application")
@@ -132,11 +130,5 @@ afterEvaluate {
     }
 }
 
-// Compose 1.8.0 requires JVM 11.
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = JavaVersion.VERSION_11.toString()
-}
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget = JvmTarget.JVM_11
-}
+// Compose 1.8.0 requires JVM 11 only for the JVM target.
+applyJvm11OnlyToJvmTarget()


### PR DESCRIPTION
I thought this was required by Compose 1.8.0 for all targets, however it turns out it's only required for `jvmMain` (desktop). We can go back to JVM 8 bytecode for Android.