### PR TITLE
Restrict which response codes are cacheable.

### DIFF
--- a/coil-network-core/src/commonMain/kotlin/coil3/network/internal/DefaultCacheStrategy.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/internal/DefaultCacheStrategy.kt
@@ -31,7 +31,19 @@ internal class DefaultCacheStrategy : CacheStrategy {
             return WriteResult(networkResponse.copy(headers = combinedHeaders, body = null))
         }
 
-        // Write the response metadata and response body to disk.
-        return WriteResult(networkResponse)
+        // Write the response metadata and body to disk.
+        // Cache all 2xx responses for backwards compatibility.
+        if (networkResponse.code in 200 until 300
+            || networkResponse.code in CACHEABLE_STATUS_CODES) {
+            return WriteResult(networkResponse)
+        }
+
+        // Disable writing to disk for non-cacheable HTTP status codes.
+        return WriteResult.DISABLED
+    }
+
+    private companion object {
+        // List of non-200 HTTP codes that are cacheable by default according to RFC semantics.
+        private val CACHEABLE_STATUS_CODES = setOf(300, 301, 404, 405, 410, 414, 501)
     }
 }

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/internal/DefaultCacheStrategy.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/internal/DefaultCacheStrategy.kt
@@ -33,8 +33,8 @@ internal class DefaultCacheStrategy : CacheStrategy {
 
         // Write the response metadata and body to disk.
         // Cache all 2xx responses for backwards compatibility.
-        if (networkResponse.code in 200 until 300
-            || networkResponse.code in CACHEABLE_STATUS_CODES) {
+        if (networkResponse.code in 200 until 300 ||
+            networkResponse.code in CACHEABLE_STATUS_CODES) {
             return WriteResult(networkResponse)
         }
 


### PR DESCRIPTION
Follow up to https://github.com/coil-kt/coil/pull/3137. I realized that we shouldn't cache response codes like 500s.