### PR TITLE
add ImageLoader.Builder.repeatCount(Int) method

### DIFF
--- a/coil-gif/api/coil-gif.api
+++ b/coil-gif/api/coil-gif.api
@@ -58,6 +58,7 @@ public final class coil3/gif/ImageRequestsKt {
 	public static final fun getRepeatCount (Lcoil3/request/Options;)I
 	public static final fun onAnimationEnd (Lcoil3/request/ImageRequest$Builder;Lkotlin/jvm/functions/Function0;)Lcoil3/request/ImageRequest$Builder;
 	public static final fun onAnimationStart (Lcoil3/request/ImageRequest$Builder;Lkotlin/jvm/functions/Function0;)Lcoil3/request/ImageRequest$Builder;
+	public static final fun repeatCount (Lcoil3/ImageLoader$Builder;I)Lcoil3/ImageLoader$Builder;
 	public static final fun repeatCount (Lcoil3/request/ImageRequest$Builder;I)Lcoil3/request/ImageRequest$Builder;
 }
 

--- a/coil-gif/src/main/java/coil3/gif/imageRequests.kt
+++ b/coil-gif/src/main/java/coil3/gif/imageRequests.kt
@@ -5,6 +5,7 @@ import android.graphics.drawable.AnimatedImageDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build.VERSION.SDK_INT
 import coil3.Extras
+import coil3.ImageLoader
 import coil3.annotation.ExperimentalCoilApi
 import coil3.getExtra
 import coil3.gif.AnimatedImageDecoder.Companion.ENCODED_LOOP_COUNT
@@ -19,6 +20,15 @@ import coil3.request.Options
  * @see AnimatedImageDrawable.setRepeatCount
  */
 fun ImageRequest.Builder.repeatCount(repeatCount: Int) = apply {
+    if (SDK_INT >= 28) {
+        require(repeatCount >= ENCODED_LOOP_COUNT) { "Invalid repeatCount: $repeatCount" }
+    } else {
+        require(repeatCount >= REPEAT_INFINITE) { "Invalid repeatCount: $repeatCount" }
+    }
+    extras[repeatCountKey] = repeatCount
+}
+
+fun ImageLoader.Builder.repeatCount(repeatCount: Int) = apply {
     if (SDK_INT >= 28) {
         require(repeatCount >= ENCODED_LOOP_COUNT) { "Invalid repeatCount: $repeatCount" }
     } else {


### PR DESCRIPTION
Animation webp have their own number of loops, but in coil animation images are looped indefinitely by default. I'm not sure why.

In my project, most animated webp are played once by default, and I don't want to call `repeatCount(0)` every time I load image

Or, whether to consider the number of animated image loops is set by default to `AnimatedImageDecoder.ENCODED_LOOP_COUNT`


