### PR TITLE
Fix CrossfadePainter intrinsic size logic

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
@@ -99,12 +99,14 @@ class CrossfadePainter(
 
         val isStartSpecified = startSize.isSpecified
         val isEndSpecified = endSize.isSpecified
-        if (isStartSpecified && isEndSpecified) {
-            return Size(
-                width = maxOf(startSize.width, endSize.width),
-                height = maxOf(startSize.height, endSize.height),
-            )
+
+        if (isEndSpecified) {
+            return endSize
         }
+        if (isStartSpecified) {
+            return startSize
+        }
+
         if (preferExactIntrinsicSize) {
             if (isStartSpecified) return startSize
             if (isEndSpecified) return endSize


### PR DESCRIPTION
## Fix CrossfadePainter intrinsic size logic for proper ContentScale behavior


### Solution
Refactored the intrinsic size computation logic to:
- Prioritize the end image's intrinsic size when available
- Fall back to start image's size only when end image size is unspecified


### Changes
- Ensures ContentScale is applied correctly to the final image regardless of placeholder dimensions


### Motivation
- Addresses #1688
