### PR TITLE
Fix potential race condition when consuming OkHttp response body.

### DIFF
--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/CallFactoryNetworkClient.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/CallFactoryNetworkClient.kt
@@ -1,0 +1,70 @@
+package coil3.network.okhttp.internal
+
+import coil3.network.NetworkClient
+import coil3.network.NetworkHeaders
+import coil3.network.NetworkRequest
+import coil3.network.NetworkRequestBody
+import coil3.network.NetworkResponse
+import coil3.network.NetworkResponseBody
+import okhttp3.Call
+import okhttp3.Headers
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okio.Buffer
+import okio.ByteString
+
+@JvmInline
+internal value class CallFactoryNetworkClient(
+    private val callFactory: Call.Factory,
+) : NetworkClient {
+    override suspend fun <T> executeRequest(
+        request: NetworkRequest,
+        block: suspend (response: NetworkResponse) -> T,
+    ) = callFactory.newCall(request.toRequest()).await().use { response ->
+        block(response.toNetworkResponse())
+    }
+}
+
+private suspend fun NetworkRequest.toRequest(): Request {
+    val request = Request.Builder()
+    request.url(url)
+    request.method(method, body?.readByteString()?.toRequestBody())
+    request.headers(headers.toHeaders())
+    return request.build()
+}
+
+private suspend fun NetworkRequestBody.readByteString(): ByteString {
+    val buffer = Buffer()
+    writeTo(buffer)
+    return buffer.readByteString()
+}
+
+private fun Response.toNetworkResponse(): NetworkResponse {
+    return NetworkResponse(
+        code = code,
+        requestMillis = sentRequestAtMillis,
+        responseMillis = receivedResponseAtMillis,
+        headers = headers.toNetworkHeaders(),
+        body = body?.source()?.let(::NetworkResponseBody),
+        delegate = this,
+    )
+}
+
+private fun NetworkHeaders.toHeaders(): Headers {
+    val headers = Headers.Builder()
+    for ((key, values) in asMap()) {
+        for (value in values) {
+            headers.addUnsafeNonAscii(key, value)
+        }
+    }
+    return headers.build()
+}
+
+private fun Headers.toNetworkHeaders(): NetworkHeaders {
+    val headers = NetworkHeaders.Builder()
+    for ((key, values) in this) {
+        headers.add(key, values)
+    }
+    return headers.build()
+}

--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/calls.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/calls.kt
@@ -1,41 +1,51 @@
+/*
+ * Copyright (c) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 package coil3.network.okhttp.internal
 
-import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.CompletionHandler
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Response
 import okio.IOException
 
+// Copied from https://github.com/square/okhttp/blob/master/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt
+// Once we set OkHttp 5.0 as the minimum version we can depend on okhttp-coroutines directly.
 internal suspend fun Call.await(): Response {
     return suspendCancellableCoroutine { continuation ->
-        val callback = ContinuationCallback(this, continuation)
-        enqueue(callback)
-        continuation.invokeOnCancellation(callback)
-    }
-}
+        continuation.invokeOnCancellation { cancel() }
+        enqueue(
+            object : Callback {
+                override fun onFailure(
+                    call: Call,
+                    e: IOException,
+                ) {
+                    continuation.resumeWithException(e)
+                }
 
-private class ContinuationCallback(
-    private val call: Call,
-    private val continuation: CancellableContinuation<Response>
-) : Callback, CompletionHandler {
-
-    override fun onResponse(call: Call, response: Response) {
-        continuation.resume(response)
-    }
-
-    override fun onFailure(call: Call, e: IOException) {
-        if (!call.isCanceled()) {
-            continuation.resumeWithException(e)
-        }
-    }
-
-    override fun invoke(cause: Throwable?) {
-        try {
-            call.cancel()
-        } catch (_: Throwable) {}
+                override fun onResponse(
+                    call: Call,
+                    response: Response,
+                ) {
+                    continuation.resume(response) { _, value, _ ->
+                        value.closeQuietly()
+                    }
+                }
+            },
+        )
     }
 }

--- a/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
+++ b/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt
@@ -1,70 +1,9 @@
 package coil3.network.okhttp.internal
 
-import coil3.network.NetworkClient
-import coil3.network.NetworkHeaders
-import coil3.network.NetworkRequest
-import coil3.network.NetworkRequestBody
-import coil3.network.NetworkResponse
-import coil3.network.NetworkResponseBody
-import okhttp3.Call
-import okhttp3.Headers
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
-import okio.Buffer
-import okio.ByteString
-
-@JvmInline
-internal value class CallFactoryNetworkClient(
-    private val callFactory: Call.Factory,
-) : NetworkClient {
-    override suspend fun <T> executeRequest(
-        request: NetworkRequest,
-        block: suspend (response: NetworkResponse) -> T,
-    ) = callFactory.newCall(request.toRequest()).await().use { response ->
-        block(response.toNetworkResponse())
-    }
-}
-
-private suspend fun NetworkRequest.toRequest(): Request {
-    val request = Request.Builder()
-    request.url(url)
-    request.method(method, body?.readByteString()?.toRequestBody())
-    request.headers(headers.toHeaders())
-    return request.build()
-}
-
-private suspend fun NetworkRequestBody.readByteString(): ByteString {
-    val buffer = Buffer()
-    writeTo(buffer)
-    return buffer.readByteString()
-}
-
-private fun Response.toNetworkResponse(): NetworkResponse {
-    return NetworkResponse(
-        code = code,
-        requestMillis = sentRequestAtMillis,
-        responseMillis = receivedResponseAtMillis,
-        headers = headers.toNetworkHeaders(),
-        body = body?.source()?.let(::NetworkResponseBody),
-        delegate = this,
-    )
-}
-
-private fun NetworkHeaders.toHeaders(): Headers {
-    val headers = Headers.Builder()
-    for ((key, values) in asMap()) {
-        for (value in values) {
-            headers.addUnsafeNonAscii(key, value)
-        }
-    }
-    return headers.build()
-}
-
-private fun Headers.toNetworkHeaders(): NetworkHeaders {
-    val headers = NetworkHeaders.Builder()
-    for ((key, values) in this) {
-        headers.add(key, values)
-    }
-    return headers.build()
+internal fun AutoCloseable.closeQuietly() {
+    try {
+        close()
+    } catch (e: RuntimeException) {
+        throw e
+    } catch (_: Exception) {}
 }


### PR DESCRIPTION
Fixes: https://github.com/coil-kt/coil/issues/3162

I'm not 100%, but I believe this response body leak was due to calling `continuation.resume(response)` without the trailing lambda `onCancellation` callback. In that case it's possible to never close the response body as we cancel before resuming the continuation [and calling `use`](https://github.com/coil-kt/coil/blob/main/coil-network-okhttp/src/commonMain/kotlin/coil3/network/okhttp/internal/utils.kt#L24).

Also this copies the first party OkHttp `await` implementation which I trust more.