### PR TITLE
Fixed the alignment issue when both crossfade and placeholder are present in AsyncImage.

### DIFF
--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
@@ -2,6 +2,7 @@ package coil3.compose
 
 import android.graphics.drawable.Drawable
 import android.view.View
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
 import coil3.request.SuccessResult
 import coil3.request.transitionFactory
@@ -13,6 +14,7 @@ internal actual fun maybeNewCrossfadePainter(
     previous: AsyncImagePainter.State,
     current: AsyncImagePainter.State,
     contentScale: ContentScale,
+    alignment: Alignment,
 ): CrossfadePainter? {
     // We can only invoke the transition factory if the state is success or error.
     val result = when (current) {
@@ -32,7 +34,8 @@ internal actual fun maybeNewCrossfadePainter(
             duration = transition.durationMillis.milliseconds,
             fadeStart = result !is SuccessResult || !result.isPlaceholderCached,
             preferExactIntrinsicSize = transition.preferExactIntrinsicSize,
-            preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize
+            preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize,
+            alignment = alignment
         )
     } else {
         return null

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.ColorFilter
@@ -181,6 +182,7 @@ class AsyncImagePainter internal constructor(
     internal var contentScale = ContentScale.Fit
     internal var filterQuality = DefaultFilterQuality
     internal var previewHandler: AsyncImagePreviewHandler? = null
+    internal var alignment = Alignment.Center
 
     internal var _input: Input? = input
         set(value) {
@@ -309,7 +311,7 @@ class AsyncImagePainter internal constructor(
         val previous = stateFlow.value
         val current = transform(state)
         stateFlow.value = current
-        painter = maybeNewCrossfadePainter(previous, current, contentScale) ?: current.painter
+        painter = maybeNewCrossfadePainter(previous, current, contentScale, alignment) ?: current.painter
 
         // Manually forget and remember the old/new painters.
         if (previous.painter !== current.painter) {
@@ -418,4 +420,5 @@ internal expect fun maybeNewCrossfadePainter(
     previous: State,
     current: State,
     contentScale: ContentScale,
+    alignment: Alignment,
 ): CrossfadePainter?

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/CrossfadePainter.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.geometry.isUnspecified
@@ -14,6 +15,8 @@ import androidx.compose.ui.graphics.drawscope.inset
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.times
+import androidx.compose.ui.unit.IntSize
+import coil3.compose.internal.toIntSize
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
@@ -38,6 +41,7 @@ import kotlin.time.TimeSource
  * @param preferEndFirstIntrinsicSize Returns `true` if this request prefers the end painter's intrinsic size
  * when calculating the `CrossfadePainter`'s intrinsic size.
  * When enabled, the end painter's intrinsic size takes precedence.
+ * @param alignment Optional alignment parameter used to place the painters in the given bounds.
  */
 @Stable
 class CrossfadePainter(
@@ -48,7 +52,8 @@ class CrossfadePainter(
     val timeSource: TimeSource = TimeSource.Monotonic,
     val fadeStart: Boolean = true,
     val preferExactIntrinsicSize: Boolean = false,
-    val preferEndFirstIntrinsicSize: Boolean = false
+    val preferEndFirstIntrinsicSize: Boolean = false,
+    val alignment: Alignment = Alignment.Center
 ) : Painter() {
 
     @Deprecated("Kept for binary compatibility.", level = DeprecationLevel.HIDDEN)
@@ -60,7 +65,7 @@ class CrossfadePainter(
         timeSource: TimeSource = TimeSource.Monotonic,
         fadeStart: Boolean = true,
         preferExactIntrinsicSize: Boolean = false,
-    ) : this(start, end, contentScale, duration, timeSource, fadeStart, preferExactIntrinsicSize)
+    ) : this(start, end, contentScale, duration, timeSource, fadeStart, preferExactIntrinsicSize, Alignment.Center)
 
     private var invalidateTick by mutableIntStateOf(0)
     private var startTime: TimeMark? = null
@@ -144,9 +149,14 @@ class CrossfadePainter(
             if (size.isUnspecified || size.isEmpty()) {
                 draw(drawSize, alpha, colorFilter)
             } else {
+                val (dx, dy) = alignment.align(
+                    size = drawSize.toIntSize(),
+                    space = size.toIntSize(),
+                    layoutDirection = layoutDirection,
+                )
                 inset(
-                    horizontal = (size.width - drawSize.width) / 2,
-                    vertical = (size.height - drawSize.height) / 2,
+                    horizontal = dx.toFloat(),
+                    vertical = dy.toFloat(),
                 ) {
                     draw(drawSize, alpha, colorFilter)
                 }

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/ContentPainterModifier.kt
@@ -77,6 +77,7 @@ internal data class ContentPainterElement(
         painter.contentScale = contentScale
         painter.filterQuality = filterQuality
         painter.previewHandler = previewHandler
+        painter.alignment = alignment
         painter._input = input
 
         return ContentPainterNode(
@@ -101,6 +102,7 @@ internal data class ContentPainterElement(
         painter.contentScale = contentScale
         painter.filterQuality = filterQuality
         painter.previewHandler = previewHandler
+        painter.alignment = alignment
         painter._input = input
 
         val intrinsicsChanged = previousIntrinsics != painter.intrinsicSize

--- a/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
+++ b/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
@@ -1,5 +1,6 @@
 package coil3.compose
 
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
 import coil3.decode.DataSource
 import coil3.request.SuccessResult
@@ -10,6 +11,7 @@ internal actual fun maybeNewCrossfadePainter(
     previous: AsyncImagePainter.State,
     current: AsyncImagePainter.State,
     contentScale: ContentScale,
+    alignment: Alignment,
 ): CrossfadePainter? {
     // We can only invoke the transition factory if the state is success or error.
     val result = when (current) {
@@ -38,7 +40,8 @@ internal actual fun maybeNewCrossfadePainter(
             duration = crossfadeMillis.milliseconds,
             fadeStart = !result.isPlaceholderCached,
             preferExactIntrinsicSize = false,
-            preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize
+            preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize,
+            alignment = alignment
         )
     } else {
         return null


### PR DESCRIPTION
Fixed the alignment issue when both crossfade and placeholder are present in AsyncImage.
The problem was that CrossfadePainter always centered its child painters, overriding the alignment set on AsyncImage.
Changes made:
CrossfadePainter.kt: Added alignment parameter and updated drawPainter() to use alignment instead of centering
AsyncImagePainter.kt: Added alignment property and passed it to maybeNewCrossfadePainter
AsyncImagePainter.android.kt and AsyncImagePainter.nonAndroid.kt: Updated maybeNewCrossfadePainter to accept and pass alignment to CrossfadePainter
ContentPainterModifier.kt: Updated to set alignment on AsyncImagePainter when creating/updating