### PR TITLE
docs: use Ktor3 instead of OkHttp in Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Import the Compose library and a [networking library](https://coil-kt.github.io/
 
 ```kotlin
 implementation("io.coil-kt.coil3:coil-compose:3.3.0")
-implementation("io.coil-kt.coil3:coil-network-okhttp:3.3.0")
+implementation("io.coil-kt.coil3:coil-network-ktor3:3.3.0")
 ```
 
 To load an image, use the `AsyncImage` composable:


### PR DESCRIPTION
## Summary

Updates the Quick Start example in the README to use `coil-network-ktor3` instead of `coil-network-okhttp`.

## Motivation

While working on a Compose Multiplatform project, I followed the Quick Start guide and used the `coil-network-okhttp` dependency. After integrating Coil and running the project, I encountered errors on iOS because OkHttp is not compatible with KMP (iOS not supported).

I had to research and discover that Ktor3 is the KMP-compatible alternative, then update my dependencies accordingly.

## Why This Change Makes Sense

1. **Coil markets itself as supporting Compose Multiplatform** - the README tagline explicitly mentions "Android and Compose Multiplatform"
2. **Ktor3 works for both Android-only and KMP projects** - it's a universal solution that won't block any users
3. **Better developer experience** - users won't need to debug and switch networking libraries after initial setup
4. **Aligns example with target audience** - many developers coming to Coil are working on KMP projects

## Changes

- Updated Quick Start dependency from `coil-network-okhttp` to `coil-network-ktor3`

This is a documentation-only change with no impact on the library code itself.