### PR TITLE
Make BitmapFetcher available in common code

### DIFF
--- a/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/RealImageLoader.android.kt
@@ -5,7 +5,6 @@ import coil3.decode.BitmapFactoryDecoder
 import coil3.decode.ExifOrientationStrategy.Companion.RESPECT_PERFORMANCE
 import coil3.decode.StaticImageDecoder
 import coil3.fetch.AssetUriFetcher
-import coil3.fetch.BitmapFetcher
 import coil3.fetch.ContentUriFetcher
 import coil3.fetch.DrawableFetcher
 import coil3.fetch.ResourceUriFetcher
@@ -84,7 +83,6 @@ internal actual fun ComponentRegistry.Builder.addAndroidComponents(
     add(ContentUriFetcher.Factory())
     add(ResourceUriFetcher.Factory())
     add(DrawableFetcher.Factory())
-    add(BitmapFetcher.Factory())
 
     // Decoders
     val parallelismLock = Semaphore(options.bitmapFactoryMaxParallelism)

--- a/coil-core/src/commonMain/kotlin/coil3/RealImageLoader.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/RealImageLoader.kt
@@ -1,6 +1,7 @@
 package coil3
 
 import coil3.disk.DiskCache
+import coil3.fetch.BitmapFetcher
 import coil3.fetch.ByteArrayFetcher
 import coil3.fetch.DataUriFetcher
 import coil3.fetch.FileUriFetcher
@@ -301,6 +302,7 @@ internal fun ComponentRegistry.Builder.addCommonComponents(): ComponentRegistry.
         .add(FileUriFetcher.Factory())
         .add(ByteArrayFetcher.Factory())
         .add(DataUriFetcher.Factory())
+        .add(BitmapFetcher.Factory())
 }
 
 private const val TAG = "RealImageLoader"

--- a/coil-core/src/commonMain/kotlin/coil3/fetch/BitmapFetcher.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/fetch/BitmapFetcher.kt
@@ -1,20 +1,18 @@
 package coil3.fetch
 
-import android.graphics.Bitmap
+import coil3.Bitmap
 import coil3.ImageLoader
 import coil3.asImage
 import coil3.decode.DataSource
 import coil3.request.Options
-import coil3.util.toDrawable
 
 internal class BitmapFetcher(
     private val data: Bitmap,
-    private val options: Options,
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult {
         return ImageFetchResult(
-            image = data.toDrawable(options.context).asImage(),
+            image = data.asImage(),
             isSampled = false,
             dataSource = DataSource.MEMORY,
         )
@@ -23,7 +21,7 @@ internal class BitmapFetcher(
     class Factory : Fetcher.Factory<Bitmap> {
 
         override fun create(data: Bitmap, options: Options, imageLoader: ImageLoader): Fetcher {
-            return BitmapFetcher(data, options)
+            return BitmapFetcher(data)
         }
     }
 }


### PR DESCRIPTION
In our compose multiplatform project we noticed that on iOS Coil was unable to display in-memory images (`coil3.Bitmap` instances) because there is no fetcher registered. On Android this does work out of the box due to the existence of a `BitmapFetcher`. I could see no reason why this should be implemented only for Android, and so in this PR I've moved the implementation to common code.

The Android implementation originally called `data.toDrawable(options.context).asImage()`, but the `toDrawable(...)` step in-between is basically a no-op as far as I can tell, so it should be safe to just leave that out.