### PR TITLE
  Add lint check for kotlin.error() misuse inside ImageRequest.Builder. (#2887)

### DIFF
--- a/coil-lint/build.gradle.kts
+++ b/coil-lint/build.gradle.kts
@@ -1,0 +1,41 @@
+import coil3.setupPublishing
+import com.vanniktech.maven.publish.JavaLibrary
+import com.vanniktech.maven.publish.JavadocJar
+import org.gradle.api.attributes.java.TargetJvmVersion
+
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+    id("com.vanniktech.maven.publish.base")
+}
+
+setupPublishing {
+    configure(JavaLibrary(javadocJar = JavadocJar.Empty()))
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+// Lint dependencies require JVM 11+, so we must request JVM 17 compatible dependencies.
+configurations.configureEach {
+    if (isCanBeResolved) {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
+}
+
+dependencies {
+    compileOnly(libs.lint.api)
+    compileOnly(libs.lint.checks)
+
+    testImplementation(libs.lint.core)
+    testImplementation(libs.lint.tests)
+    testImplementation(libs.junit)
+}
+
+tasks.jar {
+    manifest {
+        attributes("Lint-Registry-v2" to "coil3.lint.CoilIssueRegistry")
+    }
+}

--- a/coil-lint/gradle.properties
+++ b/coil-lint/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=coil-lint
+POM_NAME=coil-lint
+POM_PACKAGING=jar

--- a/coil-lint/src/main/kotlin/coil3/lint/CoilIssueRegistry.kt
+++ b/coil-lint/src/main/kotlin/coil3/lint/CoilIssueRegistry.kt
@@ -1,0 +1,21 @@
+package coil3.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.client.api.Vendor
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+class CoilIssueRegistry : IssueRegistry() {
+
+    override val issues: List<Issue> = listOf(
+        ErrorFunctionDetector.ISSUE,
+    )
+
+    override val api: Int = CURRENT_API
+
+    override val vendor: Vendor = Vendor(
+        vendorName = "Coil",
+        identifier = "coil",
+        feedbackUrl = "https://github.com/coil-kt/coil/issues",
+    )
+}

--- a/coil-lint/src/main/kotlin/coil3/lint/ErrorFunctionDetector.kt
+++ b/coil-lint/src/main/kotlin/coil3/lint/ErrorFunctionDetector.kt
@@ -1,0 +1,148 @@
+package coil3.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.ULambdaExpression
+
+class ErrorFunctionDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableMethodNames(): List<String> = listOf("error")
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: PsiMethod,
+    ) {
+        // Check if this is kotlin.error() from stdlib
+        if (!isKotlinStdlibError(method)) {
+            return
+        }
+
+        // Check if we're inside an ImageRequest.Builder lambda context
+        if (!isInsideImageRequestBuilderLambda(node)) {
+            return
+        }
+
+        context.report(
+            issue = ISSUE,
+            scope = node,
+            location = context.getLocation(node),
+            message = "Using `kotlin.error()` inside `ImageRequest.Builder`. " +
+                "Did you mean to use Coil's `error()` extension function to set an error drawable? " +
+                "Consider importing `coil3.request.error` instead.",
+        )
+    }
+
+    private fun isKotlinStdlibError(method: PsiMethod): Boolean {
+        val containingClass = method.containingClass?.qualifiedName ?: return false
+
+        // Standard stdlib class names
+        if (containingClass == "kotlin.PreconditionsKt" ||
+            containingClass == "kotlin.PreconditionsKt__PreconditionsKt"
+        ) {
+            return true
+        }
+
+        // For test stubs and some Kotlin versions, the file facade might have different names
+        // Check if it's a top-level function in the kotlin package that returns Nothing
+        if (containingClass.startsWith("kotlin.") &&
+            method.returnType?.canonicalText == "kotlin.Nothing"
+        ) {
+            return true
+        }
+
+        return false
+    }
+
+    private fun isInsideImageRequestBuilderLambda(node: UElement): Boolean {
+        var current: UElement? = node
+        while (current != null) {
+            if (current is ULambdaExpression) {
+                val lambdaParent = current.uastParent
+                if (lambdaParent is UCallExpression) {
+                    val receiverType = lambdaParent.receiverType?.canonicalText
+                    val methodName = lambdaParent.methodName
+
+                    // Check for ImageView.load { } or AsyncImage calls
+                    if (methodName == "load" || methodName == "AsyncImage" || methodName == "SubcomposeAsyncImage") {
+                        return true
+                    }
+
+                    // Check for ImageRequest.Builder { } or ImageRequest.Builder().apply { }
+                    if (receiverType?.contains("ImageRequest.Builder") == true) {
+                        return true
+                    }
+                    if (receiverType?.contains("ImageRequest\$Builder") == true) {
+                        return true
+                    }
+
+                    // Check if the lambda is the trailing lambda of a function that returns/uses ImageRequest.Builder
+                    val resolvedMethod = lambdaParent.resolve()
+                    if (resolvedMethod != null) {
+                        val returnType = resolvedMethod.returnType?.canonicalText ?: ""
+                        if (returnType.contains("ImageRequest.Builder") || returnType.contains("ImageRequest\$Builder")) {
+                            return true
+                        }
+
+                        // Check parameter types for builder lambda
+                        for (param in resolvedMethod.parameterList.parameters) {
+                            val paramType = param.type.canonicalText
+                            if (paramType.contains("ImageRequest.Builder") || paramType.contains("ImageRequest\$Builder")) {
+                                return true
+                            }
+                        }
+                    }
+                }
+            }
+            current = current.uastParent
+        }
+        return false
+    }
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "CoilErrorFunction",
+            briefDescription = "Kotlin stdlib `error()` used inside ImageRequest.Builder",
+            explanation = """
+                Using Kotlin's stdlib `error()` function inside an `ImageRequest.Builder` lambda \
+                (such as in `imageView.load { }` or `AsyncImage`) will throw an `IllegalStateException` \
+                at runtime instead of setting an error drawable.
+
+                This is likely a mistake caused by IDE auto-import selecting the wrong function. \
+                Use Coil's `error(drawable)` extension function instead to set an error placeholder.
+
+                **Wrong:**
+                ```kotlin
+                imageView.load(url) {
+                    error(R.drawable.error) // This is kotlin.error() - throws exception!
+                }
+                ```
+
+                **Correct:**
+                ```kotlin
+                import coil3.request.error
+
+                imageView.load(url) {
+                    error(R.drawable.error) // This is coil3.request.error() - sets error drawable
+                }
+                ```
+            """.trimIndent(),
+            category = Category.CORRECTNESS,
+            priority = 6,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                ErrorFunctionDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            ),
+        )
+    }
+}

--- a/coil-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
+++ b/coil-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
@@ -1,0 +1,1 @@
+coil3.lint.CoilIssueRegistry

--- a/coil-lint/src/test/kotlin/coil3/lint/ErrorFunctionDetectorTest.kt
+++ b/coil-lint/src/test/kotlin/coil3/lint/ErrorFunctionDetectorTest.kt
@@ -1,0 +1,160 @@
+package coil3.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+
+class ErrorFunctionDetectorTest : LintDetectorTest() {
+
+    override fun getDetector(): Detector = ErrorFunctionDetector()
+
+    override fun getIssues(): List<Issue> = listOf(ErrorFunctionDetector.ISSUE)
+
+    private val imageViewStub: TestFile = kotlin(
+        """
+        package android.widget
+        class ImageView
+        """,
+    ).indented()
+
+    private val coilExtensionsStub: TestFile = kotlin(
+        """
+        package coil3
+        import android.widget.ImageView
+        inline fun ImageView.load(
+            data: Any?,
+            builder: ImageRequestBuilder.() -> Unit = {},
+        ) {}
+        class ImageRequestBuilder {
+            fun placeholder(drawable: Int) {}
+            fun crossfade(enable: Boolean) {}
+        }
+        """,
+    ).indented()
+
+    private val coilErrorExtensionStub: TestFile = kotlin(
+        """
+        package coil3.request
+        import coil3.ImageRequestBuilder
+        fun ImageRequestBuilder.error(drawable: Int) {}
+        """,
+    ).indented()
+
+    private val kotlinErrorStub: TestFile = kotlin(
+        """
+        package kotlin
+        fun error(message: Any): Nothing = throw IllegalStateException(message.toString())
+        """,
+    ).indented()
+
+    @Test
+    fun testStdlibErrorInsideLoadBlockTriggersWarning() {
+        lint()
+            .allowMissingSdk()
+            .testModes(TestMode.JVM_OVERLOADS)
+            .files(
+                imageViewStub,
+                coilExtensionsStub,
+                kotlinErrorStub,
+                kotlin(
+                    """
+                    package test
+
+                    import android.widget.ImageView
+                    import coil3.load
+                    import kotlin.error
+
+                    fun test(imageView: ImageView) {
+                        imageView.load("https://example.com/image.jpg") {
+                            error("Failed to load") // Wrong: This is kotlin.error()
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectWarningCount(1)
+            .expectContains("Using kotlin.error() inside ImageRequest.Builder")
+    }
+
+    @Test
+    fun testCoilErrorExtensionDoesNotTriggerWarning() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                imageViewStub,
+                coilExtensionsStub,
+                coilErrorExtensionStub,
+                kotlin(
+                    """
+                    package test
+
+                    import android.widget.ImageView
+                    import coil3.load
+                    import coil3.request.error
+
+                    fun test(imageView: ImageView) {
+                        imageView.load("https://example.com/image.jpg") {
+                            error(android.R.drawable.ic_delete) // Correct: Coil's error()
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun testStdlibErrorOutsideCoilContextDoesNotTriggerWarning() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                kotlinErrorStub,
+                kotlin(
+                    """
+                    package test
+
+                    import kotlin.error
+
+                    fun validateInput(input: String) {
+                        if (input.isEmpty()) {
+                            error("Input cannot be empty") // This is fine - not in Coil context
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun testStdlibErrorInRegularLambdaDoesNotTriggerWarning() {
+        lint()
+            .allowMissingSdk()
+            .files(
+                kotlinErrorStub,
+                kotlin(
+                    """
+                    package test
+
+                    import kotlin.error
+
+                    fun process(items: List<String>) {
+                        items.forEach { item ->
+                            if (item.isEmpty()) {
+                                error("Empty item found") // This is fine - not in Coil context
+                            }
+                        }
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ okio = "3.16.4"
 paparazzi = "2.0.0-alpha04"
 roborazzi = "1.56.0"
 skiko = "0.9.22.2"
+lint = "31.13.2"
 
 [plugins]
 baselineProfile = { id = "androidx.baselineprofile", version.ref = "androidx-benchmark" }
@@ -99,6 +100,11 @@ roborazzi-junit = { module = "io.github.takahirom.roborazzi:roborazzi-junit-rule
 skiko = { module = "org.jetbrains.skiko:skiko", version.ref = "skiko" }
 
 svg = "com.caverock:androidsvg-aar:1.4"
+
+lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
+lint-checks = { module = "com.android.tools.lint:lint-checks", version.ref = "lint" }
+lint-core = { module = "com.android.tools.lint:lint", version.ref = "lint" }
+lint-tests = { module = "com.android.tools.lint:lint-tests", version.ref = "lint" }
 
 [bundles]
 test-android = [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "coil-network-okhttp",
     "coil-network-cache-control",
     "coil-gif",
+    "coil-lint",
     "coil-svg",
     "coil-video",
     "coil-bom",


### PR DESCRIPTION
                                                                                                                                                                           
  ## Summary                                                                                                                                                               
  - Add new `coil-lint` module with `ErrorFunctionDetector` that warns when `kotlin.error()` is accidentally used inside `ImageRequest.Builder` lambdas (e.g.,
  `imageView.load {}`, `AsyncImage`, `SubcomposeAsyncImage`)                                                                                                               
  - IDE auto-import often selects `kotlin.error()` instead of Coil's `error()` extension, causing runtime `IllegalStateException` instead of setting an error drawable     

  ## Test plan
  - [x] Unit test: `kotlin.error()` inside `load {}` triggers warning
  - [x] Unit test: Coil's `error()` extension does not trigger warning
  - [x] Unit test: `kotlin.error()` outside Coil context does not trigger warning
  - [x] Unit test: `kotlin.error()` in regular lambdas does not trigger warning

  Closes #2887

