### PR TITLE
Update sonatype snapshot repo link in faq

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,7 +78,7 @@ Gradle (`.gradle`):
 ```groovy
 allprojects {
     repositories {
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
     }
 }
 ```
@@ -88,7 +88,7 @@ Gradle Kotlin DSL (`.gradle.kts`):
 ```kotlin
 allprojects {
     repositories {
-        maven("https://oss.sonatype.org/content/repositories/snapshots")
+        maven("https://central.sonatype.com/repository/maven-snapshots/")
     }
 }
 ```


### PR DESCRIPTION
Sonatype OSS (OSSRH) is deprecated and migrated to central sonatype, so I've updated the repo url accordingly
