### PR TITLE
feat: Add default `accept` header on Android

### DIFF
--- a/coil-network-core/src/androidHostTest/kotlin/coil3/network/AcceptHeadersTest.kt
+++ b/coil-network-core/src/androidHostTest/kotlin/coil3/network/AcceptHeadersTest.kt
@@ -1,0 +1,149 @@
+package coil3.network
+
+import android.graphics.ImageDecoder
+import android.os.Build
+import coil3.Extras
+import coil3.fetch.SourceFetchResult
+import coil3.request.Options
+import coil3.test.utils.RobolectricTest
+import coil3.test.utils.context
+import coil3.test.utils.runTestAsync
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import okio.Buffer
+import okio.ByteString.Companion.toByteString
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+
+@Config(shadows = [AcceptHeadersTest.CustomShadowImageDecoder::class])
+class AcceptHeadersTest : RobolectricTest() {
+
+    @AfterTest
+    fun tearDown(){
+        CustomShadowImageDecoder.clearSupportedMimeTypes()
+    }
+
+    @Test
+    @Config(sdk = [Config.OLDEST_SDK])
+    fun allAndroidsSupportBasicFormats() = testAcceptHeader(
+        isAvifSupported = false,
+        expectedValue = "image/bmp;q=0.1,image/gif;q=0.1,image/jpeg;q=0.2,image/pjpg;q=0.2,image/png;q=0.3,image/webp;q=0.4",
+    )
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.O])
+    fun android8SupportsHeic() = testAcceptHeader(
+        isAvifSupported = false,
+        expectedValue = "image/bmp;q=0.1,image/gif;q=0.1,image/jpeg;q=0.2,image/pjpg;q=0.2,image/png;q=0.3,image/webp;q=0.4,image/heic;q=0.5",
+    )
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.S])
+    fun android12DoesntHaveToSupportsAvif() = testAcceptHeader(
+        isAvifSupported = false,
+        expectedValue = "image/bmp;q=0.1,image/gif;q=0.1,image/jpeg;q=0.2,image/pjpg;q=0.2,image/png;q=0.3,image/webp;q=0.4,image/heic;q=0.5",
+    )
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+    fun android14SupportsAvif() = testAcceptHeader(
+        isAvifSupported = true,
+        expectedValue = "image/bmp;q=0.1,image/gif;q=0.1,image/jpeg;q=0.2,image/pjpg;q=0.2,image/png;q=0.3,image/webp;q=0.4,image/heic;q=0.5,image/avif;q=0.6",
+    )
+
+    @Test
+    @Config(sdk = [Config.NEWEST_SDK])
+    fun acceptHeaderIsPassedThrough() = testAcceptHeader(
+        isAvifSupported = true,
+        headers = NetworkHeaders.Builder().set("accept", "image/gif").build(),
+        expectedValue = "image/gif",
+    )
+
+    private fun testAcceptHeader(
+        isAvifSupported: Boolean,
+        headers: NetworkHeaders = NetworkHeaders.EMPTY,
+        expectedValue: String,
+    ) = runTestAsync {
+        if (isAvifSupported) CustomShadowImageDecoder.addSupportedMimeType("image/avif")
+
+        val expectedSize = 1_000
+        val url = "https://example.com/image.jpg"
+        val method = "POST"
+        val body = NetworkRequestBody(ByteArray(500).toByteString())
+        val options = Options(
+            context = context,
+            extras = Extras.Builder()
+                .set(Extras.Key.httpMethod, method)
+                .set(Extras.Key.httpHeaders, headers)
+                .set(Extras.Key.httpBody, body)
+                .build(),
+        )
+        val networkClient = FakeNetworkClient(
+            respond = {
+                NetworkResponse(
+                    body = NetworkResponseBody(
+                        source = Buffer().apply { write(ByteArray(expectedSize)) },
+                    ),
+                )
+            },
+        )
+        val result = NetworkFetcher(
+            url = url,
+            options = options,
+            networkClient = lazyOf(networkClient),
+            diskCache = lazyOf(null),
+            cacheStrategy = lazyOf(CacheStrategy.DEFAULT),
+            connectivityChecker = lazyOf(ConnectivityChecker(context)),
+            concurrentRequestStrategy = lazyOf(ConcurrentRequestStrategy.UNCOORDINATED),
+        ).fetch()
+
+        assertIs<SourceFetchResult>(result)
+
+        assertEquals(networkClient.requests.single().headers["accept"], expectedValue)
+    }
+
+    class FakeNetworkClient(
+        private val respond: suspend (NetworkRequest) -> NetworkResponse,
+    ) : NetworkClient {
+        val requests = mutableListOf<NetworkRequest>()
+        val responses = mutableListOf<NetworkResponse>()
+
+        override suspend fun <T> executeRequest(
+            request: NetworkRequest, block: suspend (response: NetworkResponse) -> T,
+        ): T {
+            requests += request
+            val response = respond(request)
+            responses += response
+            return block(response)
+        }
+    }
+
+    @Implements(ImageDecoder::class)
+    class CustomShadowImageDecoder {
+        companion object {
+            private val supportedMimeTypes = mutableSetOf<String>()
+
+            fun setSupportedMimeTypes(vararg mimeTypes: String) {
+                supportedMimeTypes.clear()
+                supportedMimeTypes.addAll(mimeTypes)
+            }
+
+            fun addSupportedMimeType(mimeType: String) {
+                supportedMimeTypes.add(mimeType)
+            }
+
+            fun clearSupportedMimeTypes() {
+                supportedMimeTypes.clear()
+            }
+
+            @Implementation
+            @JvmStatic
+            fun isMimeTypeSupported(mimeType: String): Boolean {
+                return supportedMimeTypes.contains(mimeType)
+            }
+        }
+    }
+}

--- a/coil-network-core/src/androidHostTest/kotlin/coil3/network/AcceptHeadersTest.kt
+++ b/coil-network-core/src/androidHostTest/kotlin/coil3/network/AcceptHeadersTest.kt
@@ -22,7 +22,7 @@ import org.robolectric.annotation.Implements
 class AcceptHeadersTest : RobolectricTest() {
 
     @AfterTest
-    fun tearDown(){
+    fun tearDown() {
         CustomShadowImageDecoder.clearSupportedMimeTypes()
     }
 

--- a/coil-network-core/src/androidMain/kotlin/coil3/network/internal/PlatformHeaders.android.kt
+++ b/coil-network-core/src/androidMain/kotlin/coil3/network/internal/PlatformHeaders.android.kt
@@ -1,0 +1,24 @@
+package coil3.network.internal
+
+import android.graphics.ImageDecoder
+import android.os.Build
+import coil3.network.NetworkHeaders
+
+internal actual fun getPlatformHeaders(): NetworkHeaders = NetworkHeaders.Builder().set("accept", supportedMimeTypes).build()
+
+// Won't change during runtime
+private val supportedMimeTypes by lazy {
+    // https://developer.android.com/media/platform/supported-formats#image-formats
+    val alwaysSupportedTypes =
+        listOf("bmp;q=0.1", "gif;q=0.1", "jpeg;q=0.2", "pjpg;q=0.2", "png;q=0.3", "webp;q=0.4")
+    val typesSupportedFromSpecificApi = buildList {
+        // Technically previous release could also work, but we can't check for 4.2.1, only for 4.2
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            add("heic;q=0.5")
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ImageDecoder.isMimeTypeSupported("image/avif")) {
+            add("avif;q=0.6")
+        }
+    }
+    (alwaysSupportedTypes + typesSupportedFromSpecificApi).joinToString(",") { "image/$it" }
+}

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/NetworkFetcher.kt
@@ -17,6 +17,8 @@ import coil3.network.internal.MIME_TYPE_TEXT_PLAIN
 import coil3.network.internal.abortQuietly
 import coil3.network.internal.assertNotOnMainThread
 import coil3.network.internal.closeQuietly
+import coil3.network.internal.getPlatformHeaders
+import coil3.network.internal.plus
 import coil3.network.internal.readBuffer
 import coil3.network.internal.requireBody
 import coil3.network.internal.singleParameterLazy
@@ -204,7 +206,8 @@ class NetworkFetcher(
     }
 
     private fun newRequest(): NetworkRequest {
-        val headers = options.httpHeaders.newBuilder()
+        // We get default platform headers, but they can be overridden by user-set ones
+        val headers = getPlatformHeaders().plus(options.httpHeaders).newBuilder()
         val diskRead = options.diskCachePolicy.readEnabled
         val networkRead = options.networkCachePolicy.readEnabled && connectivityChecker.value.isOnline()
         when {

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/internal/PlatformHeaders.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/internal/PlatformHeaders.kt
@@ -2,4 +2,4 @@ package coil3.network.internal
 
 import coil3.network.NetworkHeaders
 
-internal fun getPlatformHeaders(): NetworkHeaders = NetworkHeaders.EMPTY
+internal expect fun getPlatformHeaders(): NetworkHeaders

--- a/coil-network-core/src/commonMain/kotlin/coil3/network/internal/PlatformHeaders.kt
+++ b/coil-network-core/src/commonMain/kotlin/coil3/network/internal/PlatformHeaders.kt
@@ -1,0 +1,5 @@
+package coil3.network.internal
+
+import coil3.network.NetworkHeaders
+
+internal fun getPlatformHeaders(): NetworkHeaders = NetworkHeaders.EMPTY

--- a/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
+++ b/coil-network-core/src/commonTest/kotlin/coil3/network/NetworkFetcherTest.kt
@@ -3,6 +3,8 @@ package coil3.network
 import coil3.Extras
 import coil3.disk.DiskCache
 import coil3.fetch.SourceFetchResult
+import coil3.network.internal.getPlatformHeaders
+import coil3.network.internal.plus
 import coil3.request.Options
 import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
@@ -18,7 +20,7 @@ import okio.fakefilesystem.FakeFileSystem
 class NetworkFetcherTest : RobolectricTest() {
 
     @Test
-    fun networkRequestParamsArePassedThrough() = runTestAsync {
+    fun networkRequestParamsAreUsedInFinalRequest() = runTestAsync {
         val expectedSize = 1_000
         val url = "https://example.com/image.jpg"
         val method = "POST"
@@ -55,7 +57,7 @@ class NetworkFetcherTest : RobolectricTest() {
 
         assertIs<SourceFetchResult>(result)
 
-        val expected = NetworkRequest(url, method, headers, body, options.extras)
+        val expected = NetworkRequest(url, method, getPlatformHeaders() + headers, body, options.extras)
 
         assertEquals(expected, networkClient.requests.single())
     }

--- a/coil-network-core/src/nonAndroidMain/kotlin/coil3/network/internal/PlatformHeaders.nonAndroid.kt
+++ b/coil-network-core/src/nonAndroidMain/kotlin/coil3/network/internal/PlatformHeaders.nonAndroid.kt
@@ -1,0 +1,5 @@
+package coil3.network.internal
+
+import coil3.network.NetworkHeaders
+
+internal actual fun getPlatformHeaders(): NetworkHeaders = NetworkHeaders.EMPTY


### PR DESCRIPTION
This PR adds `accept` header for Android used by some CDNs, so that the best possible image format could be delivered by the CDN, instead of falling back to "default" one (which often is just `image/jpeg`).

It also retains `accept` header if it was explicitly set by the user.