### PR TITLE
fix: re-apply transform when it changes in AsyncImagePainter

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -175,8 +175,22 @@ class AsyncImagePainter internal constructor(
             }
         }
 
+    private var rawState: State = State.Empty
+
     internal lateinit var scope: CoroutineScope
     internal var transform = DefaultTransform
+        set(value) {
+            if (field !== value) {
+                field = value
+                // Re-apply the new transform to the current raw state so that
+                // painter changes driven by external state (e.g. light/dark mode
+                // switching the error/placeholder painter) are reflected immediately
+                // without requiring a full image reload.
+                if (isRemembered) {
+                    updateState(rawState)
+                }
+            }
+        }
     internal var onState: ((State) -> Unit)? = null
     internal var contentScale = ContentScale.Fit
     internal var filterQuality = DefaultFilterQuality
@@ -306,6 +320,7 @@ class AsyncImagePainter internal constructor(
     }
 
     private fun updateState(state: State) {
+        rawState = state
         val previous = stateFlow.value
         val current = transform(state)
         stateFlow.value = current


### PR DESCRIPTION
## Summary

When the `transform` function is updated (e.g. light/dark mode changes causing `painterResource()` to return a new error/fallback painter), `AsyncImagePainter` was not refreshing the displayed painter because `updateState()` was never called again for the already-settled result.

### Root cause

`AsyncImagePainter.transform` is a plain `var`. On recomposition, `painter.transform = transform` is called with the new transform. However, the painter stored in `stateFlow` was never re-derived from the new transform, so the old (pre-theme-change) painter remained on screen.

### Fix

- Store the pre-transform state as `rawState`
- Add a custom setter on `transform` that calls `updateState(rawState)` when the transform reference changes

No public API changes.

Closes #3245
