### PR TITLE
Fix JS/Wasm EXIF orientation sizing

### DIFF
--- a/coil-core/src/jsCommonMain/kotlin/coil3/decode/SkiaImageDecoder.jsCommon.kt
+++ b/coil-core/src/jsCommonMain/kotlin/coil3/decode/SkiaImageDecoder.jsCommon.kt
@@ -80,6 +80,7 @@ internal fun getJpegSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
     if (bytes.size < 10) return null
     if (int16(bytes[0], bytes[1]) == 0xFFD8u) {
         var offset = 2
+        var orientation = 0
         while (offset < bytes.size - 6) {
             val marker = int16(bytes[offset], bytes[offset + 1])
             offset += 2
@@ -87,14 +88,91 @@ internal fun getJpegSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
             if (marker in 0xFFC0u..0xFFCFu && marker != 0xFFC4u && marker != 0xFFC8u && marker != 0xFFCCu) {
                 val height = int16(bytes[offset + 3], bytes[offset + 4])
                 val width = int16(bytes[offset + 5], bytes[offset + 6])
-                return width.toInt() to height.toInt()
+                return if (orientation.isSwapped) {
+                    height.toInt() to width.toInt()
+                } else {
+                    width.toInt() to height.toInt()
+                }
             }
 
             val segmentLength = int16(bytes[offset], bytes[offset + 1])
+            if (marker == 0xFFE1u) {
+                val exifOrientation = getExifOrientation(
+                    bytes = bytes,
+                    offset = offset + 2,
+                    length = segmentLength.toInt() - 2,
+                )
+                if (exifOrientation > 0) {
+                    orientation = exifOrientation
+                }
+            }
             offset += segmentLength.toInt()
         }
     }
     return null
+}
+
+private val Int.isSwapped: Boolean
+    get() = this in 5..8
+
+private fun getExifOrientation(
+    bytes: ByteArray,
+    offset: Int,
+    length: Int,
+): Int {
+    if (length < 14 || offset < 0 || offset + length > bytes.size) return 0
+    if (bytes[offset + 0].asInt() != 0x45u || // E
+        bytes[offset + 1].asInt() != 0x78u || // x
+        bytes[offset + 2].asInt() != 0x69u || // i
+        bytes[offset + 3].asInt() != 0x66u || // f
+        bytes[offset + 4].asInt() != 0u ||
+        bytes[offset + 5].asInt() != 0u
+    ) {
+        return 0
+    }
+
+    val tiffOffset = offset + 6
+    val isLittleEndian = when (int16(bytes[tiffOffset], bytes[tiffOffset + 1])) {
+        0x4949u -> true
+        0x4D4Du -> false
+        else -> return 0
+    }
+    val read16 = if (isLittleEndian) ::int16LE else ::int16
+    val read32 = if (isLittleEndian) ::int32LE else ::int32
+    if (read16(bytes[tiffOffset + 2], bytes[tiffOffset + 3]) != 42u) return 0
+
+    val ifdOffset = read32(
+        bytes[tiffOffset + 4],
+        bytes[tiffOffset + 5],
+        bytes[tiffOffset + 6],
+        bytes[tiffOffset + 7],
+    ).toInt()
+    val ifdStart = tiffOffset + ifdOffset
+    if (ifdStart < tiffOffset || ifdStart + 2 > offset + length) return 0
+
+    val entryCount = read16(bytes[ifdStart], bytes[ifdStart + 1]).toInt()
+    var entryOffset = ifdStart + 2
+    repeat(entryCount) {
+        if (entryOffset + 12 > offset + length) return 0
+
+        val tag = read16(bytes[entryOffset], bytes[entryOffset + 1])
+        if (tag == 0x0112u) {
+            val type = read16(bytes[entryOffset + 2], bytes[entryOffset + 3])
+            val count = read32(
+                bytes[entryOffset + 4],
+                bytes[entryOffset + 5],
+                bytes[entryOffset + 6],
+                bytes[entryOffset + 7],
+            )
+            if (type == 3u && count == 1u) {
+                return read16(bytes[entryOffset + 8], bytes[entryOffset + 9]).toInt()
+            }
+            return 0
+        }
+
+        entryOffset += 12
+    }
+    return 0
 }
 
 internal fun getWebpSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {

--- a/coil-core/src/jsCommonMain/kotlin/coil3/decode/SkiaImageDecoder.jsCommon.kt
+++ b/coil-core/src/jsCommonMain/kotlin/coil3/decode/SkiaImageDecoder.jsCommon.kt
@@ -46,7 +46,7 @@ internal actual suspend fun decodeBitmap(
     )
 }
 
-// try to read a size directly for PNG and JPEG images.
+// try to read a size directly for PNG, JPEG, and WebP images.
 // It is faster than Image.makeFromEncoded(bytes)
 internal fun getOriginalSize(bytes: ByteArray): Pair<Int, Int> { // (w,h)
     val pngSize = getPngSizeOrNull(bytes)
@@ -69,9 +69,51 @@ internal fun getPngSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
         int32(bytes[0], bytes[1], bytes[2], bytes[3]) == 0x8950_4E47u &&
         int32(bytes[4], bytes[5], bytes[6], bytes[7]) == 0x0D0A_1A0Au
     ) {
-        val width = int32(bytes[16], bytes[17], bytes[18], bytes[19])
-        val height = int32(bytes[20], bytes[21], bytes[22], bytes[23])
-        return width.toInt() to height.toInt()
+        var offset = 8
+        var size: Pair<Int, Int>? = null
+        var orientation = 0
+        while (offset <= bytes.size - 12) {
+            val chunkLength = int32(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+            val dataOffset = offset + 8
+            if (chunkLength > (bytes.size - dataOffset - 4).toUInt()) {
+                return size?.applyExifOrientation(orientation)
+            }
+
+            when (int32(bytes[offset + 4], bytes[offset + 5], bytes[offset + 6], bytes[offset + 7])) {
+                0x4948_4452u -> { // "IHDR"
+                    if (chunkLength >= 8u) {
+                        val width = int32(
+                            bytes[dataOffset],
+                            bytes[dataOffset + 1],
+                            bytes[dataOffset + 2],
+                            bytes[dataOffset + 3],
+                        )
+                        val height = int32(
+                            bytes[dataOffset + 4],
+                            bytes[dataOffset + 5],
+                            bytes[dataOffset + 6],
+                            bytes[dataOffset + 7],
+                        )
+                        size = width.toInt() to height.toInt()
+                    }
+                }
+                0x6558_4966u -> { // "eXIf"
+                    val exifOrientation = getExifOrientation(
+                        bytes = bytes,
+                        offset = dataOffset,
+                        length = chunkLength.toInt(),
+                        hasExifPrefix = false,
+                    )
+                    if (exifOrientation > 0) {
+                        orientation = exifOrientation
+                    }
+                }
+                0x4945_4E44u -> break // "IEND"
+            }
+
+            offset = dataOffset + chunkLength.toInt() + 4
+        }
+        return size?.applyExifOrientation(orientation)
     }
     return null
 }
@@ -88,11 +130,7 @@ internal fun getJpegSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
             if (marker in 0xFFC0u..0xFFCFu && marker != 0xFFC4u && marker != 0xFFC8u && marker != 0xFFCCu) {
                 val height = int16(bytes[offset + 3], bytes[offset + 4])
                 val width = int16(bytes[offset + 5], bytes[offset + 6])
-                return if (orientation.isSwapped) {
-                    height.toInt() to width.toInt()
-                } else {
-                    width.toInt() to height.toInt()
-                }
+                return (width.toInt() to height.toInt()).applyExifOrientation(orientation)
             }
 
             val segmentLength = int16(bytes[offset], bytes[offset + 1])
@@ -101,6 +139,7 @@ internal fun getJpegSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
                     bytes = bytes,
                     offset = offset + 2,
                     length = segmentLength.toInt() - 2,
+                    hasExifPrefix = true,
                 )
                 if (exifOrientation > 0) {
                     orientation = exifOrientation
@@ -115,23 +154,35 @@ internal fun getJpegSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
 private val Int.isSwapped: Boolean
     get() = this in 5..8
 
+private fun Pair<Int, Int>.applyExifOrientation(orientation: Int): Pair<Int, Int> {
+    return if (orientation.isSwapped) second to first else this
+}
+
 private fun getExifOrientation(
     bytes: ByteArray,
     offset: Int,
     length: Int,
+    hasExifPrefix: Boolean,
 ): Int {
-    if (length < 14 || offset < 0 || offset + length > bytes.size) return 0
-    if (bytes[offset + 0].asInt() != 0x45u || // E
-        bytes[offset + 1].asInt() != 0x78u || // x
-        bytes[offset + 2].asInt() != 0x69u || // i
-        bytes[offset + 3].asInt() != 0x66u || // f
-        bytes[offset + 4].asInt() != 0u ||
-        bytes[offset + 5].asInt() != 0u
-    ) {
-        return 0
+    if (length < 8 || offset < 0 || length < 0 || offset > bytes.size - length) return 0
+
+    val endOffset = offset + length
+    val tiffOffset = if (hasExifPrefix) {
+        if (length < 14 ||
+            bytes[offset + 0].asInt() != 0x45u || // E
+            bytes[offset + 1].asInt() != 0x78u || // x
+            bytes[offset + 2].asInt() != 0x69u || // i
+            bytes[offset + 3].asInt() != 0x66u || // f
+            bytes[offset + 4].asInt() != 0u ||
+            bytes[offset + 5].asInt() != 0u
+        ) {
+            return 0
+        }
+        offset + 6
+    } else {
+        offset
     }
 
-    val tiffOffset = offset + 6
     val isLittleEndian = when (int16(bytes[tiffOffset], bytes[tiffOffset + 1])) {
         0x4949u -> true
         0x4D4Du -> false
@@ -146,14 +197,16 @@ private fun getExifOrientation(
         bytes[tiffOffset + 5],
         bytes[tiffOffset + 6],
         bytes[tiffOffset + 7],
-    ).toInt()
-    val ifdStart = tiffOffset + ifdOffset
-    if (ifdStart < tiffOffset || ifdStart + 2 > offset + length) return 0
+    )
+    if (ifdOffset > (endOffset - tiffOffset).toUInt()) return 0
+
+    val ifdStart = tiffOffset + ifdOffset.toInt()
+    if (ifdStart > endOffset - 2) return 0
 
     val entryCount = read16(bytes[ifdStart], bytes[ifdStart + 1]).toInt()
     var entryOffset = ifdStart + 2
     repeat(entryCount) {
-        if (entryOffset + 12 > offset + length) return 0
+        if (entryOffset > endOffset - 12) return 0
 
         val tag = read16(bytes[entryOffset], bytes[entryOffset + 1])
         if (tag == 0x0112u) {
@@ -165,7 +218,7 @@ private fun getExifOrientation(
                 bytes[entryOffset + 7],
             )
             if (type == 3u && count == 1u) {
-                return read16(bytes[entryOffset + 8], bytes[entryOffset + 9]).toInt()
+                return read16(bytes[entryOffset + 8], bytes[entryOffset + 9]).toInt().takeIf { it in 1..8 } ?: 0
             }
             return 0
         }
@@ -176,7 +229,7 @@ private fun getExifOrientation(
 }
 
 internal fun getWebpSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
-    if (bytes.size < 30) return null
+    if (bytes.size < 20) return null
 
     // check "RIFF" and "WEBP" signatures
     if (
@@ -186,31 +239,78 @@ internal fun getWebpSizeOrNull(bytes: ByteArray): Pair<Int, Int>? {
         return null
     }
 
-    val chunkType = int32(bytes[12], bytes[13], bytes[14], bytes[15])
+    var offset = 12
+    var size: Pair<Int, Int>? = null
+    var orientation = 0
+    while (offset <= bytes.size - 8) {
+        val chunkType = int32(bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+        val chunkLength = int32LE(bytes[offset + 4], bytes[offset + 5], bytes[offset + 6], bytes[offset + 7])
+        val dataOffset = offset + 8
+        if (chunkLength > (bytes.size - dataOffset).toUInt()) {
+            return size?.applyExifOrientation(orientation)
+        }
 
-    return when (chunkType) {
-        0x5650_3858u -> { // "VP8X" (Extended WebP)
-            val w = int24LE(bytes[24], bytes[25], bytes[26]).toInt() + 1
-            val h = int24LE(bytes[27], bytes[28], bytes[29]).toInt() + 1
-            w to h
+        if (size == null) {
+            size = when (chunkType) {
+                0x5650_3858u -> { // "VP8X" (Extended WebP)
+                    if (chunkLength < 10u) return null
+                    val width = int24LE(bytes[dataOffset + 4], bytes[dataOffset + 5], bytes[dataOffset + 6]).toInt() + 1
+                    val height = int24LE(bytes[dataOffset + 7], bytes[dataOffset + 8], bytes[dataOffset + 9]).toInt() + 1
+                    width to height
+                }
+                0x5650_3820u -> { // "VP8" (Lossy WebP)
+                    if (chunkLength < 10u) return null
+                    // Check Sync Code "0x9D 0x01 0x2A"
+                    if (bytes[dataOffset + 3].asInt() != 0x9Du ||
+                        bytes[dataOffset + 4].asInt() != 0x01u ||
+                        bytes[dataOffset + 5].asInt() != 0x2Au
+                    ) {
+                        return null
+                    }
+                    val width = (int16LE(bytes[dataOffset + 6], bytes[dataOffset + 7]) and 0x3FFFu).toInt()
+                    val height = (int16LE(bytes[dataOffset + 8], bytes[dataOffset + 9]) and 0x3FFFu).toInt()
+                    width to height
+                }
+                0x5650_384Cu -> { // "VP8L" (Lossless WebP)
+                    if (chunkLength < 5u) return null
+                    // Check Lossless
+                    if (bytes[dataOffset].asInt() != 0x2Fu) return null
+                    val bits = int32LE(
+                        bytes[dataOffset + 1],
+                        bytes[dataOffset + 2],
+                        bytes[dataOffset + 3],
+                        bytes[dataOffset + 4],
+                    )
+                    val width = (bits and 0x3FFFu).toInt() + 1
+                    val height = ((bits shr 14) and 0x3FFFu).toInt() + 1
+                    width to height
+                }
+                else -> null
+            }
         }
-        0x5650_3820u -> { // "VP8" (Lossy WebP)
-            // Check Sync Code "0x9D 0x01 0x2A"
-            if (bytes[23].asInt() != 0x9Du || bytes[24].asInt() != 0x01u || bytes[25].asInt() != 0x2Au) return null
-            val w = (int16LE(bytes[26], bytes[27]) and 0x3FFFu).toInt()
-            val h = (int16LE(bytes[28], bytes[29]) and 0x3FFFu).toInt()
-            w to h
+        if (chunkType == 0x4558_4946u) { // "EXIF"
+            var exifOrientation = getExifOrientation(
+                bytes = bytes,
+                offset = dataOffset,
+                length = chunkLength.toInt(),
+                hasExifPrefix = false,
+            )
+            if (exifOrientation == 0) {
+                exifOrientation = getExifOrientation(
+                    bytes = bytes,
+                    offset = dataOffset,
+                    length = chunkLength.toInt(),
+                    hasExifPrefix = true,
+                )
+            }
+            if (exifOrientation > 0) {
+                orientation = exifOrientation
+            }
         }
-        0x5650_384Cu -> { // "VP8L" (Lossless WebP)
-            // Check Lossless
-            if (bytes[20].asInt() != 0x2Fu) return null
-            val bits = int32LE(bytes[21], bytes[22], bytes[23], bytes[24])
-            val w = (bits and 0x3FFFu).toInt() + 1
-            val h = ((bits shr 14) and 0x3FFFu).toInt() + 1
-            w to h
-        }
-        else -> null
+
+        offset = dataOffset + chunkLength.toInt() + (chunkLength.toInt() and 1)
     }
+    return size?.applyExifOrientation(orientation)
 }
 
 private fun int16(b1: Byte, b2: Byte): UInt =

--- a/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
+++ b/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
@@ -21,6 +21,31 @@ class ImageSizeExtractionTest {
             "2gAIAQIBAT8Q6VvS2QGL/8QAGhAAAwEAAwAAAAAAAAAAAAAAAAEhETFBUf/aAAgBAQABPxCvLSdjW8bD" +
             "41SmhXz6f//Z"
         ).decodeBase64()!!.toByteArray()
+    private val jpegWithExifOrientation6 = intArrayOf(
+        0xFF, 0xD8, // SOI.
+        0xFF, 0xE1, // APP1.
+        0x00, 0x22, // Segment length.
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // Exif header.
+        0x4D, 0x4D, // Big endian.
+        0x00, 0x2A, // TIFF magic number.
+        0x00, 0x00, 0x00, 0x08, // IFD0 offset.
+        0x00, 0x01, // Entry count.
+        0x01, 0x12, // Orientation tag.
+        0x00, 0x03, // SHORT.
+        0x00, 0x00, 0x00, 0x01, // Value count.
+        0x00, 0x06, 0x00, 0x00, // Orientation 6.
+        0x00, 0x00, 0x00, 0x00, // Next IFD offset.
+        0xFF, 0xC0, // SOF0.
+        0x00, 0x11, // Segment length.
+        0x08, // Precision.
+        0x00, 0x14, // Height.
+        0x00, 0x0A, // Width.
+        0x03, // Component count.
+        0x01, 0x11, 0x00,
+        0x02, 0x11, 0x00,
+        0x03, 0x11, 0x00,
+        0xFF, 0xD9, // EOI.
+    ).map { it.toByte() }.toByteArray()
     private val png = (
         "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8" +
             "YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAuIwAA" +
@@ -87,6 +112,7 @@ class ImageSizeExtractionTest {
         assertNull(getPngSizeOrNull(webp_VP8L))
         assertNull(getPngSizeOrNull(bmp))
         assertEquals(10 to 10, getJpegSizeOrNull(jpeg))
+        assertEquals(20 to 10, getJpegSizeOrNull(jpegWithExifOrientation6))
     }
 
     @Test

--- a/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
+++ b/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
@@ -21,11 +21,7 @@ class ImageSizeExtractionTest {
             "2gAIAQIBAT8Q6VvS2QGL/8QAGhAAAwEAAwAAAAAAAAAAAAAAAAEhETFBUf/aAAgBAQABPxCvLSdjW8bD" +
             "41SmhXz6f//Z"
         ).decodeBase64()!!.toByteArray()
-    private val jpegWithExifOrientation6 = intArrayOf(
-        0xFF, 0xD8, // SOI.
-        0xFF, 0xE1, // APP1.
-        0x00, 0x22, // Segment length.
-        0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // Exif header.
+    private val exifOrientation6 = intArrayOf(
         0x4D, 0x4D, // Big endian.
         0x00, 0x2A, // TIFF magic number.
         0x00, 0x00, 0x00, 0x08, // IFD0 offset.
@@ -35,6 +31,13 @@ class ImageSizeExtractionTest {
         0x00, 0x00, 0x00, 0x01, // Value count.
         0x00, 0x06, 0x00, 0x00, // Orientation 6.
         0x00, 0x00, 0x00, 0x00, // Next IFD offset.
+    )
+    private val jpegWithExifOrientation6 = intArrayOf(
+        0xFF, 0xD8, // SOI.
+        0xFF, 0xE1, // APP1.
+        0x00, 0x22, // Segment length.
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // Exif header.
+        *exifOrientation6,
         0xFF, 0xC0, // SOF0.
         0x00, 0x11, // Segment length.
         0x08, // Precision.
@@ -53,6 +56,22 @@ class ImageSizeExtractionTest {
             "ARWTZAhkOpcpEihsRJfX/K+75gJudrNWwJORN1NXD9u5+C3ixcMRQh+d7lKGuoh9nbLzFcp3uT/LG3VR" +
             "Ps8KSNENWM+pI9YAAAAASUVORK5CYII="
         ).decodeBase64()!!.toByteArray()
+    private val pngWithExifOrientation6 = intArrayOf(
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature.
+        0x00, 0x00, 0x00, 0x0D, // Chunk length.
+        0x49, 0x48, 0x44, 0x52, // IHDR.
+        0x00, 0x00, 0x00, 0x0A, // Width.
+        0x00, 0x00, 0x00, 0x14, // Height.
+        0x08, 0x02, 0x00, 0x00, 0x00, // Remaining IHDR data.
+        0x00, 0x00, 0x00, 0x00, // CRC.
+        0x00, 0x00, 0x00, 0x1A, // Chunk length.
+        0x65, 0x58, 0x49, 0x66, // eXIf.
+        *exifOrientation6,
+        0x00, 0x00, 0x00, 0x00, // CRC.
+        0x00, 0x00, 0x00, 0x00, // Chunk length.
+        0x49, 0x45, 0x4E, 0x44, // IEND.
+        0x00, 0x00, 0x00, 0x00, // CRC.
+    ).map { it.toByte() }.toByteArray()
     private val webp = (
         "UklGRqIAAABXRUJQVlA4IJYAAADwAgCdASoKAAoAAMASJbACdLoAkQDpAPRJB8C1GwNIEAD+/6IdbkpT" +
             "r3YsZ4X/1vOP/VLJh8T8lz82YxIyGV47BcfOmEaVCS1fRi4yFYwxUOO1HZ89ljeH9gTrmUf/FaTKevz1" +
@@ -80,6 +99,33 @@ class ImageSizeExtractionTest {
             "AJ0BKggACAAAwBIlsAJ0ugH4AALPcx3gAP7/uxe17up9/+aTPv/y6r/41ak0v5gXaD6ln/ZB83KC/1/p" +
             "vpt+76Zy/Bl2/uXv+ZqHfL4BJ6v8lOMxG+DLt/bsAAA="
         ).decodeBase64()!!.toByteArray()
+    private val webpWithExifOrientation6 = intArrayOf(
+        0x52, 0x49, 0x46, 0x46, // RIFF.
+        0x38, 0x00, 0x00, 0x00, // File size.
+        0x57, 0x45, 0x42, 0x50, // WEBP.
+        0x56, 0x50, 0x38, 0x58, // VP8X.
+        0x0A, 0x00, 0x00, 0x00, // Chunk length.
+        0x08, 0x00, 0x00, 0x00, // EXIF flag and reserved bytes.
+        0x09, 0x00, 0x00, // Canvas width minus one.
+        0x13, 0x00, 0x00, // Canvas height minus one.
+        0x45, 0x58, 0x49, 0x46, // EXIF.
+        0x1A, 0x00, 0x00, 0x00, // Chunk length.
+        *exifOrientation6,
+    ).map { it.toByte() }.toByteArray()
+    private val webpWithExifPrefixOrientation6 = intArrayOf(
+        0x52, 0x49, 0x46, 0x46, // RIFF.
+        0x3E, 0x00, 0x00, 0x00, // File size.
+        0x57, 0x45, 0x42, 0x50, // WEBP.
+        0x56, 0x50, 0x38, 0x58, // VP8X.
+        0x0A, 0x00, 0x00, 0x00, // Chunk length.
+        0x08, 0x00, 0x00, 0x00, // EXIF flag and reserved bytes.
+        0x09, 0x00, 0x00, // Canvas width minus one.
+        0x13, 0x00, 0x00, // Canvas height minus one.
+        0x45, 0x58, 0x49, 0x46, // EXIF.
+        0x20, 0x00, 0x00, 0x00, // Chunk length.
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // Exif header.
+        *exifOrientation6,
+    ).map { it.toByte() }.toByteArray()
     private val bmp = (
         "Qk1uAgAAAAAAAIoAAAB8AAAACwAAAAsAAAABACAAAwAAAOQBAAATCwAAEwsAAAAAAAAAAAAAAAD/AAD/" +
             "AAD/AAAAAAAA/0JHUnMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
@@ -102,6 +148,7 @@ class ImageSizeExtractionTest {
         assertNull(getPngSizeOrNull(webp_VP8L))
         assertNull(getPngSizeOrNull(bmp))
         assertEquals(10 to 10, getPngSizeOrNull(png))
+        assertEquals(20 to 10, getPngSizeOrNull(pngWithExifOrientation6))
     }
 
     @Test
@@ -123,6 +170,8 @@ class ImageSizeExtractionTest {
         assertEquals(10 to 10, getWebpSizeOrNull(webp))
         assertEquals(9 to 9, getWebpSizeOrNull(webp_VP8L))
         assertEquals(8 to 8, getWebpSizeOrNull(webp_VP8X))
+        assertEquals(20 to 10, getWebpSizeOrNull(webpWithExifOrientation6))
+        assertEquals(20 to 10, getWebpSizeOrNull(webpWithExifPrefixOrientation6))
     }
 
     @OptIn(ExperimentalWasmJsInterop::class)
@@ -133,6 +182,8 @@ class ImageSizeExtractionTest {
         assertEquals(10 to 10, getOriginalSize(webp))
         assertEquals(9 to 9, getOriginalSize(webp_VP8L))
         assertEquals(8 to 8, getOriginalSize(webp_VP8X))
+        assertEquals(20 to 10, getOriginalSize(pngWithExifOrientation6))
+        assertEquals(20 to 10, getOriginalSize(webpWithExifOrientation6))
 
         awaitSkiko()
         assertEquals(11 to 11, getOriginalSize(bmp))


### PR DESCRIPTION
Fixes #3388.

JPEG, PNG, and WEBP size extraction on JS/Wasm now accounts for EXIF orientation before computing decode dimensions, avoiding stretched output for rotated images.
