### PR TITLE
Read ContinuationInterceptor's key instead of CoroutineDispatcher.

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/internal/utils.kt
@@ -33,6 +33,7 @@ import coil3.size.Dimension
 import coil3.size.Scale
 import coil3.size.Size as CoilSize
 import coil3.size.SizeResolver
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineDispatcher
@@ -210,9 +211,8 @@ internal fun Size.toIntSize() = IntSize(width.roundToInt(), height.roundToInt())
 
 internal val Size.isPositive get() = width >= 0.5 && height >= 0.5
 
-@OptIn(ExperimentalStdlibApi::class)
 internal val CoroutineContext.dispatcher: CoroutineDispatcher?
-    get() = get(CoroutineDispatcher)
+    get() = get(ContinuationInterceptor) as? CoroutineDispatcher
 
 @ReadOnlyComposable
 @Composable

--- a/coil-core/src/commonMain/kotlin/coil3/util/utils.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/util/utils.kt
@@ -14,6 +14,7 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.NullRequestDataException
 import coil3.request.Options
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.reflect.KClass
@@ -128,6 +129,5 @@ internal expect class WeakReference<T : Any>(referred: T) {
 
 internal expect fun Image.prepareToDraw()
 
-@OptIn(ExperimentalStdlibApi::class)
 internal val CoroutineContext.dispatcher: CoroutineDispatcher?
-    get() = get(CoroutineDispatcher)
+    get() = get(ContinuationInterceptor) as? CoroutineDispatcher


### PR DESCRIPTION
Deprecated [here](https://github.com/coil-kt/coil/pull/3413), but we don't want to transitively depend on the latest coroutines version as it forces all users to update.