### PR TITLE
Fix AsyncImage error painter not updating on uiMode config change

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -177,6 +177,14 @@ class AsyncImagePainter internal constructor(
 
     internal lateinit var scope: CoroutineScope
     internal var transform = DefaultTransform
+        set(value) {
+            if (field != value) {
+                field = value
+                updateState(untransformedState)
+            }
+        }
+
+    private var untransformedState: State = State.Empty
     internal var onState: ((State) -> Unit)? = null
     internal var contentScale = ContentScale.Fit
     internal var filterQuality = DefaultFilterQuality
@@ -306,6 +314,7 @@ class AsyncImagePainter internal constructor(
     }
 
     private fun updateState(state: State) {
+        untransformedState = state
         val previous = stateFlow.value
         val current = transform(state)
         stateFlow.value = current


### PR DESCRIPTION
Fixes #3245

When an activity handles uiMode config changes manually, AsyncImage doesn't update its error painter on theme switch. The issue is that AsyncImagePainter stores only the transformed state, when transform changes during recomposition there's no way to re-apply it to the previous state.

Fix: track the untransformed state separately so that when transform is updated, updateState can be re-called and pick up the correct drawable variant for the new theme.

Credit to @nishatoma for identifying the root cause.