### PR TITLE
Disable Renovate updates for skiko

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,4 +5,12 @@
     ],
     "automerge": false,
     "dependencyDashboard": false,
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "org.jetbrains.skiko:skiko",
+            ],
+            "enabled": false,
+        },
+    ],
 }


### PR DESCRIPTION
Disable Renovate updates for `org.jetbrains.skiko:skiko` as we only update Skiko when updating Compose Multiplatform and use the same transitive version.