### PR TITLE
Add API 36 instrumentation CI variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                api-level: [23, 26, 31]
+                api-level: [23, 26, 31, 36]
         steps:
             - uses: actions/checkout@v6
             - uses: actions/setup-java@v5


### PR DESCRIPTION
Adds API 36 to the existing instrumentation test matrix so CI covers the latest Android emulator alongside the current API variants.
