### PR TITLE
Fix URI parsing of Windows drive letters in no-authority schemes

### DIFF
--- a/coil-core/src/commonMain/kotlin/coil3/Uri.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/Uri.kt
@@ -228,6 +228,13 @@ private fun parseUri(
                         authorityStartIndex = index + 1
                         pathStartIndex = index + 1
                         index += 1
+                        // If the path begins immediately after this colon, the scheme is
+                        // complete. This stops a later colon (e.g. a Windows drive letter in
+                        // "jar:file:/C:/…") from being misparsed as another scheme segment,
+                        // while still allowing multi-segment schemes like "jar:file:/…".
+                        if (index < data.length && data[index] == '/') {
+                            openScheme = false
+                        }
                     }
                 }
             }

--- a/coil-core/src/commonTest/kotlin/coil3/UriTest.kt
+++ b/coil-core/src/commonTest/kotlin/coil3/UriTest.kt
@@ -235,6 +235,29 @@ class UriTest {
     }
 
     @Test
+    fun jarFileUriWithWindowsDriveLetter() {
+        // Compose Multiplatform resources on Windows (e.g. Res.getUri) produce a jar URL
+        // whose path contains a drive-letter colon. The drive colon must not be parsed as
+        // another scheme segment. Regression test for https://github.com/coil-kt/coil/issues/2833
+        val uri = "jar:file:/C:/Users/me/app.jar!/composeResources/img.png".toUri()
+        assertEquals("jar:file", uri.scheme)
+        assertEquals("", uri.authority)
+        assertEquals("/C:/Users/me/app.jar!/composeResources/img.png", uri.path)
+        assertNull(uri.query)
+        assertNull(uri.fragment)
+    }
+
+    @Test
+    fun fileUriWithWindowsDriveLetter() {
+        val uri = "file:/C:/Users/me/image.png".toUri()
+        assertEquals("file", uri.scheme)
+        assertEquals("", uri.authority)
+        assertEquals("/C:/Users/me/image.png", uri.path)
+        assertNull(uri.query)
+        assertNull(uri.fragment)
+    }
+
+    @Test
     fun ipv6() {
         val uri = "http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]/".toUri()
         assertEquals("http", uri.scheme)


### PR DESCRIPTION
## Problem
On Windows, Compose Multiplatform resources loaded via `Res.getUri()` produce a JAR URL whose path contains a drive-letter colon, e.g. `jar:file:/C:/Users/.../app.jar!/composeResources/img.png`. `parseUri()` mis-parses the drive-letter `C:` as another scheme segment, yielding scheme `"jar:file:/C"` and a corrupted path. No fetcher matches that scheme, so loading fails with `Unable to create a fetcher that supports: ...`.

Fixes #2833 (also covers the `file:/C:/...` variant reported in the same thread).

## Root cause
The no-authority branch of `parseUri()` does `index += 1`, which skips the `/` immediately following the scheme colon. Because that `/` is never processed by the `'/'` case, `openScheme` is never cleared — so a later colon (the Windows drive letter) is still treated as a scheme delimiter.

Note this is *not* as simple as clearing `openScheme` at the first colon: coil intentionally supports multi-segment schemes like `jar:file:/...` (scheme = `"jar:file"`, see the existing `multipleSchemeSegments` test), which relies on consuming the second colon.

## Fix
Clear `openScheme` only when the path begins immediately after the colon (i.e. the next char is `/`). This stops a trailing drive-letter colon from being absorbed into the scheme, while still allowing `jar:file:/...` multi-segment schemes.

## Tests
Added `jarFileUriWithWindowsDriveLetter` and `fileUriWithWindowsDriveLetter` to `UriTest`. Verified the existing scheme/path expectations (including `multipleSchemeSegments` and `data`) are unaffected.
