### PR TITLE
fix: Fix JVM memory cache sizing to use Runtime.maxMemory()

### DIFF
--- a/coil-core/src/jvmMain/kotlin/coil3/util/contexts.jvm.kt
+++ b/coil-core/src/jvmMain/kotlin/coil3/util/contexts.jvm.kt
@@ -1,0 +1,7 @@
+package coil3.util
+
+import coil3.PlatformContext
+
+internal actual fun PlatformContext.totalAvailableMemoryBytes(): Long {
+    return Runtime.getRuntime().maxMemory()
+}

--- a/coil-core/src/jvmMain/kotlin/coil3/util/contexts.jvm.kt
+++ b/coil-core/src/jvmMain/kotlin/coil3/util/contexts.jvm.kt
@@ -3,5 +3,10 @@ package coil3.util
 import coil3.PlatformContext
 
 internal actual fun PlatformContext.totalAvailableMemoryBytes(): Long {
-    return Runtime.getRuntime().maxMemory()
+    val maxMemory = Runtime.getRuntime().maxMemory()
+    return if (maxMemory == Long.MAX_VALUE) {
+        8L * 1024 * 1024 * 1024 // 8 GB
+    } else {
+        maxMemory
+    }
 }

--- a/coil-core/src/nonAndroidMain/kotlin/coil3/util/contexts.kt
+++ b/coil-core/src/nonAndroidMain/kotlin/coil3/util/contexts.kt
@@ -8,8 +8,3 @@ internal actual val PlatformContext.application: PlatformContext
 internal actual fun PlatformContext.defaultMemoryCacheSizePercent(): Double {
     return 0.15
 }
-
-// TODO: Compute the total available memory on non-Android platforms.
-internal actual fun PlatformContext.totalAvailableMemoryBytes(): Long {
-    return 512L * 1024L * 1024L // 512 MB
-}

--- a/coil-core/src/nonJvmCommonMain/kotlin/coil3/util/contexts.nonJvmCommon.kt
+++ b/coil-core/src/nonJvmCommonMain/kotlin/coil3/util/contexts.nonJvmCommon.kt
@@ -1,0 +1,8 @@
+package coil3.util
+
+import coil3.PlatformContext
+
+internal actual fun PlatformContext.totalAvailableMemoryBytes(): Long {
+    // TODO: Figure out how to compute the total available memory on non-JVM platforms.
+    return 512L * 1024L * 1024L // 512 MB
+}


### PR DESCRIPTION
### Description
This PR fixes a performance issue on Desktop JVM where the memory cache size was artificially constrained, resulting in excessive cache evictions under heavy load.

Previously, `totalAvailableMemoryBytes()` in `nonAndroidMain` used a hardcoded fallback of `512MB`. Since `nonAndroidMain` encompasses JVM desktop targets, this severely limited the default memory cache (15%) to just 76.8MB, completely ignoring the JVM's actual allocated maximum heap size. 

**Changes:**
- Removed the `512MB` fallback `actual` implementation from `nonAndroidMain`.
- Shifted the fallback into `nonJvmCommonMain` so it still gracefully applies to JS/Wasm/Apple Native targets where querying system memory isn't fully supported.
- Added a dedicated `jvmMain` implementation that accurately queries the heap limit using `Runtime.getRuntime().maxMemory()`, with an 8GB fallback for environments where it is undefined (`Long.MAX_VALUE`).