### PR TITLE
Fix GIF filter quality in Compose

### DIFF
--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/ImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/ImagePainter.android.kt
@@ -1,6 +1,5 @@
 package coil3.compose
 
-import android.graphics.drawable.Drawable
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
@@ -12,7 +11,6 @@ import coil3.DrawableImage
 import coil3.Image
 import coil3.PlatformContext
 import coil3.asDrawable
-import coil3.size.ScaleDrawable
 import com.google.accompanist.drawablepainter.DrawablePainter
 
 actual fun Image.asPainter(
@@ -23,19 +21,14 @@ actual fun Image.asPainter(
         image = bitmap.asImageBitmap(),
         filterQuality = filterQuality,
     )
+
     is DrawableImage -> DrawablePainter(
         drawable = asDrawable(context.resources).mutate().apply {
-            setFilterBitmapRecursive(filterQuality != FilterQuality.None)
+            isFilterBitmap = filterQuality != FilterQuality.None
         },
     )
+
     else -> ImagePainter(this)
 }
 
 internal actual val Canvas.nativeCanvas get() = nativeCanvas
-
-private fun Drawable.setFilterBitmapRecursive(filter: Boolean) {
-    setFilterBitmap(filter)
-    if (this is ScaleDrawable) {
-        child.setFilterBitmapRecursive(filter)
-    }
-}

--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/ImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/ImagePainter.android.kt
@@ -1,5 +1,6 @@
 package coil3.compose
 
+import android.graphics.drawable.Drawable
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
@@ -11,6 +12,7 @@ import coil3.DrawableImage
 import coil3.Image
 import coil3.PlatformContext
 import coil3.asDrawable
+import coil3.size.ScaleDrawable
 import com.google.accompanist.drawablepainter.DrawablePainter
 
 actual fun Image.asPainter(
@@ -22,9 +24,18 @@ actual fun Image.asPainter(
         filterQuality = filterQuality,
     )
     is DrawableImage -> DrawablePainter(
-        drawable = asDrawable(context.resources).mutate(),
+        drawable = asDrawable(context.resources).mutate().apply {
+            setFilterBitmapRecursive(filterQuality != FilterQuality.None)
+        },
     )
     else -> ImagePainter(this)
 }
 
 internal actual val Canvas.nativeCanvas get() = nativeCanvas
+
+private fun Drawable.setFilterBitmapRecursive(filter: Boolean) {
+    setFilterBitmap(filter)
+    if (this is ScaleDrawable) {
+        child.setFilterBitmapRecursive(filter)
+    }
+}

--- a/coil-compose-core/src/androidUnitTest/kotlin/coil3/compose/ImagePainterTest.kt
+++ b/coil-compose-core/src/androidUnitTest/kotlin/coil3/compose/ImagePainterTest.kt
@@ -6,11 +6,11 @@ import android.graphics.PixelFormat
 import android.graphics.drawable.Drawable
 import androidx.compose.ui.graphics.FilterQuality
 import coil3.asImage
-import coil3.size.ScaleDrawable
 import coil3.test.utils.RobolectricTest
 import coil3.test.utils.context
 import kotlin.test.Test
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ImagePainterTest : RobolectricTest() {
 
@@ -24,16 +24,18 @@ class ImagePainterTest : RobolectricTest() {
     }
 
     @Test
-    fun scaleDrawableImageAsPainter_appliesFilterQualityToChild() {
-        val child = TestDrawable()
+    fun drawableImageAsPainter_enablesFilterQuality() {
+        val drawable = TestDrawable(initialFilterBitmap = false)
 
-        ScaleDrawable(child).asImage().asPainter(context, FilterQuality.None)
+        drawable.asImage().asPainter(context, FilterQuality.Low)
 
-        assertFalse(child.filterBitmap)
+        assertTrue(drawable.filterBitmap)
     }
 
-    private class TestDrawable : Drawable() {
-        var filterBitmap = true
+    private class TestDrawable(
+        initialFilterBitmap: Boolean = true,
+    ) : Drawable() {
+        var filterBitmap = initialFilterBitmap
 
         override fun draw(canvas: Canvas) = Unit
 

--- a/coil-compose-core/src/androidUnitTest/kotlin/coil3/compose/ImagePainterTest.kt
+++ b/coil-compose-core/src/androidUnitTest/kotlin/coil3/compose/ImagePainterTest.kt
@@ -1,0 +1,55 @@
+package coil3.compose
+
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.PixelFormat
+import android.graphics.drawable.Drawable
+import androidx.compose.ui.graphics.FilterQuality
+import coil3.asImage
+import coil3.size.ScaleDrawable
+import coil3.test.utils.RobolectricTest
+import coil3.test.utils.context
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class ImagePainterTest : RobolectricTest() {
+
+    @Test
+    fun drawableImageAsPainter_appliesFilterQuality() {
+        val drawable = TestDrawable()
+
+        drawable.asImage().asPainter(context, FilterQuality.None)
+
+        assertFalse(drawable.filterBitmap)
+    }
+
+    @Test
+    fun scaleDrawableImageAsPainter_appliesFilterQualityToChild() {
+        val child = TestDrawable()
+
+        ScaleDrawable(child).asImage().asPainter(context, FilterQuality.None)
+
+        assertFalse(child.filterBitmap)
+    }
+
+    private class TestDrawable : Drawable() {
+        var filterBitmap = true
+
+        override fun draw(canvas: Canvas) = Unit
+
+        override fun setAlpha(alpha: Int) = Unit
+
+        override fun setColorFilter(colorFilter: ColorFilter?) = Unit
+
+        override fun setFilterBitmap(filter: Boolean) {
+            filterBitmap = filter
+        }
+
+        override fun mutate(): Drawable {
+            return this
+        }
+
+        @Deprecated("Deprecated in Java")
+        override fun getOpacity() = PixelFormat.TRANSLUCENT
+    }
+}

--- a/coil-core/api/android/coil-core.api
+++ b/coil-core/api/android/coil-core.api
@@ -950,11 +950,13 @@ public final class coil3/size/ScaleDrawable : android/graphics/drawable/Drawable
 	public fun getOpacity ()I
 	public final fun getScale ()Lcoil3/size/Scale;
 	public fun invalidateDrawable (Landroid/graphics/drawable/Drawable;)V
+	public fun isFilterBitmap ()Z
 	public fun isRunning ()Z
 	public fun isStateful ()Z
 	public fun scheduleDrawable (Landroid/graphics/drawable/Drawable;Ljava/lang/Runnable;J)V
 	public fun setAlpha (I)V
 	public fun setColorFilter (Landroid/graphics/ColorFilter;)V
+	public fun setFilterBitmap (Z)V
 	public fun setTint (I)V
 	public fun setTintBlendMode (Landroid/graphics/BlendMode;)V
 	public fun setTintList (Landroid/content/res/ColorStateList;)V

--- a/coil-core/src/androidMain/kotlin/coil3/size/ScaleDrawable.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/size/ScaleDrawable.kt
@@ -55,6 +55,12 @@ class ScaleDrawable @JvmOverloads constructor(
         child.colorFilter = colorFilter
     }
 
+    override fun isFilterBitmap() = child.isFilterBitmap
+
+    override fun setFilterBitmap(filter: Boolean) {
+        child.setFilterBitmap(filter)
+    }
+
     override fun onBoundsChange(bounds: Rect) {
         val width = child.intrinsicWidth
         val height = child.intrinsicHeight


### PR DESCRIPTION
## Summary
- apply Compose FilterQuality.None to Android Drawable-backed images
- propagate the flag into Coil's ScaleDrawable children so AnimatedImageDrawable can receive it
- add Android host tests for DrawableImage and ScaleDrawable-backed images

Fixes #2939

## Tests
- ./gradlew :coil-core:checkKotlinAbi :coil-compose-core:checkKotlinAbi :coil-compose-core:testAndroidHostTest :coil-compose-core:spotlessKotlinCheck --console=plain
- ./test.sh