### PR TITLE
Crossfade cached images when useExistingImageAsPlaceholder is set

### DIFF
--- a/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
+++ b/coil-compose-core/src/androidMain/kotlin/coil3/compose/AsyncImagePainter.android.kt
@@ -21,22 +21,24 @@ internal actual fun maybeNewCrossfadePainter(
         else -> return null
     }
 
-    // Invoke the transition factory and wrap the painter in a `CrossfadePainter` if it returns
-    // a `CrossfadeTransformation`.
-    val transition = result.request.transitionFactory.create(FakeTransitionTarget, result)
-    if (transition is CrossfadeTransition) {
-        return CrossfadePainter(
-            start = previous.painter.takeIf { previous is AsyncImagePainter.State.Loading },
-            end = current.painter,
-            contentScale = contentScale,
-            duration = transition.durationMillis.milliseconds,
-            fadeStart = result !is SuccessResult || !result.isPlaceholderCached,
-            preferExactIntrinsicSize = transition.preferExactIntrinsicSize,
-            preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize,
-        )
-    } else {
+    val factory = result.request.transitionFactory as? CrossfadeTransition.Factory ?: return null
+
+    // For errors and cache hits, create() returns a non-crossfade transition. Still crossfade
+    // cache hits when the caller opted in via useExistingImageAsPlaceholder.
+    val transition = factory.create(FakeTransitionTarget, result)
+    if (transition !is CrossfadeTransition && !crossfadeFromExistingImage(previous, result)) {
         return null
     }
+
+    return CrossfadePainter(
+        start = previous.painter.takeIf { previous is AsyncImagePainter.State.Loading },
+        end = current.painter,
+        contentScale = contentScale,
+        duration = factory.durationMillis.milliseconds,
+        fadeStart = result !is SuccessResult || !result.isPlaceholderCached,
+        preferExactIntrinsicSize = factory.preferExactIntrinsicSize,
+        preferEndFirstIntrinsicSize = result.request.preferEndFirstIntrinsicSize,
+    )
 }
 
 private val FakeTransitionTarget = object : TransitionTarget {

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -34,6 +34,7 @@ import coil3.compose.internal.requestOf
 import coil3.compose.internal.toScale
 import coil3.compose.internal.transformOf
 import coil3.compose.internal.validateRequest
+import coil3.decode.DataSource
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import coil3.request.ImageResult
@@ -419,3 +420,18 @@ internal expect fun maybeNewCrossfadePainter(
     current: State,
     contentScale: ContentScale,
 ): CrossfadePainter?
+
+/**
+ * Cache hits normally skip the crossfade, but [useExistingImageAsPlaceholder] opts into crossfading
+ * between consecutive images, cached ones included.
+ */
+internal fun crossfadeFromExistingImage(
+    previous: State,
+    result: ImageResult,
+): Boolean {
+    return result is SuccessResult &&
+        result.dataSource == DataSource.MEMORY_CACHE &&
+        result.request.useExistingImageAsPlaceholder &&
+        previous is State.Loading &&
+        previous.painter != null
+}

--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/imageRequests.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/imageRequests.kt
@@ -14,7 +14,7 @@ import coil3.request.crossfade
  * used as the placeholder even if it is null.
  *
  * When used with [crossfade] this allows crossfading between subsequent image requests without
- * manually setting the placeholder to the previous image.
+ * manually setting the placeholder to the previous image, even when the new image is cached.
  *
  * NOTE: This configuration option only works with Compose targets.
  */

--- a/coil-compose-core/src/commonTest/kotlin/coil3/compose/CrossfadeBetweenImagesTest.kt
+++ b/coil-compose-core/src/commonTest/kotlin/coil3/compose/CrossfadeBetweenImagesTest.kt
@@ -1,0 +1,86 @@
+package coil3.compose
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImagePainter.State
+import coil3.decode.DataSource
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.request.crossfade
+import coil3.test.utils.FakeImage
+import coil3.test.utils.RobolectricTest
+import coil3.test.utils.context
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Crossfading between two loaded images (#3473). With the opt-in, the previous image is the
+ * [State.Loading] painter, so the crossfade runs from it to the new result. The cases vary the
+ * new result's [DataSource] and whether `useExistingImageAsPlaceholder` is set.
+ */
+class CrossfadeBetweenImagesTest : RobolectricTest() {
+
+    private val previousImage: Painter = ColorPainter(Color.Red)
+    private val newImage: Painter = ColorPainter(Color.Blue)
+
+    /** Control: a disk-sourced result crossfades from the previous image. */
+    @Test
+    fun crossfadeBetweenImages_fromDisk_isApplied() {
+        val crossfade = maybeNewCrossfadePainter(
+            previous = State.Loading(previousImage),
+            current = successState(DataSource.DISK, useExistingImage = true),
+            contentScale = ContentScale.Fit,
+        )
+
+        val painter = assertNotNull(crossfade)
+        assertSame(newImage, painter.end)
+    }
+
+    /** A cache hit should still crossfade from the previous image when opted in. */
+    @Test
+    fun crossfadeBetweenImages_fromMemoryCache_withOptIn_isApplied() {
+        val crossfade = maybeNewCrossfadePainter(
+            previous = State.Loading(previousImage),
+            current = successState(DataSource.MEMORY_CACHE, useExistingImage = true),
+            contentScale = ContentScale.Fit,
+        )
+
+        val painter = assertNotNull(
+            crossfade,
+            "Expected a crossfade from the previous image to the memory-cache result.",
+        )
+        assertSame(newImage, painter.end)
+    }
+
+    /** Without the opt-in, cache hits keep swapping instantly (no re-animation on scroll). */
+    @Test
+    fun crossfadeBetweenImages_fromMemoryCache_withoutOptIn_isNotApplied() {
+        val crossfade = maybeNewCrossfadePainter(
+            previous = State.Loading(previousImage),
+            current = successState(DataSource.MEMORY_CACHE, useExistingImage = false),
+            contentScale = ContentScale.Fit,
+        )
+
+        assertNull(crossfade)
+    }
+
+    private fun successState(
+        dataSource: DataSource,
+        useExistingImage: Boolean,
+    ) = State.Success(
+        painter = newImage,
+        result = SuccessResult(
+            image = FakeImage(),
+            request = ImageRequest.Builder(context)
+                .data("https://example.com/image")
+                .crossfade(true)
+                .useExistingImageAsPlaceholder(useExistingImage)
+                .build(),
+            dataSource = dataSource,
+        ),
+    )
+}

--- a/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
+++ b/coil-compose-core/src/nonAndroidMain/kotlin/coil3/compose/AsyncImagePainter.nonAndroid.kt
@@ -23,8 +23,10 @@ internal actual fun maybeNewCrossfadePainter(
         return null
     }
 
-    // Don't animate if the request was fulfilled by the memory cache.
-    if (result.dataSource == DataSource.MEMORY_CACHE) {
+    // Skip cache hits, unless the caller opted in via useExistingImageAsPlaceholder.
+    if (result.dataSource == DataSource.MEMORY_CACHE &&
+        !crossfadeFromExistingImage(previous, result)
+    ) {
         return null
     }
 


### PR DESCRIPTION
`useExistingImageAsPlaceholder` + `crossfade` is meant to fade between
consecutive images, but it skipped the animation whenever the next image was
already in the memory cache, so cached images popped in instead of fading.

Now memory cache hits crossfade too, but only when the opt-in is set. Without
it they still swap instantly, so scrolling a list doesn't re-animate
already-loaded items.

Added a test covering disk (control), a cache hit with the opt-in, and a cache
hit without it.

Fixes #3473.