### PR TITLE
Bundle Proguard rules with non-Android JVM artifact.

### DIFF
--- a/coil-core/src/jvmMain/resources/META-INF/proguard/proguard-rules.pro
+++ b/coil-core/src/jvmMain/resources/META-INF/proguard/proguard-rules.pro
@@ -1,0 +1,5 @@
+-keep class coil3.util.DecoderServiceLoaderTarget { *; }
+-keep class coil3.util.FetcherServiceLoaderTarget { *; }
+-keep class coil3.util.ServiceLoaderComponentRegistry { *; }
+-keep class * implements coil3.util.DecoderServiceLoaderTarget { *; }
+-keep class * implements coil3.util.FetcherServiceLoaderTarget { *; }

--- a/coil-core/src/jvmMain/resources/META-INF/proguard/shrinker-rules.pro
+++ b/coil-core/src/jvmMain/resources/META-INF/proguard/shrinker-rules.pro
@@ -1,0 +1,1 @@
+../../../../../shrinker-rules.pro

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -100,15 +100,7 @@ Then depend on the same artifacts with [the latest snapshot version](https://git
 
 ## How to I use Proguard with Coil?
 
-To use Proguard with Coil, add the following rules to your config:
-
-```
--keep class coil3.util.DecoderServiceLoaderTarget { *; }
--keep class coil3.util.FetcherServiceLoaderTarget { *; }
--keep class coil3.util.ServiceLoaderComponentRegistry { *; }
--keep class * implements coil3.util.DecoderServiceLoaderTarget { *; }
--keep class * implements coil3.util.FetcherServiceLoaderTarget { *; }
-```
+To use Proguard with Coil, [add these Proguard rules to your config](https://github.com/coil-kt/coil/blob/main/coil-core/src/jvmMain/resources/META-INF/proguard/proguard-rules.pro).
 
 You may also need to add custom rules for Ktor, OkHttp, and Coroutines.
 


### PR DESCRIPTION
Bundles the recommended Proguard rules in the JVM artifact. We don't need these rules on Android as R8 automatically optimizes the services loader targets. The rules will be automatically included in the build once [this issue](https://youtrack.jetbrains.com/issue/CMP-7777/Support-ProGuard-rules-bundled-in-libraries) is fixed.