### PR TITLE
Properly convey typed asset file uri open requirement

### DIFF
--- a/coil-core/api/android/coil-core.api
+++ b/coil-core/api/android/coil-core.api
@@ -293,6 +293,12 @@ public final class coil3/decode/AssetMetadata : coil3/decode/ImageSource$Metadat
 	public final fun getFilePath ()Ljava/lang/String;
 }
 
+public abstract class coil3/decode/BaseContentMetadata : coil3/decode/ImageSource$Metadata {
+	public fun <init> ()V
+	public abstract fun getAssetFileDescriptor ()Landroid/content/res/AssetFileDescriptor;
+	public final fun getSeekable ()Z
+}
+
 public final class coil3/decode/BitmapFactoryDecoder : coil3/decode/Decoder {
 	public fun <init> (Lcoil3/decode/ImageSource;Lcoil3/request/Options;Lkotlinx/coroutines/sync/Semaphore;Lcoil3/decode/ExifOrientationStrategy;)V
 	public synthetic fun <init> (Lcoil3/decode/ImageSource;Lcoil3/request/Options;Lkotlinx/coroutines/sync/Semaphore;Lcoil3/decode/ExifOrientationStrategy;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -329,9 +335,9 @@ public final class coil3/decode/ByteBufferMetadata : coil3/decode/ImageSource$Me
 	public final fun getByteBuffer ()Ljava/nio/ByteBuffer;
 }
 
-public final class coil3/decode/ContentMetadata : coil3/decode/ImageSource$Metadata {
+public final class coil3/decode/ContentMetadata : coil3/decode/BaseContentMetadata {
 	public fun <init> (Lcoil3/Uri;Landroid/content/res/AssetFileDescriptor;)V
-	public final fun getAssetFileDescriptor ()Landroid/content/res/AssetFileDescriptor;
+	public fun getAssetFileDescriptor ()Landroid/content/res/AssetFileDescriptor;
 	public final fun getUri ()Lcoil3/Uri;
 }
 
@@ -422,6 +428,14 @@ public final class coil3/decode/StaticImageDecoder$Factory : coil3/decode/Decode
 	public fun <init> (Lkotlinx/coroutines/sync/Semaphore;)V
 	public synthetic fun <init> (Lkotlinx/coroutines/sync/Semaphore;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lcoil3/fetch/SourceFetchResult;Lcoil3/request/Options;Lcoil3/ImageLoader;)Lcoil3/decode/Decoder;
+}
+
+public final class coil3/decode/TypedContentMetadata : coil3/decode/BaseContentMetadata {
+	public fun <init> (Lcoil3/Uri;Ljava/lang/String;Landroid/os/Bundle;Landroid/content/res/AssetFileDescriptor;)V
+	public fun getAssetFileDescriptor ()Landroid/content/res/AssetFileDescriptor;
+	public final fun getMimeTypeFilter ()Ljava/lang/String;
+	public final fun getOpts ()Landroid/os/Bundle;
+	public final fun getUri ()Lcoil3/Uri;
 }
 
 public abstract interface class coil3/disk/DiskCache {

--- a/coil-core/src/androidMain/kotlin/coil3/decode/ImageSource.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/ImageSource.kt
@@ -1,6 +1,10 @@
 package coil3.decode
 
 import android.content.res.AssetFileDescriptor
+import android.os.Bundle
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants.SEEK_SET
 import androidx.annotation.DrawableRes
 import coil3.Uri
 
@@ -12,12 +16,45 @@ class AssetMetadata(
 ) : ImageSource.Metadata()
 
 /**
- * Metadata containing the [uri] and associated [assetFileDescriptor] of a `content` URI.
+ * Abstract superclass for metadata relating to the asset file descriptor obtained from a
+ * `content` URI.
+ */
+abstract class BaseContentMetadata : ImageSource.Metadata() {
+    abstract val assetFileDescriptor: AssetFileDescriptor
+    val seekable by lazy {
+        try {
+            Os.lseek(
+                assetFileDescriptor.fileDescriptor, assetFileDescriptor.startOffset,
+                SEEK_SET,
+            )
+            true
+        } catch (_: ErrnoException) {
+            false
+        }
+    }
+}
+
+/**
+ * Metadata containing the [uri] and associated [assetFileDescriptor] of a `content` URI
+ * that can be opened without special considerations.
  */
 class ContentMetadata(
     val uri: Uri,
-    val assetFileDescriptor: AssetFileDescriptor,
-) : ImageSource.Metadata()
+    override val assetFileDescriptor: AssetFileDescriptor,
+) : BaseContentMetadata()
+
+/**
+ * Metadata containing the [uri] and associated [assetFileDescriptor] of a `content` URI
+ * that must be opened with [android.content.ContentResolver.openTypedAssetFileDescriptor] (as
+ * opposed to [android.content.ContentResolver.openAssetFileDescriptor]), while also passing the
+ * [mimeTypeFilter] and [opts] (if present) to the content resolver.
+ */
+class TypedContentMetadata(
+    val uri: Uri,
+    val mimeTypeFilter: String,
+    val opts: Bundle?,
+    override val assetFileDescriptor: AssetFileDescriptor,
+) : BaseContentMetadata()
 
 /**
  * Metadata containing the [packageName], [resId], and [density] of an Android resource.

--- a/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/decode/StaticImageDecoder.kt
@@ -144,14 +144,10 @@ fun ImageSource.toImageDecoderSourceOrNull(
             return ImageDecoder.createSource(options.context.assets, metadata.filePath)
         }
 
-        metadata is ContentMetadata && SDK_INT >= 29 -> {
-            try {
-                // Ensure the file descriptor supports lseek.
-                // https://github.com/coil-kt/coil/issues/2434
-                val asset = metadata.assetFileDescriptor
-                Os.lseek(asset.fileDescriptor, asset.startOffset, SEEK_SET)
-                return ImageDecoder.createSource { asset }
-            } catch (_: ErrnoException) {}
+        // Ensure the file descriptor supports lseek.
+        // https://github.com/coil-kt/coil/issues/2434
+        metadata is BaseContentMetadata && SDK_INT >= 29 && metadata.seekable -> {
+            return ImageDecoder.createSource { metadata.assetFileDescriptor }
         }
 
         metadata is ResourceMetadata && metadata.packageName == options.context.packageName -> {

--- a/coil-core/src/androidMain/kotlin/coil3/fetch/ContentUriFetcher.kt
+++ b/coil-core/src/androidMain/kotlin/coil3/fetch/ContentUriFetcher.kt
@@ -3,6 +3,7 @@ package coil3.fetch
 import android.content.ContentResolver
 import android.content.ContentResolver.EXTRA_SIZE
 import android.content.ContentResolver.SCHEME_CONTENT
+import android.content.res.AssetFileDescriptor
 import android.graphics.Point
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
@@ -12,9 +13,11 @@ import android.provider.MediaStore
 import androidx.annotation.VisibleForTesting
 import coil3.ImageLoader
 import coil3.Uri
+import coil3.decode.BaseContentMetadata
 import coil3.decode.ContentMetadata
 import coil3.decode.DataSource
 import coil3.decode.ImageSource
+import coil3.decode.TypedContentMetadata
 import coil3.pathSegments
 import coil3.request.Options
 import coil3.size.Dimension
@@ -30,28 +33,28 @@ internal class ContentUriFetcher(
     override suspend fun fetch(): FetchResult {
         val androidUri = data.toAndroidUri()
         val contentResolver = options.context.contentResolver
-        val afd = if (isContactPhotoUri(data)) {
-            // Modified from ContactsContract.Contacts.openContactPhotoInputStream.
-            val afd = contentResolver
-                //noinspection Recycle: Automatically recycled after being decoded.
-                .openAssetFileDescriptor(androidUri, "r")
-            checkNotNull(afd) { "Unable to find a contact photo associated with '$androidUri'." }
-        } else if (SDK_INT >= 29 && isMusicThumbnailUri(data)) {
+        val metadata = if (SDK_INT >= 29 && isMusicThumbnailUri(data)) {
             val bundle = newMusicThumbnailSizeOptions()
-            val afd = contentResolver
-                //noinspection Recycle: Automatically recycled after being decoded.
-                .openTypedAssetFile(androidUri, "image/*", bundle, null)
+            val mimeTypeFilter = "image/*"
+            //noinspection Recycle: Automatically recycled after being decoded.
+            val afd = contentResolver.openTypedAssetFile(androidUri, mimeTypeFilter, bundle, null)
             checkNotNull(afd) { "Unable to find a music thumbnail associated with '$androidUri'." }
+            TypedContentMetadata(data, mimeTypeFilter, bundle, afd)
         } else {
-            val stream = contentResolver.openAssetFileDescriptor(androidUri, "r")
-            checkNotNull(stream) { "Unable to open '$androidUri'." }
+            val afd = contentResolver.openAssetFileDescriptor(androidUri, "r")
+            if (isContactPhotoUri(data)) {
+                checkNotNull(afd) { "Unable to find a contact photo associated with '$androidUri'." }
+            } else {
+                checkNotNull(afd) { "Unable to open '$androidUri'." }
+            }
+            ContentMetadata(data, afd)
         }
 
         return SourceFetchResult(
             source = ImageSource(
-                source = afd.createInputStream().source().buffer(),
+                source = metadata.assetFileDescriptor.createInputStream().source().buffer(),
                 fileSystem = options.fileSystem,
-                metadata = ContentMetadata(data, afd),
+                metadata = metadata,
             ),
             mimeType = contentResolver.getType(androidUri),
             dataSource = DataSource.DISK,
@@ -60,7 +63,8 @@ internal class ContentUriFetcher(
 
     /**
      * Contact photos are a special case of content uris that must be loaded using
-     * [ContentResolver.openAssetFileDescriptor] or [ContentResolver.openTypedAssetFile].
+     * [ContentResolver.openAssetFileDescriptor] or [ContentResolver.openTypedAssetFile], as
+     * opposed to [ContentResolver.openInputStream].
      */
     @VisibleForTesting
     internal fun isContactPhotoUri(data: Uri): Boolean {
@@ -70,16 +74,18 @@ internal class ContentUriFetcher(
 
     /**
      * Music thumbnails on API 29+ are a special case of content uris that must be loaded using
-     * [ContentResolver.openAssetFileDescriptor] or [ContentResolver.openTypedAssetFile].
+     * [ContentResolver.openTypedAssetFileDescriptor] with an `image/` MIME type.
      *
-     * Example URI: content://media/external/audio/albums/1961323289806133467
+     * Example URIs: content://media/external/audio/albums/1961323289806133467 or
+     * content://media/external/audio/media/27
      */
     @VisibleForTesting
     internal fun isMusicThumbnailUri(data: Uri): Boolean {
         if (data.authority != MediaStore.AUTHORITY) return false
         val segments = data.pathSegments
         val size = segments.size
-        return size >= 3 && segments[size - 3] == "audio" && segments[size - 2] == "albums"
+        return size >= 3 && segments[size - 3] == "audio" &&
+            (segments[size - 2] == "albums" || segments[size - 2] == "media")
     }
 
     private fun newMusicThumbnailSizeOptions(): Bundle? {


### PR DESCRIPTION
There are various special cases where a content:// uri MUST be opened with openTypedAssetFileDescriptor and some specific MIME type set, such as MediaStore's thumbnails (including music thumbnails already supported). If you open the exact same Uri using the normal openAssetFileDescriptor, in the album case you get an error and in the music case you get the .mp3 file as file descriptor instead. So it's important to split ContentMetadata to allow conveying how the Uri needs to be opened exactly. Otherwise, (image) decoders that work like VideoFrameDecoder, using the content uri directly, would accidentally open .mp3 file or album (which can't be opened) instead of the thumbnail. Prefereably, the decoder directly uses AssetFileDescriptor, which doesn't require special handling as the uri was already opened. So for the benefit of StaticImageDecoder, this is extracted into superclass BaseContentMetadata, from which ContentMetadata and TypedContentMetadata inherit. (Note that uri is NOT extracted into superclass because the semantics differ, any user must always check which subclass it is before using the uri, hence adding uri field to BaseContentMetadata would just mislead API consumers.)

If there are multiple decoders like StaticImageDecoder that require seekable AssetFileDescriptor, we don't need to check multiple times, store the check result as Lazy in BaseContentMetadata.