### PR TITLE
Adds support for loading images from blob URLs (object URLs) on web (JS/Wasm) targets

### DIFF
--- a/coil-core/src/commonMain/kotlin/coil3/Uri.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/Uri.kt
@@ -215,7 +215,10 @@ private fun parseUri(
                 ) {
                     if (index + 2 < original.length &&
                         original[index + 1] == '/' &&
-                        original[index + 2] == '/'
+                        original[index + 2] == '/' &&
+                        // An authority cannot start after the path has already begun. This guards
+                        // against nested-scheme URIs (e.g. "blob:http://host/id") throwing.
+                        pathStartIndex == -1
                     ) {
                         // Standard URI with an authority (e.g. "file:///path/image.jpg").
                         openScheme = false

--- a/coil-core/src/commonTest/kotlin/coil3/UriTest.kt
+++ b/coil-core/src/commonTest/kotlin/coil3/UriTest.kt
@@ -259,6 +259,20 @@ class UriTest {
     }
 
     @Test
+    fun blobWithHttpOrigin() {
+        val string = "blob:http://localhost:8081/a3953f30-e6ef-47b6-8750-731ce8afe0f8"
+        val uri = string.toUri()
+        assertEquals(string, uri.toString())
+    }
+
+    @Test
+    fun blobWithOpaqueOrigin() {
+        val uri = "blob:null/a3953f30-e6ef-47b6-8750-731ce8afe0f8".toUri()
+        assertEquals("blob", uri.scheme)
+        assertEquals("blob:null/a3953f30-e6ef-47b6-8750-731ce8afe0f8", uri.toString())
+    }
+
+    @Test
     fun uriCopy() {
         val uri = "http://localhost/test?q=1".toUri()
         val copiedUri = uri.newBuilder().build()

--- a/coil-core/src/jsCommonMain/kotlin/coil3/fetch/BlobUriFetcher.kt
+++ b/coil-core/src/jsCommonMain/kotlin/coil3/fetch/BlobUriFetcher.kt
@@ -1,0 +1,45 @@
+package coil3.fetch
+
+import coil3.ImageLoader
+import coil3.Uri
+import coil3.decode.DataSource
+import coil3.decode.ImageSource
+import coil3.request.Options
+import okio.Buffer
+
+/**
+ * Fetches images from blob URLs created by `URL.createObjectURL` on the web
+ * (e.g. "blob:http://localhost:8081/a3953f30-e6ef-47b6-8750-731ce8afe0f8").
+ */
+internal class BlobUriFetcher(
+    private val uri: Uri,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult {
+        val bytes = fetchBlobBytes(uri.toString())
+
+        return SourceFetchResult(
+            source = ImageSource(
+                source = Buffer().apply { write(bytes) },
+                fileSystem = options.fileSystem,
+            ),
+            mimeType = null,
+            dataSource = DataSource.MEMORY,
+        )
+    }
+
+    class Factory : Fetcher.Factory<Uri> {
+        override fun create(
+            data: Uri,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Fetcher? {
+            if (!data.toString().startsWith("blob:")) return null
+            return BlobUriFetcher(data, options)
+        }
+    }
+}
+
+/** Read the bytes referenced by a blob [url] using the browser's `fetch` API. */
+internal expect suspend fun fetchBlobBytes(url: String): ByteArray

--- a/coil-core/src/jsCommonMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.kt
+++ b/coil-core/src/jsCommonMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.kt
@@ -1,0 +1,10 @@
+package coil3.fetch.internal
+
+import coil3.Uri
+import coil3.fetch.BlobUriFetcher
+import coil3.util.FetcherServiceLoaderTarget
+
+internal class BlobUriFetcherServiceLoaderTarget : FetcherServiceLoaderTarget<Uri> {
+    override fun factory() = BlobUriFetcher.Factory()
+    override fun type() = Uri::class
+}

--- a/coil-core/src/jsCommonTest/kotlin/coil3/fetch/BlobUriFetcherTest.kt
+++ b/coil-core/src/jsCommonTest/kotlin/coil3/fetch/BlobUriFetcherTest.kt
@@ -1,0 +1,31 @@
+package coil3.fetch
+
+import coil3.ImageLoader
+import coil3.request.Options
+import coil3.test.utils.context
+import coil3.toUri
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class BlobUriFetcherTest {
+    private val factory = BlobUriFetcher.Factory()
+
+    @Test
+    fun handlesBlobUriWithHttpOrigin() {
+        val uri = "blob:http://localhost:8081/a3953f30-e6ef-47b6-8750-731ce8afe0f8".toUri()
+        assertNotNull(factory.create(uri, Options(context), ImageLoader(context)))
+    }
+
+    @Test
+    fun handlesBlobUriWithOpaqueOrigin() {
+        val uri = "blob:null/a3953f30-e6ef-47b6-8750-731ce8afe0f8".toUri()
+        assertNotNull(factory.create(uri, Options(context), ImageLoader(context)))
+    }
+
+    @Test
+    fun ignoresNonBlobUri() {
+        val uri = "https://www.example.com/image.jpg".toUri()
+        assertNull(factory.create(uri, Options(context), ImageLoader(context)))
+    }
+}

--- a/coil-core/src/jsMain/kotlin/coil3/fetch/BlobUriFetcher.js.kt
+++ b/coil-core/src/jsMain/kotlin/coil3/fetch/BlobUriFetcher.js.kt
@@ -1,0 +1,16 @@
+package coil3.fetch
+
+import kotlin.js.Promise
+import kotlinx.coroutines.await
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import org.khronos.webgl.get
+
+internal actual suspend fun fetchBlobBytes(url: String): ByteArray {
+    val buffer: ArrayBuffer = fetchArrayBuffer(url).await()
+    val int8 = Int8Array(buffer)
+    return ByteArray(int8.length) { int8[it] }
+}
+
+private fun fetchArrayBuffer(url: String): Promise<ArrayBuffer> =
+    js("fetch(url).then(function(response) { return response.arrayBuffer(); })")

--- a/coil-core/src/jsMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.js.kt
+++ b/coil-core/src/jsMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.js.kt
@@ -1,0 +1,13 @@
+package coil3.fetch.internal
+
+import coil3.annotation.InternalCoilApi
+import coil3.util.ServiceLoaderComponentRegistry
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalStdlibApi::class, ExperimentalJsExport::class)
+@EagerInitialization
+@JsExport
+@InternalCoilApi
+@Deprecated("", level = DeprecationLevel.HIDDEN)
+val initBlobUriFetcherHook: Any =
+    ServiceLoaderComponentRegistry.register(BlobUriFetcherServiceLoaderTarget())

--- a/coil-core/src/wasmJsMain/kotlin/coil3/fetch/BlobUriFetcher.wasmJs.kt
+++ b/coil-core/src/wasmJsMain/kotlin/coil3/fetch/BlobUriFetcher.wasmJs.kt
@@ -1,0 +1,16 @@
+package coil3.fetch
+
+import kotlin.js.Promise
+import kotlinx.coroutines.await
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import org.khronos.webgl.get
+
+internal actual suspend fun fetchBlobBytes(url: String): ByteArray {
+    val buffer: ArrayBuffer = fetchArrayBuffer(url).await()
+    val int8 = Int8Array(buffer)
+    return ByteArray(int8.length) { int8[it] }
+}
+
+private fun fetchArrayBuffer(url: String): Promise<ArrayBuffer> =
+    js("fetch(url).then(function(response) { return response.arrayBuffer(); })")

--- a/coil-core/src/wasmJsMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.wasmJs.kt
+++ b/coil-core/src/wasmJsMain/kotlin/coil3/fetch/internal/BlobUriFetcherServiceLoaderTarget.wasmJs.kt
@@ -1,0 +1,12 @@
+package coil3.fetch.internal
+
+import coil3.annotation.InternalCoilApi
+import coil3.util.ServiceLoaderComponentRegistry
+
+@Suppress("DEPRECATION")
+@OptIn(ExperimentalStdlibApi::class)
+@EagerInitialization
+@InternalCoilApi
+@Deprecated("", level = DeprecationLevel.HIDDEN)
+val initBlobUriFetcherHook: Any =
+    ServiceLoaderComponentRegistry.register(BlobUriFetcherServiceLoaderTarget())


### PR DESCRIPTION
## Summary

Adds support for loading images from blob URLs (object URLs) on web (JS/Wasm) targets, e.g. `blob:http://localhost:8081/a3953f30-e6ef-47b6-8750-731ce8afe0f8` created via `URL.createObjectURL(...)`.

Previously such a request failed **before it ever reached a fetcher**: a `String` request is mapped to a `Uri` via `StringMapper.toUri()`, and `parseUri` threw an `IndexOutOfBoundsException` on the nested-scheme shape of a blob URL (`blob:http://…`), because it tracked an `authorityStartIndex` past the already-set `pathStartIndex`. This violated `toUri`'s documented "will not throw if the URI is malformed" contract.

## Changes

- **Fix `parseUri` (`coil-core`, common):** an authority may not begin after the path has already started. Added a `pathStartIndex == -1` guard to the authority-detection branch so nested-scheme URIs (`blob:http://…`) parse without throwing and `Uri.toString()` still round-trips the original string. Verified against all existing `UriTest` cases with no regressions.
- **`BlobUriFetcher` (web only):** matches on the raw string prefix `blob:` (object URLs have a nested origin such as `blob:http://…` or `blob:null/…`, so the parsed scheme isn't reliable), reads the referenced bytes via the browser `fetch()` API, and returns a `SourceFetchResult` (`DataSource.MEMORY`), mirroring `DataUriFetcher`. Decoding then flows through the existing `SkiaImageDecoder`/web-worker path.
- Byte reading is an `expect`/`actual` (`jsMain` + `wasmJsMain`) because the `Promise` / `ArrayBuffer → ByteArray` interop differs between the two targets.
- **Auto-registration** via the ServiceLoader eager-init hook pattern already used by the Ktor network fetchers (`jsMain`/`wasmJsMain`), so blob support is enabled automatically on web with no user configuration.

## Testing

- `UriTest`: added cases asserting `blob:http://…` no longer throws and round-trips, and that `blob:null/…` parses with scheme `blob`.
- `BlobUriFetcherTest` (`jsCommonTest`): factory accepts `blob:` URIs (http and opaque origins) and rejects non-blob URIs.

## Notes

- No public API changes — all additions are internal.