### PR TITLE
Fix AsyncImagePainter not updating placeholder/error/fallback when transform changes

### DIFF
--- a/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
+++ b/coil-compose-core/src/commonMain/kotlin/coil3/compose/AsyncImagePainter.kt
@@ -176,6 +176,15 @@ class AsyncImagePainter internal constructor(
 
     internal lateinit var scope: CoroutineScope
     internal var transform = DefaultTransform
+        set(value) {
+            if (field === value) return
+
+            field = value
+
+            if (isRemembered) {
+                updateState(rawState)
+            }
+        }
     internal var onState: ((State) -> Unit)? = null
     internal var contentScale = ContentScale.Fit
     internal var filterQuality = DefaultFilterQuality
@@ -197,6 +206,7 @@ class AsyncImagePainter internal constructor(
 
     private val stateFlow: MutableStateFlow<State> = MutableStateFlow(State.Empty)
     val state: StateFlow<State> = stateFlow.asStateFlow()
+    private var rawState: State = State.Empty
 
     override val intrinsicSize: Size
         get() = painter?.intrinsicSize ?: Size.Unspecified
@@ -305,8 +315,10 @@ class AsyncImagePainter internal constructor(
     }
 
     private fun updateState(state: State) {
+        rawState = state
+
         val previous = stateFlow.value
-        val current = transform(state)
+        val current = transform(rawState)
         stateFlow.value = current
         painter = maybeNewCrossfadePainter(previous, current, contentScale) ?: current.painter
 


### PR DESCRIPTION
## Summary

Fixes an issue where updating the `placeholder`, `error`, or `fallback` painter after `AsyncImagePainter` has already entered the corresponding state does not update the displayed painter.

The root cause is that the `transform` callback is updated during recomposition, but it is only applied when a new image loading state is emitted. If only the transform changes, the current state is never re-transformed.

This change stores the latest untransformed state and reapplies the transform whenever the `transform` callback changes, without restarting the image request.

## Reproduction

```kotlin
var fallback by remember {
    mutableStateOf<Painter>(ColorPainter(Color.Red))
}

LaunchedEffect(Unit) {
    delay(2.seconds)
    fallback = ColorPainter(Color.Blue)
}

AsyncImage(
    model = null,
    fallback = fallback,
    contentDescription = null,
)
```

### Before

The displayed fallback painter remained red indefinitely.

### After

The displayed fallback painter updates to blue immediately after recomposition.

## Visual demonstration

The video below shows the fallback painter updating from red to blue after the `fallback` parameter changes, without restarting the image request.

https://github.com/user-attachments/assets/2f952d87-4f04-433e-b06c-0d80390e02c7

Fixes #1908

Related: #3477


