### PR TITLE
Fix outdated API names in image pipeline docs

### DIFF
--- a/docs/image_pipeline.md
+++ b/docs/image_pipeline.md
@@ -32,12 +32,12 @@ class CustomCacheInterceptor(
         val value = cache.get(chain.request.data.toString())
         if (value != null) {
             return SuccessResult(
-                image = value.bitmap.toImage(),
+                image = value.bitmap.asImage(),
                 request = chain.request,
                 dataSource = DataSource.MEMORY_CACHE,
             )
         }
-        return chain.proceed(chain.request)
+        return chain.proceed()
     }
 }
 ```
@@ -133,10 +133,10 @@ class TimeoutInterceptor : Interceptor {
         val timeout = chain.request.timeout
         if (timeout.isFinite()) {
             return withTimeout(timeout) {
-                chain.proceed(chain.request)
+                chain.proceed()
             }
         } else {
-            return chain.proceed(chain.request)
+            return chain.proceed()
         }
     }
 }
@@ -146,7 +146,7 @@ Finally, we can set the property when creating our `ImageRequest`:
 
 ```kotlin
 AsyncImage(
-    model = ImageRequest.Builder(PlatformContext.current)
+    model = ImageRequest.Builder(LocalPlatformContext.current)
         .data("https://example.com/image.jpg")
         .timeout(10.seconds)
         .build(),


### PR DESCRIPTION
Three API names in `docs/image_pipeline.md` no longer match the source. In each case Coil's own other docs already use the correct form, so this file just missed the rename.

### `chain.proceed(chain.request)` → `chain.proceed()` (lines 40, 136, 139)

`Interceptor.kt:40` declares `suspend fun proceed(): ImageResult` — no parameters. `docs/recipes.md:189` and `:204` already call `chain.proceed()`.

### `value.bitmap.toImage()` → `value.bitmap.asImage()` (line 35)

There is no `Bitmap.toImage()` anywhere in the codebase. The extension is `Bitmap.asImage(...)`, declared at `Image.kt:66` with actuals in `Image.android.kt:23` and `Image.nonAndroid.kt:16`.

### `PlatformContext.current` → `LocalPlatformContext.current` (line 149)

`PlatformContext` has no `current`. `docs/upgrading_to_coil3.md:36` says explicitly: "Use `LocalPlatformContext.current` to get a reference in Compose Multiplatform", and `docs/recipes.md:61` uses exactly that inside the same `ImageRequest.Builder(...)` shape.

Docs only — one file.
