### PR TITLE
fix: prevent R8 from dropping ViewTarget super calls

### DIFF
--- a/coil-core/shrinker-rules.pro
+++ b/coil-core/shrinker-rules.pro
@@ -1,1 +1,8 @@
 -dontwarn coil3.PlatformContext
+
+# Prevent R8 9.0+ from vertically merging GenericViewTarget into any of
+# its subclasses. That merge silently drops `super` calls to Target's
+# default onStart/onSuccess/onError methods, which can cause images to
+# fail to render in release builds.
+# https://issuetracker.google.com/issues/524864608
+-keep class * extends coil3.target.GenericViewTarget { *; }


### PR DESCRIPTION
## Summary

R8 9.0+ vertically merges `GenericViewTarget` into its single concrete subclass and, in doing so, silently drops `super` calls to `Target`'s default interface methods (`onStart`/`onSuccess`/`onError`) inside further subclasses that override them.

The override still executes, but the side effect performed by the dropped `super` call (e.g. `ImageView.setImageDrawable(...)`) never runs (e.g. images stay blank in release builds only).

This is a known R8 9.0+ issue: https://issuetracker.google.com/issues/524864608

## Fix

Add a keep rule to `coil-core/shrinker-rules.pro` to prevent R8 from performing this merge for `GenericViewTarget` and any of its subclasses.

## Verification

Reproduced in a production app, and minimal sandbox app (Coil 3.5.0, AGP 9.2.1) with a custom `ImageViewTarget` subclass overriding `onSuccess`/`onError`:

```kotlin
class TestImageViewTarget(
    view: ImageView,
) : ImageViewTarget(view) {
    override fun onError(error: Image?) {
        super.onError(error)
    }

    override fun onSuccess(result: Image) {
        super.onSuccess(result)
    }
}
```

- Debug build: `super.onSuccess()`/`super.onError()` calls present, image renders correctly.
- Release build (R8, no fix): `onSuccess`/`onError` methods absent from the merged class (`ImageView.setImageDrawable(...)` never invoked, image stays blank).
- Release build (R8, with this fix): `super` calls present, image renders correctly.