### PR TITLE
fix: WeakMemoryCache dropping smaller entries under same key

### DIFF
--- a/coil-core/src/commonMain/kotlin/coil3/memory/WeakMemoryCache.kt
+++ b/coil-core/src/commonMain/kotlin/coil3/memory/WeakMemoryCache.kt
@@ -75,6 +75,7 @@ internal class RealWeakMemoryCache : WeakMemoryCache {
         if (values.isEmpty()) {
             values += newValue
         } else {
+            var added = false
             for (index in values.indices) {
                 val value = values[index]
                 if (size >= value.size) {
@@ -83,8 +84,12 @@ internal class RealWeakMemoryCache : WeakMemoryCache {
                     } else {
                         values.add(index, newValue)
                     }
+                    added = true
                     break
                 }
+            }
+            if (!added) {
+                values += newValue
             }
         }
 

--- a/coil-core/src/commonTest/kotlin/coil3/memory/WeakMemoryCacheTest.kt
+++ b/coil-core/src/commonTest/kotlin/coil3/memory/WeakMemoryCacheTest.kt
@@ -113,6 +113,31 @@ class WeakMemoryCacheTest {
     }
 
     @Test
+    fun smallestImageInsertedLastIsNotDropped() {
+        val imageLarge = reference(FakeImage())
+        val imageMedium = reference(FakeImage())
+        val imageSmall = reference(FakeImage())
+
+        // Insert largest first, smallest last.
+        weakMemoryCache.set(Key("key"), imageLarge, emptyMap(), 300)
+        weakMemoryCache.set(Key("key"), imageMedium, emptyMap(), 200)
+        weakMemoryCache.set(Key("key"), imageSmall, emptyMap(), 100)
+
+        // Largest should be returned first.
+        assertEquals(imageLarge, weakMemoryCache.get(Key("key"))?.image)
+        weakMemoryCache.garbageCollect(imageLarge)
+
+        assertEquals(imageMedium, weakMemoryCache.get(Key("key"))?.image)
+        weakMemoryCache.garbageCollect(imageMedium)
+
+        // The smallest image must still be retrievable.
+        assertEquals(imageSmall, weakMemoryCache.get(Key("key"))?.image)
+        weakMemoryCache.garbageCollect(imageSmall)
+
+        assertNull(weakMemoryCache.get(Key("key")))
+    }
+
+    @Test
     fun cleanUpClearsAllCollectedValues() {
         val image1 = reference(FakeImage())
         weakMemoryCache.set(Key("key1"), image1, emptyMap(), 100)


### PR DESCRIPTION
Fixed a bug in `WeakMemoryCache.set()` where inserting an image smaller than all existing entries under the same cache key would cause the loop to finish without inserting the item, silently dropping it from the weak memory cache.

**Changes**
`WeakMemoryCache.kt`: Added tracking to ensure images with sizes smaller than all currently cached entries for a key are appended to the end of the list instead of dropped.
`WeakMemoryCacheTest.kt`: Added `smallestImageInsertedLastIsNotDropped()` regression test to verify inserting values in `largest -> medium -> smallest` order correctly retains all items in descending size order.

**Test Evidence**
`./gradlew spotlessCheck`: Passed
`./gradlew :coil-core:jvmTest --tests "coil3.memory.WeakMemoryCacheTest"`: Passed (7/7 tests)