### PR TITLE
Pin GitHub Actions to commit SHAs and declare workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
 
             - name: Check Gradle wrapper
-              uses: gradle/actions/wrapper-validation@v6
+              uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
 
             - name: Check style
               run: ./gradlew spotlessCheck
@@ -45,12 +45,12 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 120
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: gradle/actions/setup-gradle@v6
+            - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
               continue-on-error: true
               timeout-minutes: 5
               with:
@@ -64,12 +64,12 @@ jobs:
         runs-on: macos-26
         timeout-minutes: 120
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: gradle/actions/setup-gradle@v6
+            - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
               continue-on-error: true
               timeout-minutes: 5
               with:
@@ -87,12 +87,12 @@ jobs:
             matrix:
                 api-level: [23, 26, 31, 36]
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: gradle/actions/setup-gradle@v6
+            - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
               continue-on-error: true
               timeout-minutes: 5
               with:
@@ -112,7 +112,7 @@ jobs:
                   sudo udevadm trigger --name-match=kvm
 
             - name: Instrumentation tests
-              uses: reactivecircus/android-emulator-runner@v2
+              uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
               with:
                   api-level: ${{ matrix.api-level }}
                   arch: ${{ steps.avd-info.outputs.arch }}
@@ -124,12 +124,12 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: gradle/actions/setup-gradle@v6
+            - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
               continue-on-error: true
               timeout-minutes: 5
               with:
@@ -146,12 +146,12 @@ jobs:
         runs-on: macos-26
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: gradle/actions/setup-gradle@v6
+            - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
               continue-on-error: true
               timeout-minutes: 5
               with:
@@ -167,8 +167,8 @@ jobs:
         if: github.repository == 'coil-kt/coil' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/2.x')
         needs: [checks, unit-tests, unit-tests-macos, instrumentation-tests, build-samples, build-samples-macos]
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
@@ -186,12 +186,12 @@ jobs:
         if: github.repository == 'coil-kt/coil' && github.ref == 'refs/heads/main'
         needs: [checks, unit-tests, unit-tests-macos, instrumentation-tests, build-samples, build-samples-macos]
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-java@v5
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+            - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
               with:
                   distribution: 'zulu'
                   java-version: ${{ env.JAVA_VERSION }}
-            - uses: actions/setup-python@v7
+            - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
               with:
                   python-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ env:
     JAVA_VERSION: 21
     ORG_GRADLE_IDE_DOWNLOADJAVADOC: false
     ORG_GRADLE_IDE_DOWNLOADSOURCES: false
+permissions:
+  contents: read
+
 jobs:
     checks:
         name: Checks
@@ -180,6 +183,9 @@ jobs:
               run: ./gradlew publishToMavenCentral
 
     deploy-docs:
+        # deploy_docs.sh runs mkdocs gh-deploy, which pushes the gh-pages branch.
+        permissions:
+            contents: write
         name: Deploy docs
         runs-on: ubuntu-latest
         timeout-minutes: 120


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v6` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's token. The sensitive spots here are the deploy jobs: `deploy-snapshot` holds your Sonatype credentials and `deploy-docs` can push to the repo. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). Renovate keeps opening its bump PRs exactly as before, it understands sha pins with a version comment, same as its recent spotless and screenshot updates.

**Commit 2 adds `permissions:` blocks.** Without one, every job's GITHUB_TOKEN inherits the repository default scope. The scopes were derived from what each job actually does with the token, not guessed: `contents: read` at the workflow level, and `contents: write` only on `deploy-docs` because `deploy_docs.sh` runs `mkdocs gh-deploy`, which pushes the gh-pages branch. The snapshot deploy authenticates through the Sonatype secrets, the GitHub token itself is unused there.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v6`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

All shas were resolved from the upstream repos and cross checked against their release tags. No workflow logic changes.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on main. I will also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.