### PR TITLE
Update Compose Multiplatform to 1.12.0-beta03

### DIFF
--- a/coil-core/src/jsCommonMain/kotlin/coil3/decode/WebWorker.kt
+++ b/coil-core/src/jsCommonMain/kotlin/coil3/decode/WebWorker.kt
@@ -122,6 +122,7 @@ private suspend fun ArrayBuffer.passToSkiko(): Data {
 }
 
 internal expect suspend fun awaitSkiko(): JsAny
+
 private fun getSkikoMemory(skikoWasm: JsAny): ArrayBuffer =
     js("skikoWasm.wasmExports.memory.buffer")
 

--- a/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
+++ b/coil-core/src/jsCommonTest/kotlin/coil3/decode/ImageSizeExtractionTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import okio.ByteString.Companion.decodeBase64
+import org.jetbrains.skia.impl.use
 
 class ImageSizeExtractionTest {
     private val jpeg = (
@@ -99,7 +100,6 @@ class ImageSizeExtractionTest {
         assertEquals(8 to 8, getWebpSizeOrNull(webp_VP8X))
     }
 
-    @OptIn(ExperimentalWasmJsInterop::class)
     @Test
     fun testSizeExtraction() = runTest {
         assertEquals(10 to 10, getOriginalSize(jpeg))
@@ -107,8 +107,16 @@ class ImageSizeExtractionTest {
         assertEquals(10 to 10, getOriginalSize(webp))
         assertEquals(9 to 9, getOriginalSize(webp_VP8L))
         assertEquals(8 to 8, getOriginalSize(webp_VP8X))
+    }
 
+    @OptIn(ExperimentalWasmJsInterop::class)
+    @Test
+    fun testAwaitSkiko() = runTest {
         awaitSkiko()
         assertEquals(11 to 11, getOriginalSize(bmp))
+        decodeImageAsync(bmp, 11, 11).use { bitmap ->
+            assertEquals(11, bitmap.width)
+            assertEquals(11, bitmap.height)
+        }
     }
 }

--- a/coil-core/src/jsMain/kotlin/coil3/decode/WebWorker.js.kt
+++ b/coil-core/src/jsMain/kotlin/coil3/decode/WebWorker.js.kt
@@ -1,8 +1,22 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package coil3.decode
 
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.Promise
 import kotlinx.coroutines.await
 
-@OptIn(ExperimentalWasmJsInterop::class)
-@Suppress("INVISIBLE_REFERENCE")
-internal actual suspend fun awaitSkiko(): JsAny =
-    org.jetbrains.skiko.wasm.awaitSkiko.await()
+@JsModule("./js-reexport-symbols.mjs")
+@JsNonModule
+private external val skikoModule: SkikoModule
+
+private external interface SkikoModule {
+    val api: SkikoApi
+}
+
+private external interface SkikoApi {
+    val awaitSkiko: Promise<JsAny>
+}
+
+internal actual suspend fun awaitSkiko(): JsAny = skikoModule.api.awaitSkiko.await()

--- a/coil-core/src/wasmJsMain/kotlin/coil3/decode/SkikoModule.wasmJs.kt
+++ b/coil-core/src/wasmJsMain/kotlin/coil3/decode/SkikoModule.wasmJs.kt
@@ -1,0 +1,11 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+@file:JsModule("./js-reexport-symbols.mjs")
+@file:JsQualifier("api")
+
+package coil3.decode
+
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.Promise
+
+internal external val awaitSkiko: Promise<JsAny>

--- a/coil-core/src/wasmJsMain/kotlin/coil3/decode/WebWorker.wasmJs.kt
+++ b/coil-core/src/wasmJsMain/kotlin/coil3/decode/WebWorker.wasmJs.kt
@@ -1,8 +1,9 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
 package coil3.decode
 
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
 import kotlinx.coroutines.await
 
-@OptIn(ExperimentalWasmJsInterop::class)
-@Suppress("INVISIBLE_REFERENCE")
-internal actual suspend fun awaitSkiko(): JsAny =
-    org.jetbrains.skiko.wasm.awaitSkiko.await()
+internal actual suspend fun awaitSkiko(): JsAny = awaitSkiko.await()

--- a/coil-core/src/wasmJsTest/kotlin/coil3/decode/SkikoModuleTest.kt
+++ b/coil-core/src/wasmJsTest/kotlin/coil3/decode/SkikoModuleTest.kt
@@ -1,0 +1,21 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package coil3.decode
+
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.js
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.await
+import kotlinx.coroutines.test.runTest
+
+class SkikoModuleTest {
+    @Test
+    fun awaitSkikoReturnsInitializedModule() = runTest {
+        assertTrue(hasInitializedMemory(awaitSkiko.await()))
+    }
+}
+
+private fun hasInitializedMemory(skikoWasm: JsAny): Boolean =
+    js("skikoWasm.wasmExports.memory.buffer.byteLength > 0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ org.jetbrains.compose.experimental.wasm.enabled=true
 # Config
 minSdk=23
 targetSdk=36
-compileSdk=36
+compileSdk=37
 
 # Maven
 SONATYPE_HOST=DEFAULT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ androidx-tracing-perfetto = "1.0.1"
 atomicfu = "0.33.0"
 coroutines = "1.10.2"
 dokka = "2.2.0"
-jetbrains-compose = "1.11.1"
+jetbrains-compose = "1.12.0-beta03"
 jetbrains-compose-material3 = "1.9.0"
 jetbrains-compose-material-icons-extended = "1.7.3"
 kotlin = "2.4.10"
@@ -19,7 +19,7 @@ okhttp = "4.12.0"
 okio = "3.18.1"
 paparazzi = "2.0.0-alpha05"
 roborazzi = "1.71.0"
-skiko = "0.144.6"
+skiko = "0.150.1"
 
 [plugins]
 baselineProfile = { id = "androidx.baselineprofile", version.ref = "androidx-benchmark" }


### PR DESCRIPTION
Updates Compose Multiplatform to `1.12.0-beta03` and aligns Skiko and compileSdk with its requirements. Replaces direct internal Skiko API access with JS/Wasm module bindings and adds regression coverage for Skiko initialization and web image decoding.

review-path-agent
