### PR TITLE
Group Compose Multiplatform and Skiko dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,8 +10,6 @@
             "matchPackageNames": [
                 "/^org\\.jetbrains\\.compose(?:\\.[^:]+)*:/",
             ],
-            // Track stable, alpha, and beta Compose Multiplatform releases.
-            "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta)\\d+)?$/",
             "groupName": "Compose Multiplatform",
             "groupSingleUpdates": true,
             "ignoreUnstable": false,

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,9 +8,26 @@
     "packageRules": [
         {
             "matchPackageNames": [
+                "/^org\\.jetbrains\\.compose(?:\\.[^:]+)*:/",
+            ],
+            // Track stable, alpha, and beta Compose Multiplatform releases.
+            "allowedVersions": "/^\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta)\\d+)?$/",
+            "groupName": "Compose Multiplatform",
+            "groupSingleUpdates": true,
+            "ignoreUnstable": false,
+            "respectLatest": false,
+            "separateMajorMinor": false,
+        },
+        {
+            "matchPackageNames": [
                 "org.jetbrains.skiko:skiko",
             ],
-            "enabled": false,
+            "enabled": true,
+            "groupName": "Compose Multiplatform",
+            "groupSingleUpdates": true,
+            // Don't open a Skiko-only PR. Wait to group it with a Compose update.
+            "minimumGroupSize": 2,
+            "separateMajorMinor": false,
         },
     ],
 }


### PR DESCRIPTION
Configure Renovate to track stable and preview Compose Multiplatform releases and group them with Skiko updates, preventing Skiko-only pull requests.